### PR TITLE
fix attempt: CME from access to mutable set in netty thread

### DIFF
--- a/src/main/kotlin/net/sbo/mod/diana/guesses/ArrowGuessBurrow.kt
+++ b/src/main/kotlin/net/sbo/mod/diana/guesses/ArrowGuessBurrow.kt
@@ -21,6 +21,8 @@ import net.sbo.mod.utils.math.SboVec
 import net.sbo.mod.utils.math.SboVec.Companion.toSboVec
 import net.sbo.mod.utils.waypoint.WaypointManager
 import java.util.regex.Pattern
+import java.util.Collections
+import java.util.concurrent.ConcurrentHashMap
 import kotlin.math.abs
 import kotlin.math.pow
 import kotlin.math.sign
@@ -59,7 +61,7 @@ object ArrowGuessBurrow {
     }
 
     private val recentArrowParticles = TimeLimitedSet<SboVec>(1.minutes)
-    private val locations: MutableSet<SboVec> = mutableSetOf()
+    private val locations: MutableSet<SboVec> = Collections.newSetFromMap(ConcurrentHashMap())
 
     private var lastBlockClicked: SboVec? = null
 
@@ -370,4 +372,5 @@ object ArrowGuessBurrow {
                 vec.y > this.minY && vec.y <= this.maxY &&
                 vec.z > this.minZ && vec.z <= this.maxZ;
     }
+
 }


### PR DESCRIPTION
This should and most likely will fix the issue. Tested for a few hours of playtime, everything seems to work normally, no CME so far, but the CME without the change was also rare so hard to know if it could still happen.

This PR targets Arrow-Guess branch which has its own PR to be merged to Diana-V2, so merging this will update the Arrow Guess PR with the commit included.

I could not figure how to make it a suggested change in the Arrow Guess PR itself as GitHub only seems to put a suggested change for 1 line of code, so had no way to add the imports at the top as a suggested change while also having the locations field line updated.