### PR TITLE
Remove excessive thread creation

### DIFF
--- a/src/main/kotlin/net/sbo/mod/utils/Helper.kt
+++ b/src/main/kotlin/net/sbo/mod/utils/Helper.kt
@@ -35,6 +35,8 @@ import kotlin.reflect.full.memberProperties
 import java.text.DecimalFormat
 import java.util.Locale
 import java.util.regex.Pattern
+import java.util.concurrent.Executors
+import java.util.concurrent.ExecutorService
 import kotlin.math.roundToInt
 import kotlin.math.roundToLong
 
@@ -58,6 +60,12 @@ object Helper {
     private var prevInv = mutableMapOf<String, Item>()
     private var priceDataAh: Map<String, Long> = emptyMap()
     private var priceDataBazaar: HypixelBazaarResponse? = null
+
+    private val SBO_CALLBACK_THREAD: ExecutorService = Executors.newThreadPerTaskExecutor(Thread
+            .ofVirtual()
+            .name("sbo-callback-thread-", 1) // sbo-callback-thread-1, sbo-callback-thread-2 etc. starting from 1 (second parameter)
+            .factory() // virtual threads are daemon by default
+    )
 
     fun init() {
         Register.onChatMessageCancable(Pattern.compile("^§e§lLOOT SHARE §fYou received loot for assisting (.*?)$", Pattern.DOTALL)) { message, matchResult ->
@@ -146,7 +154,7 @@ object Helper {
      * @param callback The function to execute after sleeping.
      */
     fun sleep(milliseconds: Long, callback: () -> Unit) {
-        thread(isDaemon = true) {
+        SBO_CALLBACK_THREAD.execute {
             Thread.sleep(milliseconds)
             callback()
         }


### PR DESCRIPTION
Uses virtual thread per task executor with custom thread name.

Virtual threads are JVM's implementation of the lightweight (green) threads, which can exist upwards of millions of threads compared to platform threads and thus are suitable for the "thread-per-task" model.

Since this is in Kotlin, Coroutines could also be used but would need marking some functions as suspend and would be most likely less performant than the JVMs native integrated virtual threads. Java Virtual Threads allows swapping with (realistically) no code changes required, unless sycnhronized was used in Java versions that cause thread pinning but that got fixed already.

Closes #28