### PR TITLE
Remove leftover debug log call

### DIFF
--- a/src/main/kotlin/net/sbo/mod/diana/DianaTracker.kt
+++ b/src/main/kotlin/net/sbo/mod/diana/DianaTracker.kt
@@ -112,7 +112,6 @@ object DianaTracker {
     }
 
     fun trackWithPickuplog(item: Item) {
-        SBOKotlin.logger.info("debug trackWithPickuplog: itemid: |${item.itemId}|, ItemName: |${item.name}|, count: |${item.count}|, timestamp now ${System.currentTimeMillis()}, timestamp of item: |${item.creation}|, item age (senconds): |${Helper.getSecondsPassed(item.creation)}|s")
         sleep (1000) {
             if (Helper.getSecondsPassed(item.creation) > 5) return@sleep
 //            if (!dianaMobDiedRecently(3)) return@sleep


### PR DESCRIPTION
Nothing is broken with the function so I assume is a leftover debug call from earlier development. No reason to print this for end users to the log files, as it was most likely only used during development.

In the future a dedicated debug function to the main class of the mod could be added that only logs for example after enabling debug mode with a command (for example /sboenabledebug)