### PR TITLE
Initial work on 1.21.11 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 ## What it does
 
-[SBO] SkyblockOverhaul is a feature‐rich Hypixel Skyblock for Minecraft fabric-1.21.5 designed primarily for the Diana event.
+[SBO] SkyblockOverhaul is a feature‐rich Hypixel Skyblock for Minecraft fabric-1.21 designed primarily for the Diana event.
 
 ---
 
@@ -78,7 +78,7 @@ Before you begin, you need to have a few things installed:
 
 **1. Install Dependencies**
 * Download the **Fabric API** and **Fabric Language Kotlin** `.jar` files from their respective Modrinth pages.
-* Make sure to download the versions that match your Minecraft version (`1.21.5`).
+* Make sure to download the versions that match your Minecraft version (like `1.21.11`).
 
 **2. Install SkyblockOverhaul**
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,7 +11,18 @@ plugins {
     id("dev.deftu.gradle.tools.shadow")
     id("dev.deftu.gradle.tools.minecraft.loom")
     id("dev.deftu.gradle.tools.minecraft.releases")
-    id("com.google.devtools.ksp") version "2.3.3"
+    id("com.google.devtools.ksp") version "2.3.6"
+}
+
+loom {
+    if (mcData.version == MinecraftVersions.VERSION_1_21_11) {
+        // Temporarily disabled because of build failure on 1.21.11:
+        // java.lang.IllegalStateException: Javadoc provided by mod (fabric-content-registries-v0) must be have an intermediary source namespace
+        enableModProvidedJavadoc = false
+
+        // Some stuff were made private / package-private in 1.21.11, so we need this.
+        accessWidenerPath = file("src/main/resources/sbo-kotlin.accesswidener")
+    }
 }
 
 repositories {
@@ -35,28 +46,38 @@ dependencies {
 
     modImplementation(include("gg.essential:elementa:${property("elementa.version")}")!!)
     modImplementation(include("net.azureaaron:hm-api:${property("hmapi.version")}")!!)
-    modImplementation(include("com.teamresourceful.resourcefulconfigkt:resourcefulconfigkt-fabric-1.21.5:${property("rconfig.version.1.21.5")}")!!)
 
     // modImplementation(include("xyz.meowing:vexel-${mcData}:${property("vexel.version")}")!!)
     when (mcData.version) {
+        MinecraftVersions.VERSION_1_21_11 -> {
+            modImplementation("net.fabricmc.fabric-api:fabric-api:${mcData.dependencies.fabric.fabricApiVersion}")
+            modImplementation("com.terraformersmc:modmenu:${property("modmenu.version.1.21.11")}")
+            modImplementation(include("com.teamresourceful.resourcefulconfig:resourcefulconfig-fabric-1.21.11:${property("rconfig.version.1.21.11")}")!!)
+            modImplementation(include("com.teamresourceful.resourcefulconfigkt:resourcefulconfigkt-fabric-1.21.11:${property("rconfigkt.version.1.21.11")}")!!)
+            modImplementation(include("gg.essential:universalcraft-1.21.11-fabric:${property("uc.version")}")!!)
+            compileOnly("maven.modrinth:iris:${property("iris.version.1.21.11")}+1.21.11-fabric")
+        }
         MinecraftVersions.VERSION_1_21_10 -> {
-            modImplementation("net.fabricmc.fabric-api:fabric-api:0.138.3+1.21.10")
+            modImplementation("net.fabricmc.fabric-api:fabric-api:${mcData.dependencies.fabric.fabricApiVersion}")
             modImplementation("com.terraformersmc:modmenu:${property("modmenu.version.1.21.10")}")
-            modImplementation(include("com.teamresourceful.resourcefulconfig:resourcefulconfig-fabric-1.21.9:${property("rconfig.version.1.21.10")}")!!)
+            modImplementation(include("com.teamresourceful.resourcefulconfig:resourcefulconfig-fabric-1.21.9:${property("rconfig.version.1.21.10")}")!!) // .9 works on .10
+            modImplementation(include("com.teamresourceful.resourcefulconfigkt:resourcefulconfigkt-fabric-1.21.5:${property("rconfigkt.version.1.21.5")}")!!)  // .5 works on .10
             modImplementation(include("gg.essential:universalcraft-1.21.9-fabric:${property("uc.version")}")!!)
-            compileOnly("maven.modrinth:iris:${property("iris.version.1.21.10")}+1.21.7-fabric")
+            compileOnly("maven.modrinth:iris:${property("iris.version.1.21.10")}+1.21.10-fabric")
         }
         MinecraftVersions.VERSION_1_21_7 -> {
             modImplementation("net.fabricmc.fabric-api:fabric-api:${mcData.dependencies.fabric.fabricApiVersion}")
             modImplementation("com.terraformersmc:modmenu:${property("modmenu.version.1.21.7")}")
             modImplementation(include("com.teamresourceful.resourcefulconfig:resourcefulconfig-fabric-${mcData.version}:${property("rconfig.version.1.21.7")}")!!)
+            modImplementation(include("com.teamresourceful.resourcefulconfigkt:resourcefulconfigkt-fabric-1.21.5:${property("rconfigkt.version.1.21.5")}")!!)  // .5 works on .7
             modImplementation(include("gg.essential:universalcraft-$mcData:${property("uc.version")}")!!)
-            compileOnly("maven.modrinth:iris:${property("iris.version.1.21.7")}+1.21.7-fabric")
+            compileOnly("maven.modrinth:iris:${property("iris.version.1.21.7")}+1.21.8-fabric") // .8 is a bugfix version so itll work on .7
         }
         MinecraftVersions.VERSION_1_21_5 -> {
             modImplementation("net.fabricmc.fabric-api:fabric-api:${mcData.dependencies.fabric.fabricApiVersion}")
             modImplementation("com.terraformersmc:modmenu:${property("modmenu.version.1.21.5")}")
             modImplementation(include("com.teamresourceful.resourcefulconfig:resourcefulconfig-fabric-${mcData.version}:${property("rconfig.version.1.21.5")}")!!)
+            modImplementation(include("com.teamresourceful.resourcefulconfigkt:resourcefulconfigkt-fabric-1.21.5:${property("rconfigkt.version.1.21.5")}")!!)
             modImplementation(include("gg.essential:universalcraft-$mcData:${property("uc.version")}")!!)
             compileOnly("maven.modrinth:iris:${property("iris.version.1.21.5")}+1.21.5-fabric")
         }
@@ -69,6 +90,7 @@ dependencies {
 
 tasks.findByName("preprocessCode")?.apply {
     when (mcData.version) {
+        MinecraftVersions.VERSION_1_21_11 -> dependsOn(":1.21.10-fabric:kspKotlin")
         MinecraftVersions.VERSION_1_21_10 -> dependsOn(":1.21.7-fabric:kspKotlin")
         MinecraftVersions.VERSION_1_21_7 -> dependsOn(":1.21.5-fabric:kspKotlin")
         else -> {}

--- a/event-processor/build.gradle
+++ b/event-processor/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'org.jetbrains.kotlin.jvm'
-    id 'com.google.devtools.ksp' version "2.3.3"
+    id 'com.google.devtools.ksp' version "2.3.6"
 }
 
 repositories {
@@ -10,5 +10,5 @@ repositories {
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib"
-    implementation "com.google.devtools.ksp:symbol-processing-api:2.3.3"
+    implementation "com.google.devtools.ksp:symbol-processing-api:2.3.6"
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -23,7 +23,7 @@ dgt.minecraft.revision=4
 
 # Mod properties
 mod.name=SBO
-mod.id=sbo
+mod.id=sbo-kotlin
 mod.version=0.2.0-beta
 mod.group=net.sbo.mod
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,9 +1,17 @@
 # Gradle configuration
-org.gradle.jvmargs=-Xms1m -Xmx4g -XX:+UnlockExperimentalVMOptions -XX:SoftMaxHeapSize=2g -XX:+UseStringDeduplication -XX:+UseZGC -XX:+IgnoreUnrecognizedVMOptions -XX:+UseCompactObjectHeaders
-kotlin.daemon.jvmargs=-Xms1m -Xmx4g -XX:+UnlockExperimentalVMOptions -XX:SoftMaxHeapSize=2g -XX:+UseStringDeduplication -XX:+UseZGC -XX:+IgnoreUnrecognizedVMOptions -XX:+UseCompactObjectHeaders
 
+# JVM flags to improve performance of the build
+# Some references: https://openjdk.org/jeps/8359211 , https://www.evanjones.ca/java-bytebuffer-leak.html , https://www.evanjones.ca/jvm-mmap-pause.html , https://openjdk.org/jeps/450
+org.gradle.jvmargs=-Xms1m -XX:SoftMaxHeapSize=1536m -Xmx2g -XX:MaxDirectMemorySize=2g -Djdk.nio.maxCachedBufferSize=262144 -XX:AllocatePrefetchStyle=3 -XX:+UseStringDeduplication -XX:+UseZGC -XX:+PerfDisableSharedMem -XX:+DisableExplicitGC -Djdk.util.jar.enableMultiRelease=force -Djava.net.preferIPv4Stack=true -Dkotlinx.coroutines.debug=off -Dsun.misc.URLClassPath.disableJarChecking=true -XX:-PrintWarnings -XX:ThreadPriorityPolicy=1 -XX:+UnlockExperimentalVMOptions -XX:+TrustFinalNonStaticFields -XX:+IgnoreUnrecognizedVMOptions -XX:+UseCompactObjectHeaders
+kotlin.daemon.jvmargs=-Xms1m -XX:SoftMaxHeapSize=1536m -Xmx2g -XX:MaxDirectMemorySize=2g -Djdk.nio.maxCachedBufferSize=262144 -XX:AllocatePrefetchStyle=3 -XX:+UseStringDeduplication -XX:+UseZGC -XX:+PerfDisableSharedMem -XX:+DisableExplicitGC -Djdk.util.jar.enableMultiRelease=force -Djava.net.preferIPv4Stack=true -Dkotlinx.coroutines.debug=off -Dsun.misc.URLClassPath.disableJarChecking=true -XX:-PrintWarnings -XX:ThreadPriorityPolicy=1 -XX:+UnlockExperimentalVMOptions -XX:+TrustFinalNonStaticFields -XX:+IgnoreUnrecognizedVMOptions -XX:+UseCompactObjectHeaders
+
+# Run tasks in parallel when possible
 org.gradle.parallel=true
+
+# Enable the build cache
 org.gradle.caching=true
+
+# Only configure tasks when they are needed
 org.gradle.configureondemand=true
 
 # loom
@@ -15,23 +23,28 @@ dgt.minecraft.revision=4
 
 # Mod properties
 mod.name=SBO
-mod.id=sbo-kotlin
+mod.id=sbo
 mod.version=0.2.0-beta
 mod.group=net.sbo.mod
 
 # Dependencies
-uc.version=444
+uc.version=453
 elementa.version=714
-rconfig.version.1.21.5=3.5.13
-rconfig.version.1.21.7=3.7.6
+rconfig.version.1.21.5=3.5.18
+rconfig.version.1.21.7=3.7.7
 rconfig.version.1.21.10=3.9.1
+rconfig.version.1.21.11=3.11.2
+rconfigkt.version.1.21.5=3.5.16
+rconfigkt.version.1.21.11=3.11.0
 hmapi.version=1.0.1+1.21.2
 modmenu.version.1.21.5=14.0.0
 modmenu.version.1.21.7=15.0.0
-modmenu.version.1.21.10=16.0.0-rc.1
+modmenu.version.1.21.10=16.0.0
+modmenu.version.1.21.11=17.0.0-beta.2
 iris.version.1.21.5=1.8.11
-iris.version.1.21.7=1.9.1
-iris.version.1.21.10=1.9.1
+iris.version.1.21.7=1.9.6
+iris.version.1.21.10=1.9.7
+iris.version.1.21.11=1.10.6
 vexel.version=126
-devauth.version=1.2.1
+devauth.version=1.2.2
 autoservice.version=1.2.0

--- a/root.gradle.kts
+++ b/root.gradle.kts
@@ -5,9 +5,11 @@ plugins {
 preprocess {
     strictExtraMappings.set(true)
 
-    "1.21.10-fabric"(1_21_10, "yarn") {
-        "1.21.7-fabric"(1_21_08, "yarn") {
-            "1.21.5-fabric"(1_21_05, "yarn")
+    "1.21.11-fabric"(1_21_11, "yarn") {
+        "1.21.10-fabric"(1_21_10, "yarn") {
+            "1.21.7-fabric"(1_21_08, "yarn") {
+                "1.21.5-fabric"(1_21_05, "yarn")
+            }
         }
     }
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -30,7 +30,8 @@ include("event-processor")
 listOf(
     "1.21.5-fabric",
     "1.21.7-fabric",
-    "1.21.10-fabric"
+    "1.21.10-fabric",
+    "1.21.11-fabric"
 ).forEach { version ->
     include(":$version")
     project(":$version").apply {

--- a/src/main/kotlin/net/sbo/mod/utils/http/Http.kt
+++ b/src/main/kotlin/net/sbo/mod/utils/http/Http.kt
@@ -16,7 +16,7 @@ object Http {
     val jsonParser = Json { ignoreUnknownKeys = true }
     private const val CONNECT_TIMEOUT = 10000
     private const val READ_TIMEOUT = 10000
-    private const val USER_AGENT = "SBO-Kotlin-Mod/1.21.5"
+    private const val USER_AGENT = "SBO-Kotlin-Mod/1.21"
 
     /**
      * Sends an asynchronous HTTP GET request.

--- a/src/main/kotlin/net/sbo/mod/utils/render/RenderUtils3D.kt
+++ b/src/main/kotlin/net/sbo/mod/utils/render/RenderUtils3D.kt
@@ -21,6 +21,11 @@ import net.sbo.mod.settings.categories.Diana
 //$$ import net.fabricmc.fabric.api.client.rendering.v1.world.WorldRenderContext
 //#endif
 
+//#if MC > 1.21.10
+//$$ import net.minecraft.world.debug.gizmo.GizmoDrawing
+//$$ import net.minecraft.util.math.Box
+//#endif
+
 object RenderUtils3D {
     fun renderWaypoint(
         context: WorldRenderContext,
@@ -37,9 +42,6 @@ object RenderUtils3D {
         drawFilledBox(
             context,
             pos,
-            1.0,
-            1.0,
-            1.0,
             colorComponents,
             alpha,
             throughWalls
@@ -94,13 +96,26 @@ object RenderUtils3D {
     fun drawFilledBox(
         context: WorldRenderContext,
         pos: SboVec,
-        width: Double,
-        height: Double,
-        depth: Double,
         colorComponents: FloatArray,
         alpha: Float,
         throughWalls: Boolean
     ) {
+        //#if MC > 1.21.10
+        //$$ val r = (colorComponents[0].coerceIn(0f, 1f) * 255).toInt()
+        //$$ val g = (colorComponents[1].coerceIn(0f, 1f) * 255).toInt()
+        //$$ val b = (colorComponents[2].coerceIn(0f, 1f) * 255).toInt()
+        //$$ val a = (alpha.coerceIn(0f, 1f) * 255).toInt()
+        //$$ val argbColor = (a shl 24) or (r shl 16) or (g shl 8) or b
+        //$$ val bPos = pos.toBlockPos().toImmutable()
+        //$$ if (throughWalls) {
+        //$$     GizmoDrawing.box(Box.enclosing(bPos, bPos), DrawStyle.filled(argbColor)).ignoreOcclusion()
+        //$$ } else {
+        //$$     GizmoDrawing.box(Box.enclosing(bPos, bPos), DrawStyle.filled(argbColor))
+        //$$ }
+        //#else
+        val width = 1.0
+        val height = 1.0
+        val depth = 1.0
         context.pushPop {
             val cameraPos = context.getCamera().pos
             translate(pos.x + 0.5 - cameraPos.x, pos.y - cameraPos.y, pos.z + 0.5 - cameraPos.z)
@@ -124,8 +139,8 @@ object RenderUtils3D {
                 maxX, maxY, maxZ,
                 colorComponents[0], colorComponents[1], colorComponents[2], alpha
             )
-
         }
+        //#endif
     }
 
     /**
@@ -415,10 +430,15 @@ object RenderUtils3D {
     }
 
     private inline fun MatrixStack.withLineWidth(lineWidth: Float, function: MatrixStack.() -> Unit) {
+        //TODO find 1.21.11 compatible way of line width
+        //#if MC > 1.21.10
+        //$$ function()
+        //#else
         val prevLineWidth = RenderSystem.getShaderLineWidth()
         RenderSystem.lineWidth(lineWidth)
         function()
         RenderSystem.lineWidth(prevLineWidth)
+        //#endif
     }
 
     private inline fun MatrixStack.pushPop(function: MatrixStack.() -> Unit) {

--- a/src/main/kotlin/net/sbo/mod/utils/render/RenderUtils3D.kt
+++ b/src/main/kotlin/net/sbo/mod/utils/render/RenderUtils3D.kt
@@ -248,11 +248,17 @@ object RenderUtils3D {
                 buffer.vertex(matrixEntry, startPos.x.toFloat(), startPos.y.toFloat(), startPos.z.toFloat())
                     .normal(matrixEntry, nx, ny, nz)
                     .color(color[0], color[1], color[2], alpha)
+                    //#if MC > 1.21.10
+                    //$$ .lineWidth(lineWidth)
+                    //#endif
 
 
                 buffer.vertex(matrixEntry, endPos.x.toFloat(), endPos.y.toFloat(), endPos.z.toFloat())
                     .normal(matrixEntry, nx, ny, nz)
                     .color(color[0], color[1], color[2], alpha)
+                    //#if MC > 1.21.10
+                    //$$ .lineWidth(lineWidth)
+                    //#endif
             }
         }
     }
@@ -430,7 +436,6 @@ object RenderUtils3D {
     }
 
     private inline fun MatrixStack.withLineWidth(lineWidth: Float, function: MatrixStack.() -> Unit) {
-        //TODO find 1.21.11 compatible way of line width
         //#if MC > 1.21.10
         //$$ function()
         //#else

--- a/src/main/kotlin/net/sbo/mod/utils/render/SboRenderLayers.kt
+++ b/src/main/kotlin/net/sbo/mod/utils/render/SboRenderLayers.kt
@@ -2,15 +2,26 @@ package net.sbo.mod.utils.render
 
 import net.minecraft.client.gl.RenderPipelines
 import net.minecraft.client.render.RenderLayer
-import net.minecraft.client.render.RenderPhase
 import net.minecraft.client.render.block.entity.BeaconBlockEntityRenderer
 import net.minecraft.util.TriState
 import java.util.OptionalDouble
+//#if MC > 1.21.10
+//$$ import net.minecraft.client.render.RenderSetup
+//$$ import net.minecraft.client.render.LayeringTransform
+//#else
+import net.minecraft.client.render.RenderPhase
+//#endif
 
 object SboRenderLayers {
     @JvmField
-    val FILLED_BOX: RenderLayer.MultiPhase = RenderLayer.of(
+    val FILLED_BOX: RenderLayer = RenderLayer.of(
         "sbo/filled_box",
+        //#if MC > 1.21.10
+        //$$ RenderSetup.builder(RenderPipelines.DEBUG_FILLED_BOX)
+        //$$     .layeringTransform(LayeringTransform.VIEW_OFFSET_Z_LAYERING)
+        //$$     .translucent()
+        //$$     .build()
+        //#else
         RenderLayer.DEFAULT_BUFFER_SIZE,
         false,
         true,
@@ -18,11 +29,18 @@ object SboRenderLayers {
         RenderLayer.MultiPhaseParameters.builder()
             .layering(RenderPhase.VIEW_OFFSET_Z_LAYERING)
             .build(false)
+        //#endif
     )
 
     @JvmField
-    val FILLED_BOX_THROUGH_WALLS: RenderLayer.MultiPhase = RenderLayer.of(
+    val FILLED_BOX_THROUGH_WALLS: RenderLayer = RenderLayer.of(
         "sbo/filled_box_through_walls",
+        //#if MC > 1.21.10
+        //$$ RenderSetup.builder(SboRenderPipelines.FILLED_BOX_THROUGH_WALLS)
+        //$$     .layeringTransform(LayeringTransform.VIEW_OFFSET_Z_LAYERING)
+        //$$     .translucent()
+        //$$     .build()
+        //#else
         RenderLayer.DEFAULT_BUFFER_SIZE,
         false,
         true,
@@ -30,11 +48,17 @@ object SboRenderLayers {
         RenderLayer.MultiPhaseParameters.builder()
             .layering(RenderPhase.VIEW_OFFSET_Z_LAYERING)
             .build(false)
+        //#endif
     )
 
     @JvmField
-    val LINES: RenderLayer.MultiPhase = RenderLayer.of(
+    val LINES: RenderLayer = RenderLayer.of(
         "lines",
+        //#if MC > 1.21.10
+        //$$ RenderSetup.builder(SboRenderPipelines.LINES)
+        //$$     .translucent()
+        //$$     .build()
+        //#else
         RenderLayer.DEFAULT_BUFFER_SIZE,
         false,
         true,
@@ -43,11 +67,17 @@ object SboRenderLayers {
             .layering(RenderPhase.VIEW_OFFSET_Z_LAYERING)
             .lineWidth(RenderPhase.LineWidth(OptionalDouble.empty()))
             .build(false)
+        //#endif
     )
 
     @JvmField
-    val LINES_THROUGH_WALLS: RenderLayer.MultiPhase = RenderLayer.of(
+    val LINES_THROUGH_WALLS: RenderLayer = RenderLayer.of(
         "sbo/lines_through_walls",
+        //#if MC > 1.21.10
+        //$$ RenderSetup.builder(SboRenderPipelines.LINES_THROUGH_WALLS)
+        //$$     .translucent()
+        //$$     .build()
+        //#else
         RenderLayer.DEFAULT_BUFFER_SIZE,
         false,
         true,
@@ -56,10 +86,16 @@ object SboRenderLayers {
             .layering(RenderPhase.VIEW_OFFSET_Z_LAYERING)
             .lineWidth(RenderPhase.LineWidth(OptionalDouble.empty()))
             .build(false)
+        //#endif
     )
 
     val BEACON_BEAM_OPAQUE: RenderLayer = RenderLayer.of(
         "beacon_beam_opaque",
+        //#if MC > 1.21.10
+        //$$ RenderSetup.builder(SboRenderPipelines.BEACON_BEAM_OPAQUE)
+        //$$     .texture("Sampler0", BeaconBlockEntityRenderer.BEAM_TEXTURE)
+        //$$     .build()
+        //#else
         1536,
         false,
         true,
@@ -75,10 +111,16 @@ object SboRenderLayers {
                 )
             )
             .build(false)
+        //#endif
     )
 
     val BEACON_BEAM_OPAQUE_THROUGH_WALLS: RenderLayer = RenderLayer.of(
         "beacon_beam_opaque_through_walls",
+        //#if MC > 1.21.10
+        //$$ RenderSetup.builder(SboRenderPipelines.BEACON_BEAM_OPAQUE_THROUGH_WALLS)
+        //$$     .texture("Sampler0", BeaconBlockEntityRenderer.BEAM_TEXTURE)
+        //$$     .build()
+        //#else
         1536,
         false,
         true,
@@ -94,10 +136,17 @@ object SboRenderLayers {
                 )
             )
             .build(false)
+        //#endif
     )
 
     val BEACON_BEAM_TRANSLUCENT: RenderLayer = RenderLayer.of(
         "beacon_beam_translucent",
+        //#if MC > 1.21.10
+        //$$ RenderSetup.builder(SboRenderPipelines.BEACON_BEAM_TRANSLUCENT)
+        //$$     .texture("Sampler0", BeaconBlockEntityRenderer.BEAM_TEXTURE)
+        //$$     .translucent()
+        //$$     .build()
+        //#else
         1536,
         false,
         true,
@@ -113,10 +162,17 @@ object SboRenderLayers {
                 )
             )
             .build(false)
+        //#endif
     )
 
     val BEACON_BEAM_TRANSLUCENT_THROUGH_WALLS: RenderLayer = RenderLayer.of(
         "devonian_beacon_beam_translucent_esp",
+        //#if MC > 1.21.10
+        //$$ RenderSetup.builder(SboRenderPipelines.BEACON_BEAM_TRANSLUCENT_THROUGH_WALLS)
+        //$$     .texture("Sampler0", BeaconBlockEntityRenderer.BEAM_TEXTURE)
+        //$$     .translucent()
+        //$$     .build()
+        //#else
         1536,
         false,
         true,
@@ -132,5 +188,6 @@ object SboRenderLayers {
                 )
             )
             .build(false)
+        //#endif
     )
 }

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -35,6 +35,7 @@
 	"mixins": [
 		"mixins.sbo-kotlin.json"
 	],
+	"accessWidener": "sbo-kotlin.accesswidener",
 	"depends": {
 		"fabricloader": ">=0.16.14",
 		"minecraft": "~${minor_mc_version}",

--- a/src/main/resources/sbo-kotlin.accesswidener
+++ b/src/main/resources/sbo-kotlin.accesswidener
@@ -1,0 +1,2 @@
+accessWidener v1 named
+

--- a/versions/1.21.10-fabric/src/main/resources/sbo-kotlin.accesswidener
+++ b/versions/1.21.10-fabric/src/main/resources/sbo-kotlin.accesswidener
@@ -1,0 +1,2 @@
+accessWidener v1 named
+

--- a/versions/1.21.11-fabric/src/main/resources/sbo-kotlin.accesswidener
+++ b/versions/1.21.11-fabric/src/main/resources/sbo-kotlin.accesswidener
@@ -1,0 +1,10 @@
+accessWidener v1 named
+
+# Chat Width (Private in 1.21.11)
+accessible method net/minecraft/client/gui/hud/ChatHud getWidth ()I
+
+# Camera Position (Private in 1.21.11)
+accessible field net/minecraft/client/render/Camera pos Lnet/minecraft/util/math/Vec3d;
+
+# RenderLayer Creation (Package-Private in 1.21.11)
+accessible method net/minecraft/client/render/RenderLayer of (Ljava/lang/String;Lnet/minecraft/client/render/RenderSetup;)Lnet/minecraft/client/render/RenderLayer;

--- a/versions/1.21.5-fabric/src/main/resources/sbo-kotlin.accesswidener
+++ b/versions/1.21.5-fabric/src/main/resources/sbo-kotlin.accesswidener
@@ -1,0 +1,2 @@
+accessWidener v1 named
+

--- a/versions/1.21.7-fabric/src/main/resources/sbo-kotlin.accesswidener
+++ b/versions/1.21.7-fabric/src/main/resources/sbo-kotlin.accesswidener
@@ -1,0 +1,2 @@
+accessWidener v1 named
+


### PR DESCRIPTION
Compiles and launches, overlays render successfully. Setting menus and party commands work. Needs verifying for 3D rendering though, which we can't test without diana easily, so marking as draft till next diana.

Did not remove 1.21.5 and/or 1.21.7 but you can't join SB anymore with them so they likely can be removed in a later PR.

Due to a loom failure, we have to use `enableModProvidedJavadoc = false` when on 1.21.11. This should not affect anything other than javadocs.

Additiionally, we have to use a few accesswidener rules because of some stuff becoming private or package-private in 1.21.11. I have not researched whether public replacements for those are available, but this is should work for now.