### PR TITLE
Refactor data saving to use single-threaded executor

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -17,7 +17,7 @@ dgt.minecraft.revision=3
 # Mod properties
 mod.name=SBO
 mod.id=sbo-kotlin
-mod.version=0.1.6-beta
+mod.version=0.1.7-beta
 mod.group=net.sbo.mod
 
 # Dependencies


### PR DESCRIPTION
Replaced virtual thread executor with a single-threaded daemon executor for data saving operations in SboDataObject. Data save methods now execute asynchronously, improving reliability and thread safety. Updated mod version to 0.1.7-beta.

Hopefully fionally fixed the disconnect issue some encounter