### PR TITLE
fix: re-entrancy of Register with TabList cache

### DIFF
--- a/src/main/kotlin/net/sbo/mod/SBOKotlin.kt
+++ b/src/main/kotlin/net/sbo/mod/SBOKotlin.kt
@@ -41,6 +41,7 @@ import net.sbo.mod.utils.SoundHandler
 import net.sbo.mod.utils.events.SBOEvent
 import net.sbo.mod.utils.overlay.OverlayManager
 import net.sbo.mod.utils.events.SboEventGeneratedRegistry
+import net.sbo.mod.utils.game.TabList
 
 object SBOKotlin {
 	@JvmField
@@ -64,6 +65,9 @@ object SBOKotlin {
 			.orElse("unknown")
 
 		logger.info("Initializing SBO-Kotlin, version: $version...")
+
+        // Initialize scheduled tab list fetch
+        TabList.init()
 
 		// Load configuration and data
 		SboDataObject.init()

--- a/src/main/kotlin/net/sbo/mod/utils/game/TabList.kt
+++ b/src/main/kotlin/net/sbo/mod/utils/game/TabList.kt
@@ -12,14 +12,17 @@ object TabList {
     private var cachedTabLines = emptyList<String>()
 
     /**
-     * Ensures the tab lines are fetched on the first call,
-     * and that future updates are scheduled for it each tick.
+     * Ensures the tab lines are fetched on the first call.
      */
     private val initOnce: Unit by lazy {
-        // The registered tick task would only update cache on next tick
-        // To avoid accessing uninitalized cache on first call, call it explicitly before registering tick task
+        // To avoid accessing uninitalized cache on first call, update cache explicitly once.
         updateCache()
+    }
 
+    /**
+     * Registers a task to update the cache each tick.
+     */
+    fun init() {
         Register.onTick(1) {
             // Periodic updates each tick
             updateCache()


### PR DESCRIPTION
When testing merging Arrow-Guess branch on top of Diana-V2 branch, the game crashes on startup with a ConcurrentModificationException:

```java
---- Minecraft Crash Report ----
// Quite honestly, I wouldn't worry myself about that.

Time: 2025-12-13 18:10:12
Description: Unexpected error

java.util.ConcurrentModificationException
	at java.base/java.util.ArrayList$Itr.checkForComodification(ArrayList.java:1096)
	at java.base/java.util.ArrayList$Itr.next(ArrayList.java:1050)
	at knot//net.sbo.mod.utils.events.TickScheduler._init_$lambda$1(TickScheduler.kt:12)
	at knot//net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientTickEvents.lambda$static$2(ClientTickEvents.java:43)
	at knot//net.minecraft.class_310.handler$boc000$fabric-lifecycle-events-v1$onEndTick(class_310.java:9092)
	at knot//net.minecraft.class_310.method_1574(class_310.java:1960)
	at knot//net.minecraft.class_310.method_1523(class_310.java:1324)
	at knot//net.minecraft.class_310.method_1514(class_310.java:947)
	at knot//net.minecraft.client.main.Main.ixeris$runRenderThread(Main.java:1081)
	at knot//net.minecraft.client.main.Main.md1fe659$ixeris$lambda$ixeris$main$0$0(Main.java:1050)
	at java.base/java.lang.Thread.run(Thread.java:1474)
```

The likely trigger is the 16268aa commit, which calls World.getWorld() inside a Register.onTick block. World.getWorld() calls TabList.findInfo, and that accesses the lazy initOnce variable, which does updateCache and calls Register.onTick to schedule future updateCache calls. Trying to Register a tick task while inside already a Registered tick task fails with CME as the tasks list is modified while it's being iterated.

This likely would not happen without the TabList cache, so the cache is at fault - but the trigger is a new commit in Arrow-Guess branch as I didn't have this crash before with the cache. There might be more places that call World.getWorld() inside a tick task, but they probably did not cause an issue because it was called earlier from a non-tick task, as initOnce only calls Register.onTick on first access.

The Register class could be changed to support registering tick tasks when inside one, or the TabList class can be made to use END_CLIENT_TICK directly, but I figured the simplest fix was to always init the tab list updateCache task at a predictable time which is not inside a re-entrant tick task (at mod init). This successfully fixes the issue for now and no further refactor is needed. I've placed the TabList.init call before all other inits just in case.