### PR TITLE
Remove synchronizedCollection usage in tab list code

### DIFF
--- a/src/main/kotlin/net/sbo/mod/utils/game/TabList.kt
+++ b/src/main/kotlin/net/sbo/mod/utils/game/TabList.kt
@@ -13,14 +13,6 @@ object TabList {
     private var cachedTabLines = emptyList<String>()
 
     /**
-     * Ensures the tab lines are fetched on the first call.
-     */
-    private val initOnce: Unit by lazy {
-        // To avoid accessing uninitalized cache on first call, update cache explicitly once.
-        updateCache()
-    }
-
-    /**
      * Registers a task to update the cache each tick.
      */
     fun init() {
@@ -54,10 +46,8 @@ object TabList {
      * Returns a list of all PlayerListEntry objects from the current tab list.
      * Each PlayerListEntry object contains detailed information about a player.
      */
-    fun getTabEntries(): List<PlayerListEntry?> {
-        val client = mc
-        val playerListCollection = client.player?.networkHandler?.playerList ?: return emptyList()
-        return Collections.synchronizedCollection(playerListCollection).toList()
+    fun getTabEntries(): Collection<PlayerListEntry?> {
+        return mc.player?.networkHandler?.playerList ?: emptyList()
     }
 
     /**
@@ -67,8 +57,6 @@ object TabList {
      * @return The value associated with the key, or null if not found.
      */
     fun findInfo(key: String): String? {
-        initOnce
-
         for (line in cachedTabLines) {
             if (line.startsWith(key)) {
                 return line.substring(key.length).trim()
@@ -78,3 +66,4 @@ object TabList {
         return null
     }
 }
+


### PR DESCRIPTION
Removed synchronizedCollection usage in getTabEntries.

Made return type Collection, as we only use iteration and do not need a List implementation. This allows to remove the .toList() call.

Adding synchronizedCollection does not solve anything, quoting [the JavaDoc](https://docs.oracle.com/javase/8/docs/api/java/util/Collections.html#synchronizedCollection-java.util.Collection-): "It is imperative that the user manually synchronize on the returned collection when traversing it via Iterator, Spliterator or Stream: " this means you still need to manually synchronize iterations even if you use synchronizedCollection, and synchronization all together is bad here because it would create an inaccident coupling between client and netty threads and would either introduce packet latency or fps loss under contention.

edit: The for (entry in getTabEntries()) line compiles down to a Iterator.

Also removed initOnce to make getTabEntries always guaranteed to be called only from Client thread. Lazy variable previously could have been init from another thread.

Tested for about 2 days, no errors or disconnects yet.