### PR TITLE
Remove alternative color char before announcing loot

### DIFF
--- a/src/main/kotlin/net/sbo/mod/diana/DianaTracker.kt
+++ b/src/main/kotlin/net/sbo/mod/diana/DianaTracker.kt
@@ -661,7 +661,7 @@ object DianaTracker {
     fun announceLootToParty(item: String, customMsg: String? = null, replaceDropMessage: Boolean = false) {
         if (!Diana.lootAnnouncerParty) return
         var msg = Helper.toTitleCase(item.replace("_LS", "").replace("_", " "))
-        if (customMsg != null) msg = customMsg.removeFormatting()
+        if (customMsg != null) msg = customMsg.removeFormatting().replace("&", "")
 
         if (replaceDropMessage) {
             Chat.command("pc $msg")


### PR DESCRIPTION
.removeFormatting only removes §, while default custom messages have & in them (added a while ago, not sure if made it into a release yet), causing a bug where the message with & is sent to party chat.

This fixes it by additionally removing the alternative color char ("&") via String#replace method.