### PR TITLE
Optimize text rendering with OrderedText and width cache

### DIFF
--- a/src/main/kotlin/net/sbo/mod/utils/overlay/OverlayTextLine.kt
+++ b/src/main/kotlin/net/sbo/mod/utils/overlay/OverlayTextLine.kt
@@ -1,15 +1,45 @@
 package net.sbo.mod.utils.overlay
 
+import net.sbo.mod.SBOKotlin.mc
+
 import net.minecraft.client.gui.DrawContext
 import net.minecraft.client.font.TextRenderer
+
+import net.minecraft.text.OrderedText
+import net.minecraft.text.Text
 
 import java.awt.Color
 
 class OverlayTextLine(
-    var text: String,
+    text: String,
     var shadow: Boolean = true,
     var linebreak: Boolean = true
 ) {
+    private var orderedText: OrderedText = Text.of(text).asOrderedText() // to avoid nullable OrderedText?
+
+    private var cachedWidth: Int = -1 // filler value used to differenate non-init vs actual width
+        private get() {
+            val isInit = field != -1 // check if actual width
+
+            if (isInit) {
+                return field
+            }
+
+            val width = mc.textRenderer!!.getWidth(orderedText)
+            field = width
+
+            return field
+        }
+
+    var text: String = text
+        set(value) {
+            field = value
+
+            // update cached values when text changes
+            orderedText = Text.of(value).asOrderedText()
+            cachedWidth = mc.textRenderer?.getWidth(orderedText) ?: -1 // textRenderer is null at init time
+        }
+
     var mouseEnterAction: (() -> Unit)? = null
     var mouseLeaveAction: (() -> Unit)? = null
     var hoverAction: ((drawContext: DrawContext, textRenderer: TextRenderer) -> Unit)? = null
@@ -89,7 +119,7 @@ class OverlayTextLine(
     }
 
     private fun isMouseOver(mouseX: Double, mouseY: Double, x: Float, y: Float, textRenderer: TextRenderer, scale: Float): Boolean {
-        val textWidth = textRenderer.getWidth(text) * scale
+        val textWidth = cachedWidth * scale
         val textHeight = (textRenderer.fontHeight + 1) * scale - 1
 
         return mouseX >= x && mouseX <= x + textWidth && mouseY >= y && mouseY <= y + textHeight
@@ -120,13 +150,13 @@ class OverlayTextLine(
 
         this.x = x
         this.y = y
-        this.width = textRenderer.getWidth(text)
+        this.width = cachedWidth
         this.height = textRenderer.fontHeight
 
         if (renderDebugBox) {
             drawContext.fill(x, y, x + width, y + height + 1, Color(128, 128, 128, 130).rgb)
         }
 
-        drawContext.drawText(textRenderer, text, x, y, -1, shadow)
+        drawContext.drawText(textRenderer, orderedText, x, y, -1, shadow)
     }
 }


### PR DESCRIPTION
This adds an orderedText field that is updated when the text changes, skipping TranslationStorage#reorder's TextReorderingProcessor and Bidi processing logic when passed to DrawContext#drawString, rather than passing the raw String (which implicitly constructs an OrderedText every frame, running all the logic).

Also adds a cachedWidth field, which eliminates TextRenderer#getWidth calls.

As SBO renders a lot of text on screen, and OverlayTextLine is per-line, TranslationStorage#reorder and TextRenderer#getWidth end up being called every frame for every line of text. Now, it will only be called when the actual text changes, which improves FPS slightly.

Kotlin's property getters/setters are used to keep all the code same. External code can still do line.text = "Hello world" and an OrderedText will be constructed along with getWidth being called to calculate the width.