### PR TITLE
Show item drop percentages with combined loot

### DIFF
--- a/src/main/kotlin/net/sbo/mod/overlays/DianaLoot.kt
+++ b/src/main/kotlin/net/sbo/mod/overlays/DianaLoot.kt
@@ -157,11 +157,15 @@ object DianaLoot {
         val totalAmount = amountBase + amountLs
         val priceLs = Helper.getItemPriceFormatted(itemNameLs.replace("_LS", ""), amountLs)
         val priceCombined = Helper.getItemPriceFormatted(itemNameBase, totalAmount)
+        val percent = data.dropMobId?.let { dropId ->
+            calcPercentOne(tracker.items, tracker.mobs, itemNameBase, dropId)
+        }
+        val percentText = percent?.let { " $GRAY($AQUA${it}%$GRAY)" } ?: ""
         val percentLs = data.dropMobLsId?.let { dropLsId ->
             calcPercentOne(tracker.items, tracker.mobs, itemNameLs, dropLsId)
         }
         val percentLsText = percentLs?.let { " $GRAY($AQUA${it}%$GRAY)" } ?: ""
-        val baseText = "$GOLD$priceCombined $GRAY| ${data.color}${data.name}: $AQUA${Helper.formatNumber(amountBase, true)}"
+        val baseText = "$GOLD$priceCombined $GRAY| ${data.color}${data.name}: $AQUA${Helper.formatNumber(amountBase, true)}$percentText"
         val lsText = "$GOLD$priceLs $GRAY| ${data.color}${data.name} $GRAY[${AQUA}LS$GRAY]: $AQUA${Helper.formatNumber(amountLs, true)}$percentLsText"
         val combinedText = "$baseText $GRAY[${AQUA}LS$GRAY:$AQUA${Helper.formatNumber(amountLs, true)}$GRAY]"
 


### PR DESCRIPTION
If combined loot option in the settings is on, previously the item drop percentages was not shown.

This fixes that by showing it before LS drop amount (which has its own percentage that doesn't show here, I assume because I lootshared zero).

Before:
<img width="321" height="22" alt="Screenshot From 2025-12-23 04-08-00" src="https://github.com/user-attachments/assets/85ed3119-5f1f-4e3b-a12b-85af8278b4f4" />

After:
<img width="411" height="23" alt="image" src="https://github.com/user-attachments/assets/8d93a323-a40d-41ef-a5b6-55b7b3623a76" />