### PR TITLE
Fix zero coins shard price

### DIFF
--- a/src/main/kotlin/net/sbo/mod/utils/Helper.kt
+++ b/src/main/kotlin/net/sbo/mod/utils/Helper.kt
@@ -497,7 +497,11 @@ object Helper {
 
 
     fun getItemPrice(sbId: String, amount: Int = 1): Long {
-        val id = if (sbId == "CHIMERA") "ENCHANTMENT_ULTIMATE_CHIMERA_1" else if (sbId.endsWith("_SHARD")) "${sbId.substringAfterLast('_')}_${sbId.substringBeforeLast('_')}" else sbId
+        val id = when {
+            sbId == "CHIMERA" -> "ENCHANTMENT_ULTIMATE_CHIMERA_1"
+            sbId.endsWith("_SHARD") -> "${sbId.substringAfterLast('_')}_${sbId.substringBeforeLast('_')}"
+            else -> sbId
+        }
         var ahPrice = priceDataAh[id]?.toDouble() ?: 0.0
         if (npcSellValueMap.containsKey(id)) {
             val npcPrice = npcSellValueMap[id]?.toDouble() ?: 0.0

--- a/src/main/kotlin/net/sbo/mod/utils/Helper.kt
+++ b/src/main/kotlin/net/sbo/mod/utils/Helper.kt
@@ -497,7 +497,7 @@ object Helper {
 
 
     fun getItemPrice(sbId: String, amount: Int = 1): Long {
-        val id = if (sbId == "CHIMERA") "ENCHANTMENT_ULTIMATE_CHIMERA_1" else sbId
+        val id = if (sbId == "CHIMERA") "ENCHANTMENT_ULTIMATE_CHIMERA_1" else if (sbId.endsWith("_SHARD")) "${sbId.substringAfterLast('_')}_${sbId.substringBeforeLast('_')}" else sbId
         var ahPrice = priceDataAh[id]?.toDouble() ?: 0.0
         if (npcSellValueMap.containsKey(id)) {
             val npcPrice = npcSellValueMap[id]?.toDouble() ?: 0.0


### PR DESCRIPTION
Hypixel Bazaar API response has shard IDs like this:

SHARD_SPHINX
SHARD_MINATOUR

etc., while the mod was trying to access:

SPHINX_SHARD
MINATOUR_SHARD

which returned 0 coins price which in turn was causing all shards in profit display to display zero coins.

There was already an existing workaround of converting sb id CHIMERA to ENCHANTMENT_ULTIMATE_CHIMERA_1, so I extended it to move the _SHARD at the end to the start instead to fix the issue. Can be merged as is but in the future more items might be needing a workaround thus increasing the size of the one-liner if statement, so likely needs to be refactored into better code later.

Fixes #33