### PR TITLE
Replace wrapper-validation with setup-gradle

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,13 +12,13 @@ jobs:
     steps:
       - name: checkout repository
         uses: actions/checkout@v6
-      - name: validate gradle wrapper
-        uses: gradle/actions/wrapper-validation@v5
       - name: setup jdk
         uses: actions/setup-java@v5
         with:
           java-version: '21'
           distribution: 'microsoft'
+      - name: setup gradle
+        uses: gradle/actions/setup-gradle@v5
       - name: make gradle wrapper executable
         run: chmod +x ./gradlew
       - name: build


### PR DESCRIPTION
This should make gradle build cache work with GitHub Actions and reduce the time actions build finishes.

It also adds a nice summary view on the action page.

As per the README, the setup-gradle action already does wrapper validation as part of its lifecycle. See https://github.com/gradle/actions?tab=readme-ov-file#the-wrapper-validation-action - "Starting with v4 the setup-gradle action will perform wrapper validation on each execution. If you are using setup-gradle in your workflows, it is unlikely that you will need to use the wrapper-validation action."

edit: Will push an empty commit once first build finishes to see how much speedup it brings to actions builds, and post a link to the summary page.