### PR TITLE
perf: only get lore when necessary

### DIFF
--- a/src/main/kotlin/net/sbo/mod/utils/Helper.kt
+++ b/src/main/kotlin/net/sbo/mod/utils/Helper.kt
@@ -345,13 +345,13 @@ object Helper {
 
             if (!stack.isEmpty) {
                 val customData = stack.get(DataComponentTypes.CUSTOM_DATA)
-                val lore = ItemUtils.getLoreList(stack)
                 var id: String
                 var item: Item
                 val sbId = ItemUtils.getSBID(customData)
                 // print for debugging the lore lines
                 var isChimera = false
                 if (sbId == "ENCHANTED_BOOK") {
+                    val lore = ItemUtils.getLoreList(stack)
                     for (line in lore) {
                         if (line.contains("Chimera")) {
                             isChimera = true
@@ -608,4 +608,5 @@ object Helper {
         return 0
     }
 }
+
 


### PR DESCRIPTION
The variable is only used inside the if id == enchanted book case, but the getLoreList method is called for each item.

getLoreList is a method that returns lore of the item with no side effects, so this optimization does not cause any issues.

Approx. 2% performance savings overall:

<img width="962" height="356" alt="Screenshot From 2025-12-10 09-22-22" src="https://github.com/user-attachments/assets/0fe6b55e-0568-42b0-b516-37b430f127bf" />