### PR TITLE
Fix Diana detection when diana is minister

### DIFF
--- a/src/main/kotlin/net/sbo/mod/utils/Helper.kt
+++ b/src/main/kotlin/net/sbo/mod/utils/Helper.kt
@@ -429,7 +429,7 @@ object Helper {
     }
 
     fun checkDiana(): Boolean {
-        val diana = (Debug.itsAlwaysDiana || ((Mayor.perks.contains("Mythological Ritual") || Mayor.mayor == "Jerry" || Mayor.mayor == "Aura") && hasSpade && World.getWorld() == "Hub"))
+        val diana = (Debug.itsAlwaysDiana || (((Mayor.perks.contains("Mythological Ritual") || Mayor.ministerPerk == "Mythological Ritual") || Mayor.mayor == "Jerry" || Mayor.mayor == "Aura") && hasSpade && World.getWorld() == "Hub"))
         return diana
     }
 


### PR DESCRIPTION
Checks ministerPerk as well in addition to Mayor.perks.contains, as the latter only has the Mayor's perks and not the Minister's perk.