### PR TITLE
 Correct fabric mod json deps

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -27,6 +27,29 @@ toolkitMultiversion {
     moveBuildsToRootProject.set(true)
 }
 
+tasks.named<ProcessResources>("processResources") {
+    val fabricLoaderVersion = mcData.dependencies.fabric.fabricLoaderVersion
+    val fabricApiVersion = mcData.dependencies.fabric.fabricApiVersion
+    val fabricLanguageKotlinVersion = mcData.dependencies.fabric.fabricLanguageKotlinVersion
+    val javaVersionMajor = mcData.version.javaVersion.majorVersion
+
+    inputs.property("fabric_loader_version", fabricLoaderVersion)
+    inputs.property("fabric_api_version", fabricApiVersion)
+    inputs.property("fabric_language_kotlin_version", fabricLanguageKotlinVersion)
+    inputs.property("java_version_major", javaVersionMajor)
+
+    filesMatching("fabric.mod.json") {
+        expand(
+            mapOf(
+                "fabric_loader_version" to fabricLoaderVersion,
+                "fabric_api_version" to fabricApiVersion,
+                "fabric_language_kotlin_version" to fabricLanguageKotlinVersion,
+                "java_version_major" to javaVersionMajor
+            ) + inputs.properties
+        )
+    }
+}
+
 dependencies {
     modImplementation("net.fabricmc:fabric-language-kotlin:${mcData.dependencies.fabric.fabricLanguageKotlinVersion}")
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,6 +18,7 @@ mod.name=SBO
 mod.id=sbo-kotlin
 mod.version=0.2.0-beta
 mod.group=net.sbo.mod
+mod.description=SBO is the ultimate diana mod for diana nons! FPS friendly, and packed with QOL features!
 
 # Dependencies
 uc.version=444

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -1,4 +1,5 @@
 {
+    "schemaVersion": 1,
 	"custom": {
 		"modmenu": {
 			"update_checker": true,
@@ -9,11 +10,10 @@
 			}
 		}
 	},
-	"schemaVersion": 1,
 	"id": "${mod_id}",
 	"version": "${mod_version}",
 	"name": "${mod_name}",
-	"description": "SBO is the ultimate diana mod for diana nons! FPS friendly, and packed with QOL features!",
+	"description": "${mod_description}",
 	"authors": [
 		"D4rkSwift/Saotzuri",
 		"RolexDE"
@@ -28,7 +28,7 @@
 	"entrypoints": {
 		"client": [
 			{
-				"value": "net.sbo.mod.SBOKotlin::onInitializeClient"
+				"value": "${mod_group}.SBOKotlin::onInitializeClient"
 			}
 		]
 	},
@@ -36,10 +36,10 @@
 		"mixins.sbo-kotlin.json"
 	],
 	"depends": {
-		"fabricloader": ">=0.16.14",
-		"minecraft": "~${minor_mc_version}",
-		"java": ">=21",
-		"fabric-api": "*",
-		"fabric-language-kotlin": "*"
+		"fabricloader": ">=${fabric_loader_version}",
+		"minecraft": ">=${mc_version}",
+		"java": ">=${java_version_major}",
+		"fabric-api": ">=${fabric_api_version}",
+		"fabric-language-kotlin": ">=${fabric_language_kotlin_version}"
 	}
 }


### PR DESCRIPTION
- Put schemaVersion as the very first entry. https://github.com/FabricMC/fabric-loom/blob/31509ae2d1f4a16a31d3d14b9e18432647d08565/src/main/java/net/fabricmc/loom/util/fmj/FabricModJsonUtils.java#L63-L65
- Move mod description to gradle.properties.
- Use mod_group in place of package name for client entrypoint.
- Use Fabric Loader version from DGT. Currently seems to be 0.18.2, up from previous 0.16.4. Latest version was 0.18.4 for a long while so users should update anyways.
- Use Fabric API version from DGT. Closes #109 by making the loader enforce the Fabric API version requirement. No other way to fix without giving up on World Render Events added in later Fabric API version for 1.21.10. Overall ensures users always have a decently up-to-date Fabric API version, even for older versions, which is good.
- Use Fabric Language Kotlin version from DGT. Previously all versions were accepted. This could cause issues if we ever used something new from kotlin-stdlib.
- Use Java version from DGT. All supported versions default to 21 at the moment but with 26.1 this will be Java 25, so better for futureproofing.
- Use >= for MC Version With 26.1 coming, patch releases won't be a thing from what I know, since it will go to 26.2 from 26.1 and so on, no 26.1.1 so no point in using ~. SemVer is cooked for MC anyways, just use >= to allow the game to launch in new MC versions.