### PR TITLE
Attempt to fix read only cache of setup-gradle

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,6 +19,8 @@ jobs:
           distribution: 'microsoft'
       - name: setup gradle
         uses: gradle/actions/setup-gradle@v5
+        with:
+          cache-read-only: false
       - name: make gradle wrapper executable
         run: chmod +x ./gradlew
       - name: build


### PR DESCRIPTION
Per https://github.com/gradle/actions/blob/main/docs/setup-gradle.md#using-the-cache-read-only, by default the action only saves cache on commits pushed to the default branch (main). As commits are pushed there only during a release and development is done on other branches, disabling read-only cache for non-default branches is benefitical.

Need to wait for the CI to finish and check summary if it's still read only, not sure if pull request branches from forks has permission to update cache state.