### PR TITLE
Track crown of greed with pickuplog

### DIFF
--- a/src/main/kotlin/net/sbo/mod/diana/DianaTracker.kt
+++ b/src/main/kotlin/net/sbo/mod/diana/DianaTracker.kt
@@ -125,6 +125,7 @@ object DianaTracker {
             if (!checkDiana()) return@sleep
             when (item.itemId) {
                 "HILT_OF_REVELATIONS" -> onRareDropFromMob("HILT_OF_REVELATIONS", false, false, false, 0)
+                "CROWN_OF_GREED" -> onRareDropFromMob("CROWN_OF_GREED", false, false, false, 0)
             }
         }
     }


### PR DESCRIPTION
I have gotten about 3 crown of greeds so far and none of them gave a rare drop message - seems like it's meant to be put here instead of the chat handler. I haven't removed the chat handler just in case anyways as I saw hilt of revelations also has both chat and pickup log handler, hopefully this does not result in duplicate drop tracking.

I'm not sure if it would gave the rare drop message with lower magic find or looting level, haven't tested.