### PR TITLE
Remove suggests section from fabric.mod.json

### DIFF
--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -44,8 +44,5 @@
 		"java": ">=21",
 		"fabric-api": "*",
 		"fabric-language-kotlin": "*"
-	},
-	"suggests": {
-		"another-mod": "*"
 	}
 }


### PR DESCRIPTION
Removed the 'suggests' section for 'another-mod' from fabric.mod.json.

This is a leftover from fabric example mod template and is completely unnecessary, and a mod named "another-mod" does not exist anyways.