### PR TITLE
Dont render overlays when hud is hidden

### DIFF
--- a/src/main/kotlin/net/sbo/mod/utils/overlay/OverlayManager.kt
+++ b/src/main/kotlin/net/sbo/mod/utils/overlay/OverlayManager.kt
@@ -56,7 +56,7 @@ object OverlayManager {
         val mouseX = mc.mouse.x / scaleFactor
         val mouseY = mc.mouse.y / scaleFactor
         for (overlay in overlays.toList()) {
-            if (renderScreen == "" && !mc.options.playerListKey.isPressed)
+            if (renderScreen == "" && !mc.options.playerListKey.isPressed && !mc.options.hudHidden)
                 overlay.render(drawContext, mouseX, mouseY)
         }
     }
@@ -67,7 +67,7 @@ object OverlayManager {
         val mouseX = mc.mouse.x / scaleFactor
         val mouseY = mc.mouse.y / scaleFactor
         for (overlay in overlays.toList()) {
-            if (renderScreen.title.string in overlay.allowedGuis)
+            if (renderScreen.title.string in overlay.allowedGuis && !mc.options.hudHidden)
                 overlay.render(drawContext, mouseX, mouseY)
         }
     }


### PR DESCRIPTION
This makes it so SBO does not render it's overlays on screen when hud is hidden with the vanilla keybind (F1 by default)