### PR TITLE
fix: correct mcmeta for sound resourcepack

### DIFF
--- a/src/main/kotlin/net/sbo/mod/utils/SoundHandler.kt
+++ b/src/main/kotlin/net/sbo/mod/utils/SoundHandler.kt
@@ -39,7 +39,7 @@ object SoundHandler {
     private fun currentResourcePackFormat(): Int {
         return try {
             //#if MC >= 1.21.9
-            //$$ (SharedConstants.getGameVersion().packVersion(ResourceType.CLIENT_RESOURCES) as Int)
+            //$$ SharedConstants.getGameVersion().packVersion(ResourceType.CLIENT_RESOURCES).major()
             //#elseif MC >= 1.21.7
             //$$ SharedConstants.getGameVersion().packVersion(ResourceType.CLIENT_RESOURCES)
             //#else
@@ -86,6 +86,20 @@ object SoundHandler {
 
         val packFormat = currentResourcePackFormat()
         val packMcmeta = File(generatedPackDir, "pack.mcmeta")
+        //#if MC >= 1.21.9
+        //$$ packMcmeta.writeText(
+            //$$ """
+            //$$ {
+              //$$ "pack": {
+                //$$ "description": "SBO Custom Sounds",
+                //$$ "pack_format": $packFormat,
+                //$$ "min_format": 65,
+                //$$ "max_format": 999
+              //$$ }
+            //$$ }
+            //$$ """.trimIndent()
+        //$$ )
+        //#else
         packMcmeta.writeText(
             """
             {
@@ -99,6 +113,7 @@ object SoundHandler {
             }
             """.trimIndent()
         )
+        //#endif
         writePackIcon()
         println("[$MOD_ID] Generated dynamic soundpack at: ${generatedPackDir.absolutePath}")
     }


### PR DESCRIPTION
Fixed currentResourcePackFormat() returning 48 (catch block) on 1.21.10 because the Int cast was throwing an exception, since the method returns a PackVersion record object, not anyting that can be converted to an Int automatically. This fix uses the major() method from PackVersion instead of trying to cast PackVersion to an Int.

Mojang replaced supported_formats with min_format and max_format in 1.21.9's first snapshot and kept it that way in final release and 1.21.10 as well. This commit in addition to fixing currentResourcePackFormat also migrates to use the new fields, making the resourcepack show as compatible in the resourcepack selection screen.

min_format is required to be at least 65, which is the version min_format is added at (1.21.9), otherwise the game throws a warning and says the pack is incompatible.

Tested ingame and verified that the pack shows as compatible.

Fixes #54