### PR TITLE
fix: overlay not hiding when tab list is open

### DIFF
--- a/src/main/kotlin/net/sbo/mod/utils/overlay/OverlayManager.kt
+++ b/src/main/kotlin/net/sbo/mod/utils/overlay/OverlayManager.kt
@@ -56,7 +56,7 @@ object OverlayManager {
         val mouseX = mc.mouse.x / scaleFactor
         val mouseY = mc.mouse.y / scaleFactor
         for (overlay in overlays.toList()) {
-            if (renderScreen == "")
+            if (renderScreen == "" && !mc.options.playerListKey.isPressed)
                 overlay.render(drawContext, mouseX, mouseY)
         }
     }


### PR DESCRIPTION
Discord message about the issue https://discord.com/channels/1163913835514699886/1245708576001884200/1448314954041266348

Basically, the overlay text makes tab list  entries hard to see since the overlay always shows unless in a screen (mc.currentScreen != null). Tab list is not considered a screen by vanilla.

There's also mc.inGameHud.playerListHud.visible, but the boolean field is private and there's no public isVisible method (even though there is a setVisible one) so it would require an accessor mixin unnecessarily complicating things. I believe just checking if key is pressed is also more compatible with custom tablist mods as the playerListHud could be replaced with a custom one so the mixin to access the visible field might fail.

edit: the OP might also mean the issue is that text is rendered on top of the screen instead of below, rather than it not being hidden when tab is open, but I believe that would still make tab list hard to see. This fix of just hiding it matches the behaviour of hiding it when any other menu that sets currentScreen and is more simpler than messing with render layering.