### PR TITLE
Run actions on directly pushed commits as well

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,7 @@
 # against bad commits.
 
 name: build
-on: [pull_request]
+on: [pull_request, push]
 
 jobs:
   build:


### PR DESCRIPTION
Previously only ran for pull request commits, this changes it to run on directly pushed commits as well. This allows users to download artifacts from latest commits in branches easier and adds additional checks that the last pushed direct commits compile correctly as the actions would fail otherwise.