### PR TITLE
Add mob selection for no shuriken overlay

### DIFF
--- a/src/main/kotlin/net/sbo/mod/diana/DianaMobDetect.kt
+++ b/src/main/kotlin/net/sbo/mod/diana/DianaMobDetect.kt
@@ -130,7 +130,7 @@ object DianaMobDetect {
                 checkCocoon(armorStand)
                 checkDianaMob(armorStand, id)?.let { overlayLines.add(it) }
 
-                val result = ckeckStarlessMob(armorStand, id, player, closestStarlessMob, closestDistanceSq)
+                val result = checkStarlessMob(armorStand, id, player, closestStarlessMob, closestDistanceSq)
                 closestStarlessMob = result.first
                 closestDistanceSq = result.second
             }
@@ -177,7 +177,7 @@ object DianaMobDetect {
         return OverlayTextLine(name)
     }
 
-    private fun ckeckStarlessMob(
+    private fun checkStarlessMob(
         entity: ArmorStandEntity,
         id: Int,
         player: PlayerEntity,

--- a/src/main/kotlin/net/sbo/mod/diana/DianaMobDetect.kt
+++ b/src/main/kotlin/net/sbo/mod/diana/DianaMobDetect.kt
@@ -186,7 +186,16 @@ object DianaMobDetect {
     ): Pair<ArmorStandEntity?, Double> {
         if (id in defeated) return currentClosest to currentDistanceSq
         val name = entity.customName?.formattedString() ?: entity.name.formattedString()
-        if (RareDianaMob.fromName(name) == null) return currentClosest to currentDistanceSq
+        val mobType = RareDianaMob.fromName(name) ?: return currentClosest to currentDistanceSq
+
+        val shouldCheck = when (mobType) {
+            RareDianaMob.INQ -> Diana.NoShurikenList.INQ in Diana.NoShurikenMobs
+            RareDianaMob.MANTI -> Diana.NoShurikenList.MANTICORE in Diana.NoShurikenMobs
+            RareDianaMob.KING -> Diana.NoShurikenList.KING in Diana.NoShurikenMobs
+            RareDianaMob.SPHINX -> Diana.NoShurikenList.SPHINX in Diana.NoShurikenMobs
+        }
+
+        if (!shouldCheck) return currentClosest to currentDistanceSq
         if (parseStarFromName(name)) return currentClosest to currentDistanceSq
 
         val health = parseHealthFromName(name)

--- a/src/main/kotlin/net/sbo/mod/settings/categories/Diana.kt
+++ b/src/main/kotlin/net/sbo/mod/settings/categories/Diana.kt
@@ -19,6 +19,10 @@ object Diana : CategoryKt("Diana") {
         INQ, MANTICORE, KING, SPHINX, OTHER
     }
 
+    enum class NoShurikenList {
+        INQ, MANTICORE, KING, SPHINX
+    }
+
     enum class SettingDiana {
         INSTASELL, SELLOFFER;
 
@@ -369,6 +373,11 @@ object Diana : CategoryKt("Diana") {
     var noShurikenOverlay by boolean(false) {
         this.name = Translated("No Shuriken Overlay")
         this.description = Translated("Shows an overlay when the RareMob has no shuriken applied /sboguis to move it")
+    }
+
+    var NoShurikenMobs by select(NoShurikenList.INQ, NoShurikenList.MANTICORE, NoShurikenList.KING, NoShurikenList.SPHINX) {
+        this.name = Translated("Select which Mobs to Check")
+        this.description = Translated("Select which mobs to check for shuriken")
     }
 
     init {


### PR DESCRIPTION
- Added a mob list toggle for the no shuriken overlay (uses the same list format as share rare mob)
- Fixed typo: renamed `ckeckStarlessMob` to `checkStarlessMob`

**Feature request:** https://discord.com/channels/1163913835514699886/1447989192201338892