### PR TITLE
Forgot this, remove the actual color code as well

### DIFF
--- a/src/main/kotlin/net/sbo/mod/diana/DianaTracker.kt
+++ b/src/main/kotlin/net/sbo/mod/diana/DianaTracker.kt
@@ -658,10 +658,12 @@ object DianaTracker {
         }
     }
 
+    private val ALT_COLOR_REGEX: Regex = Regex("&.")
+
     fun announceLootToParty(item: String, customMsg: String? = null, replaceDropMessage: Boolean = false) {
         if (!Diana.lootAnnouncerParty) return
         var msg = Helper.toTitleCase(item.replace("_LS", "").replace("_", " "))
-        if (customMsg != null) msg = customMsg.removeFormatting().replace("&", "")
+        if (customMsg != null) msg = customMsg.removeFormatting().replace(ALT_COLOR_REGEX, "")
 
         if (replaceDropMessage) {
             Chat.command("pc $msg")


### PR DESCRIPTION
In my defense I've not had my coffee for the day

Use a cached Regex like used in other places to remove the actual color code as well and not just the &

Previous code would remove & but leave actual color code like &d&lChimera --> dlChimera