### PR TITLE
Add configurable rare mob title timings

### DIFF
--- a/src/main/kotlin/net/sbo/mod/settings/categories/Diana.kt
+++ b/src/main/kotlin/net/sbo/mod/settings/categories/Diana.kt
@@ -237,6 +237,34 @@ object Diana : CategoryKt("Diana") {
         }
     }
 
+    init {
+        separator {
+            this.title = "Title Timings"
+            this.description = "Customize fade-in, display and fade-out ticks for titles"
+        }
+    }
+
+    var rareTitleFadeIn by int(0) {
+        this.name = Literal("Rare Title Fade In")
+        this.description = Literal("Fade-in (ticks) for rare mob titles")
+        this.range = 0..100
+        this.slider = true
+    }
+
+    var rareTitleTime by int(90) {
+        this.name = Literal("Rare Title Time")
+        this.description = Literal("Display time (ticks) for rare mob titles")
+        this.range = 0..100
+        this.slider = true
+    }
+
+    var rareTitleFadeOut by int(20) {
+        this.name = Literal("Rare Title Fade Out")
+        this.description = Literal("Fade-out (ticks) for rare mob titles")
+        this.range = 0..100
+        this.slider = true
+    }
+
     var lootAnnouncerParty by boolean(false) {
         this.name = Literal("Loot Party Announcer")
         this.description = Literal("Announces chimera/stick/relic and Shelmet/Plushie/Remedies (only when dropped from Inquisitor) in party chat")

--- a/src/main/kotlin/net/sbo/mod/utils/waypoint/WaypointManager.kt
+++ b/src/main/kotlin/net/sbo/mod/utils/waypoint/WaypointManager.kt
@@ -89,23 +89,23 @@ object WaypointManager {
 
                     when (mob) { // todo: add custom sounds per mob
                         "minos inquisitor", "inquisitor", "inq" -> {
-                            Helper.showTitle("§r§6§l<§b§l§kO§6§l> §b§lINQUISITOR! §6§l<§b§l§kO§6§l>", player, 0, 90, 20)
+                            Helper.showTitle("§r§6§l<§b§l§kO§6§l> §b§lINQUISITOR! §6§l<§b§l§kO§6§l>", player, Diana.rareTitleFadeIn, Diana.rareTitleTime, Diana.rareTitleFadeOut)
                             playCustomSound(Customization.inqSound[0], Customization.inqVolume)
                         }
                         "king minos", "king" -> {
-                            Helper.showTitle("§r§6§l<§b§l§kO§6§l> §b§lKING MINOS! §6§l<§b§l§kO§6§l>", player, 0, 90, 20)
+                            Helper.showTitle("§r§6§l<§b§l§kO§6§l> §b§lKING MINOS! §6§l<§b§l§kO§6§l>", player, Diana.rareTitleFadeIn, Diana.rareTitleTime, Diana.rareTitleFadeOut)
                             playCustomSound(Customization.kingSound[0], Customization.kingVolume)
                         }
                         "manticore" -> {
-                            Helper.showTitle("§r§6§l<§b§l§kO§6§l> §b§lMANTICORE! §6§l<§b§l§kO§6§l>", player, 0, 90, 20)
+                            Helper.showTitle("§r§6§l<§b§l§kO§6§l> §b§lMANTICORE! §6§l<§b§l§kO§6§l>", player, Diana.rareTitleFadeIn, Diana.rareTitleTime, Diana.rareTitleFadeOut)
                             playCustomSound(Customization.mantiSound[0], Customization.mantiVolume)
                         }
                         "sphinx" -> {
-                            Helper.showTitle("§r§6§l<§b§l§kO§6§l> §b§lSPHINX! §6§l<§b§l§kO§6§l>", player, 0, 90, 20)
+                            Helper.showTitle("§r§6§l<§b§l§kO§6§l> §b§lSPHINX! §6§l<§b§l§kO§6§l>", player, Diana.rareTitleFadeIn, Diana.rareTitleTime, Diana.rareTitleFadeOut)
                             playCustomSound(Customization.sphinxSound[0], Customization.sphinxVolume)
                         }
                         else -> {
-                            Helper.showTitle("§r§6§l<§b§l§kO§6§l> §b§lRARE MOB! §6§l<§b§l§kO§6§l>", player, 0, 90, 20)
+                            Helper.showTitle("§r§6§l<§b§l§kO§6§l> §b§lRARE MOB! §6§l<§b§l§kO§6§l>", player, Diana.rareTitleFadeIn, Diana.rareTitleTime, Diana.rareTitleFadeOut)
                             playCustomSound(Customization.rareMobSound[0], Customization.rareMobVolume)
                         }
                     }


### PR DESCRIPTION
Introduces settings for fade-in, display, and fade-out ticks for rare mob titles in the Diana category. WaypointManager now uses these configurable values instead of hardcoded timings for rare mob title display.