### PR TITLE
Add support for !since<item/mob> command variants without spaces

### DIFF
--- a/src/main/kotlin/net/sbo/mod/general/PartyCommands.kt
+++ b/src/main/kotlin/net/sbo/mod/general/PartyCommands.kt
@@ -404,6 +404,36 @@ object PartyCommands {
                         }
                     }
                 }
+                "!sincechim", "!sincechimera", "!sincechims", "!sincechimeras", "!sincebook", "!sincebooks" -> {
+                    if (!settings.dianaPartyCommands) return@onChatMessage
+                    sleep(200) {
+                        Chat.command("pc Inqs since chim: ${sboData.inqsSinceChim}")
+                    }
+                }
+                "!sincestick", "!sincesticks" -> {
+                    if (!settings.dianaPartyCommands) return@onChatMessage
+                    sleep(200) {
+                        Chat.command("pc Minos since stick: ${sboData.minotaursSinceStick}")
+                    }
+                }
+                "!sincerelic", "!sincerelics" -> {
+                    if (!settings.dianaPartyCommands) return@onChatMessage
+                    sleep(200) {
+                        Chat.command("pc Champs since relic: ${sboData.champsSinceRelic}")
+                    }
+                }
+                "!sinceinq", "!sinceinqs", "!sinceinquisitor", "!sinceinquisitors", "!sinceinquis" -> {
+                    if (!settings.dianaPartyCommands) return@onChatMessage
+                    sleep(200) {
+                        Chat.command("pc Mobs since inq: ${sboData.mobsSinceInq}")
+                    }
+                }
+                "!sincelschim", "!sincechimls", "!sincelschimera", "!sincechimerals", "!sincelsbook", "!sincebookls", "!sincelootsharechim" -> {
+                    if (!settings.dianaPartyCommands) return@onChatMessage
+                    sleep(200) {
+                        Chat.command("pc Inqs since lootshare chim: ${sboData.inqsSinceLsChim}")
+                    }
+                }
 
             }
         }


### PR DESCRIPTION
!sincechim, !sinceinq etc not working but !since chim and !since inq working was really annoying

Now they both work
Also saw another pr adding support for the !since king party command so maybe add to this also 

