### PR TITLE
Enhance setup-gradle workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,8 @@
 # against bad commits.
 
 name: build
+permissions:
+  pull-requests: write
 on: [pull_request, push]
 
 jobs:
@@ -21,10 +23,14 @@ jobs:
         uses: gradle/actions/setup-gradle@v5
         with:
           cache-read-only: false
+          add-job-summary-as-pr-comment: 'on-failure'
+          build-scan-publish: true
+          build-scan-terms-of-use-url: 'https://gradle.com/terms-of-service'
+          build-scan-terms-of-use-agree: 'yes'
       - name: make gradle wrapper executable
         run: chmod +x ./gradlew
       - name: build
-        run: ./gradlew build
+        run: ./gradlew build --scan
       - name: capture build artifacts
         uses: actions/upload-artifact@v6
         with:


### PR DESCRIPTION
Adds pr comment on build failure for job summary and build scan link generation to the workflow.

Build scan will allow us to see details of the build such as what task is taking the longest to finish, and would help optimizing the build in future. It also helps if any deprecated gradle feature is used to ensure forward compatibility, as we can see deprecated usages in the generated build scan link.