### PR TITLE
add: money hour that always shows before hover

### DIFF
--- a/src/main/kotlin/net/sbo/mod/overlays/DianaLoot.kt
+++ b/src/main/kotlin/net/sbo/mod/overlays/DianaLoot.kt
@@ -296,7 +296,8 @@ object DianaLoot {
     }
 
     private fun createProfitLine(totalProfitValue: Long, profitPerHr: Any, profitPerBurrow: Any): OverlayTextLine {
-        return OverlayTextLine("${YELLOW}Total Profit: $AQUA${Helper.formatNumber(totalProfitValue)} coins")
+        val pphText = if (profitPerHr == "NaN" || profitPerHr == "0.0") "" else " $GRAY[$AQUA$profitPerHr$GRAY/${AQUA}hr$GRAY]"
+        return OverlayTextLine("${YELLOW}Total Profit: $AQUA${Helper.formatNumber(totalProfitValue)} coins$pphText")
             .onHover { drawContext, textRenderer ->
                 val scaleFactor = mc.window.scaleFactor
                 val mouseX = mc.mouse.x / scaleFactor
@@ -352,4 +353,5 @@ object DianaLoot {
         }
         timerLine.text = text
     }
+
 }


### PR DESCRIPTION
Better feeling to see it update live while you are playing instead of stopping to type !profit or hovering over the element. Hovering over in fact does not work for me but that might just be something on 1.21.10 or on my side.

Mainly just copied the burrows/hr code and made it work on string instead of number. Looks exactly same as the burrows/hr one.

Let me know if any changes are needed!

Screenshot preview (ignore my bad money per hour, tracker was reset and had lot of dt and terrible luck):
<img width="372" height="111" alt="image" src="https://github.com/user-attachments/assets/abe75f2d-8528-4573-810d-100d11cd35c3" />