### PR TITLE
Attempt to fix auto reset not resetting playtime

### DIFF
--- a/src/main/kotlin/net/sbo/mod/diana/DianaTracker.kt
+++ b/src/main/kotlin/net/sbo/mod/diana/DianaTracker.kt
@@ -669,6 +669,8 @@ object DianaTracker {
         dianaTrackerMayor.reset()
         dianaTrackerMayor.year = Mayor.mayorElectedYear
         dianaTrackerMayor.save()
+        SboTimerManager.timerMayor.reset()
+        SboTimerManager.activeTimers.forEach { it.pause() }
         DianaMobs.updateLines()
         DianaLoot.updateLines()
         Chat.chat("§6[SBO] §aDiana mayor tracker has been reset.")

--- a/src/main/kotlin/net/sbo/mod/diana/DianaTracker.kt
+++ b/src/main/kotlin/net/sbo/mod/diana/DianaTracker.kt
@@ -67,6 +67,7 @@ object DianaTracker {
             sboData.champsSinceRelic = 0
             sboData.inqsSinceLsChim = 0
             SboDataObject.save("SboData")
+            SboTimerManager.timerSession.reset()
             DianaStats.updateLines()
         }
 

--- a/src/main/kotlin/net/sbo/mod/diana/DianaTracker.kt
+++ b/src/main/kotlin/net/sbo/mod/diana/DianaTracker.kt
@@ -58,10 +58,6 @@ object DianaTracker {
 
         Register.command("sboresetmayortracker") {
             resetMayorTracker()
-            DianaMobs.updateLines()
-            DianaLoot.updateLines()
-            SboTimerManager.timerMayor.reset()
-            SboTimerManager.activeTimers.forEach { it.pause() }
         }
 
         Register.command("sboresetstatstracker") {


### PR DESCRIPTION
Copied the timer reset code from /sboresetmayortracker code found above in this same file. As the command resets PT unlike the automatic reset, this should fix the issue but no way to test till the next time reset happens without manually forcing a reset.

Command code:
https://github.com/SkyblockOverhaul/SBO-Kotlin/blob/6545fde2a1484bbf5b7dc78d84ced7beadcca2a5/src/main/kotlin/net/sbo/mod/diana/DianaTracker.kt#L59-L65

edit: Also now removed these duplicate code from command, because now resetMayorTracker() resets everything correctly and updates lines, so it was just duplicate code.