### PR TITLE
Bump dgt again to fix mod was built with a newer version of loom message

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -20,7 +20,7 @@ pluginManagement {
 
     plugins {
         kotlin("jvm") version("2.2.21")
-        id("dev.deftu.gradle.multiversion-root") version("2.67.0")
+        id("dev.deftu.gradle.multiversion-root") version("2.69.0")
     }
 }
 


### PR DESCRIPTION
This version of dgt ships with Loom 1.11, in turn fixing the following spammed messages during build:

"Mod was built with a newer version of Loom (1.11.7), you are using Loom (1.10.36)" (repeated like 50 times)

The ignore loom version validation flag in gradle.properties is kept just in case.

The new version of Loom does not seem to cause any issues during compilation or runtime per my testing, so this is should be fine.

This did not get in to my earlier PR that bumps dependencies because the latest version was 2.68 at the time which was failing the build, 2.69 released afterwards that fixed the failure.