### PR TITLE
Restrict the mod to client environment

### DIFF
--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -24,7 +24,7 @@
 	},
 	"license": "Apache License 2.0",
 	"icon": "assets/sbo-kotlin/icon.png",
-	"environment": "*",
+	"environment": "client",
 	"entrypoints": {
 		"client": [
 			{


### PR DESCRIPTION
Self-explanatory, the mixins and the entrypoint already are only for the client env already, makes no sense to support loading the mod in server environment. Also makes mod menu show a "Client" badge for the mod in the mod list.