### PR TITLE
Use semantic versioning

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -17,7 +17,7 @@ dgt.minecraft.revision=3
 # Mod properties
 mod.name=SBO
 mod.id=sbo-kotlin
-mod.version=beta0.1.3
+mod.version=0.1.3-beta
 mod.group=net.sbo.mod
 
 # Dependencies


### PR DESCRIPTION
Moves version number before the beta prefix and adds a dash. This PR does not bump the version number and thus the number needs to be modified again still before a new release is made.

Closes #30