### PR TITLE
Misc performance improvements

### DIFF
--- a/src/main/kotlin/net/sbo/mod/diana/guesses/ArrowGuessBurrow.kt
+++ b/src/main/kotlin/net/sbo/mod/diana/guesses/ArrowGuessBurrow.kt
@@ -151,15 +151,13 @@ object ArrowGuessBurrow {
     }
 
     private fun findline(): List<SboVec> {
-        val locationsSnapshot = locations.toSet()
-
-        for (location in locationsSnapshot) {
+        for (location in locations) {
             val line = mutableListOf<SboVec>()
             val visited = mutableSetOf<SboVec>()
             line.add(location)
             visited.add(location)
 
-            if (extendLine(line, visited, locationsSnapshot, SHAFT_LENGTH, PARTICLE_DETECTION_TOLERANCE)) {
+            if (extendLine(line, visited, locations, SHAFT_LENGTH, PARTICLE_DETECTION_TOLERANCE)) {
                 return line.toList()
             }
         }
@@ -267,14 +265,14 @@ object ArrowGuessBurrow {
         if (allGuesses.isEmpty()) return
         val player = SBOKotlin.mc.player ?: return
         val hasSpade = InventoryUtils.isItemHeld("SPADE", 1.seconds)
-        val burrowLocations = BurrowDetector.burrows.values.map { it.waypoint?.pos ?: SboVec(0.0, 0.0, 0.0) }.toSet()
+        val burrowLocations = BurrowDetector.burrows.values.map { it.waypoint?.pos ?: SboVec(0.0, 0.0, 0.0) }
         //#if MC >= 1.21.9
         //$$ val playerPos = player.entityPos.toSboVec()
         //#else
         val playerPos = player.pos.toSboVec()
         //#endif
 
-        for (guess in allGuesses.toList()) {
+        for (guess in allGuesses) {
             if (guess == null) continue
             val current = guess.getCurrent()
             if (!isBlockValid(current)) {

--- a/src/main/kotlin/net/sbo/mod/utils/Helper.kt
+++ b/src/main/kotlin/net/sbo/mod/utils/Helper.kt
@@ -252,12 +252,14 @@ object Helper {
         return builder.toString().trim()
     }
 
+    private val COLOR_REGEX: Regex = Regex("§.")
+
     fun String.removeFormatting(): String {
-        return this.replace(Regex("§."), "")
+        return this.replace(COLOR_REGEX, "")
     }
 
     fun Text.removeFormatting(): String {
-        return this.string.replace(Regex("§."), "")
+        return this.string.replace(COLOR_REGEX, "")
     }
 
     fun matchLvlToColor(lvl: Int): String {
@@ -353,7 +355,8 @@ object Helper {
                 val customData = stack.get(DataComponentTypes.CUSTOM_DATA)
                 var id: String
                 var item: Item
-                val sbId = ItemUtils.getSBID(customData)
+                val nbt = customData?.copyNbt()
+                val sbId = ItemUtils.getSBID(customData, nbt)
                 // print for debugging the lore lines
                 var isChimera = false
                 if (sbId == "ENCHANTED_BOOK") {
@@ -369,18 +372,18 @@ object Helper {
                 if (!isChimera) {
                     item = Item(
                         sbId,
-                        ItemUtils.getUUID(customData),
+                        ItemUtils.getUUID(customData, nbt),
                         ItemUtils.getDisplayName(stack),
-                        ItemUtils.getTimestamp(customData),
+                        ItemUtils.getTimestamp(customData, nbt),
                         stack.count
                     )
                     id = if (item.itemUUID != "") item.itemUUID else item.itemId
                 } else {
                     item = Item(
                         "CHIMERA",
-                        ItemUtils.getUUID(customData),
+                        ItemUtils.getUUID(customData, nbt),
                         "§d§lChimera",
-                        ItemUtils.getTimestamp(customData),
+                        ItemUtils.getTimestamp(customData, nbt),
                         stack.count
                     )
                     id = "CHIMERA"

--- a/src/main/kotlin/net/sbo/mod/utils/game/ItemUtils.kt
+++ b/src/main/kotlin/net/sbo/mod/utils/game/ItemUtils.kt
@@ -3,28 +3,26 @@ package net.sbo.mod.utils.game
 import gg.essential.universal.utils.toFormattedString
 import net.minecraft.component.DataComponentTypes
 import net.minecraft.component.type.NbtComponent
+import net.minecraft.nbt.NbtCompound
 import net.minecraft.item.ItemStack
 import net.minecraft.text.Text
 
 object ItemUtils {
 
-    fun getTimestamp(customData: NbtComponent?): Long {
-        if (customData == null) return 0L
-        val nbt = customData.copyNbt()
+    fun getTimestamp(customData: NbtComponent?, nbt: NbtCompound? = customData?.copyNbt()): Long {
+        if (customData == null || nbt == null) return 0L
         if (!nbt.contains("timestamp")) return 0L
         return nbt.getLong("timestamp").orElse(0L)
     }
 
-    fun getSBID(customData: NbtComponent?): String {
-        if (customData == null) return ""
-        val nbt = customData.copyNbt()
+    fun getSBID(customData: NbtComponent?, nbt: NbtCompound? = customData?.copyNbt()): String {
+        if (customData == null || nbt == null) return ""
         if (!nbt.contains("id")) return ""
         return nbt.getString("id").orElse("")
     }
 
-    fun getUUID(customData: NbtComponent?): String {
-        if (customData == null) return ""
-        val nbt = customData.copyNbt()
+    fun getUUID(customData: NbtComponent?, nbt: NbtCompound? = customData?.copyNbt()): String {
+        if (customData == null || nbt == null) return ""
         if (!nbt.contains("uuid")) return ""
         return nbt.getString("uuid").orElse("")
     }

--- a/src/main/kotlin/net/sbo/mod/utils/overlay/Overlay.kt
+++ b/src/main/kotlin/net/sbo/mod/utils/overlay/Overlay.kt
@@ -183,7 +183,7 @@ class Overlay(
                 currentY += textRenderer.fontHeight + 1
                 currentX = (x / scale)
             } else {
-                currentX += textRenderer.getWidth(line.text)
+                currentX += line.width
             }
         }
 

--- a/src/main/kotlin/net/sbo/mod/utils/overlay/OverlayTextLine.kt
+++ b/src/main/kotlin/net/sbo/mod/utils/overlay/OverlayTextLine.kt
@@ -17,7 +17,7 @@ class OverlayTextLine(
     var isHovered: Boolean = false
     var x: Int = 0
     var y: Int = 0
-    private var width: Int = 0
+    var width: Int = 0
     private var height: Int = 0
     var renderDebugBox: Boolean = false
     private var condition: () -> Boolean = { true }


### PR DESCRIPTION
- Removed toSet() and toList() calls from some places. These were bandaid fixes for concurrent modification exceptions that did not actually fix the issue, just made it rarer. As the backing collections are now concurrent or copy on write types, these are no longer needed. As the methods have to create a new set/list from stratch, removing those when we already have concurrent collections improves performance a little.

- Cache Regex creation in Helper#removeFormatting. Kotlin Regex compiles down to Pattern.compile, which is not free in terms of runtime cost to call. Saving it to a variable and re-using increases performance slightly.

- Avoided calling copyNbt() 3 times inside readPlayerInv. With the help of default arguments, made readPlayerInv pre-copy NBT and pass the already copied NBT as second parameter. NBT copying seems to allocate memory and do other operations, so only doing it once improves performance slightly.

- Cache the reflective getDeclaredField call in SboTimerManager. Optimally, VarHandle or Kotlin's property getter/setters should be used, but caching the Field is the miniimal difference over original code to improve performance slightly here.

- Avoided calling textRenderer.getWidth 2 times inside Overlay#render for each line. The line.draw call assigns this.width to textRenderer.getWidth(this.text) already, this removes private modifier from width and accesses it directly from Overlay#render. Improves both consistency (both widths are exactly same value) and performance.

Nothing of an extraordinary performance improvement, but those should still add up to around 3-4% improvement.

No regressions that I could find, tested for about 2 hours. None of the new ministers picked Diana, so can't do more testing for now.