### PR TITLE
Misc changes

### DIFF
--- a/src/main/kotlin/net/sbo/mod/general/PartyCommands.kt
+++ b/src/main/kotlin/net/sbo/mod/general/PartyCommands.kt
@@ -57,18 +57,28 @@ object PartyCommands {
 
     fun partyCommands() {
         Register.command("sbopartycommands", "sbopcom") {
-            Chat.chat("§6[SBO] §eDiana party commands:")
-            Chat.chat("§7> §a!chim")
-            Chat.chat("§7> §a!chimls")
-            Chat.chat("§7> §a!stick")
-            Chat.chat("§7> §a!relic")
-            Chat.chat("§7> §a!feathers")
-            Chat.chat("§7> §a!profit")
-            Chat.chat("§7> §a!playtime")
-            Chat.chat("§7> §a!mobs")
-            Chat.chat("§7> §a!burrows")
-            Chat.chat("§7> §a!stats <playername>")
-            Chat.chat("§7> §a!since (chim, chimls, relic, stick, inq, king, manti)")
+            help()
+        }
+    }
+
+    val helpCommands = listOf(
+        "!chim",
+        "!chimls",
+        "!stick",
+        "!relic",
+        "!feathers",
+        "!profit",
+        "!playtime",
+        "!mobs",
+        "!burrows",
+        "!stats <playername>",
+        "!since (chim, chimls, relic, stick, inq, king, manti, core, corels, wool, woolls)"
+    )
+
+    fun help() {
+        Chat.chat("§6[SBO] §eDiana party commands:")
+        helpCommands.forEach {
+            Chat.chat("§7> §a$it")
         }
     }
 
@@ -427,7 +437,16 @@ object PartyCommands {
                         }
                     }
                 }
+                "!help" -> {
+                    if (!settings.dianaPartyCommands) return@onChatMessage
+                    sleep(200) {
+                        help() // will work for people with SBO
 
+                        // Also send in party chat in case someone is curious what diana party commands SBO has without having SBO
+                        val commands = helpCommands.joinToString(",")
+                        Chat.command("pc Available diana party commands: $commands")
+                    }
+                }
             }
         }
     }

--- a/src/main/kotlin/net/sbo/mod/guis/Guis.kt
+++ b/src/main/kotlin/net/sbo/mod/guis/Guis.kt
@@ -10,6 +10,10 @@ import net.sbo.mod.utils.events.Register
 import net.sbo.mod.utils.events.impl.partyfinder.PartyFinderOpenEvent
 import net.sbo.mod.utils.game.World
 import net.sbo.mod.utils.http.Http
+import net.minecraft.client.toast.SystemToast
+import net.minecraft.text.Text
+import net.minecraft.text.Style
+import net.minecraft.util.Formatting
 
 object Guis {
     private var partyFinderGui: PartyFinderGUI? = null
@@ -20,19 +24,27 @@ object Guis {
     private var lastUpdate = 0L
     private const val UPDATE_INTERVAL = 300_000L // 5 minutes in ms
 
+    fun openSboPf(calledFromGUI: Boolean = false) {
+        if (!World.isInSkyblock()) {
+            if (!calledFromGUI) {
+                Chat.chat("§6[SBO] §cYou can only use this command in Skyblock.")
+                return
+            }
+            mc.getToastManager().add(SystemToast.create(mc, SystemToast.Type.PERIODIC_NOTIFICATION, Text.literal("SBO").setStyle(Style.EMPTY.withColor(Formatting.GOLD)), Text.literal("Join skyblock before opening Party Finder!").setStyle(Style.EMPTY.withColor(Formatting.RED))))
+            return
+        }
+        mc.send {
+            if (partyFinderGui == null) {
+                partyFinderGui = PartyFinderGUI()
+            }
+            UScreen.displayScreen(partyFinderGui!!)
+            SBOEvent.emit(PartyFinderOpenEvent())
+        }
+    }
+
     fun register() {
         Register.command("sbopf") {
-            if (!World.isInSkyblock()) {
-                Chat.chat("§6[SBO] §cYou can only use this command in Skyblock.")
-                return@command
-            }
-            mc.send {
-                if (partyFinderGui == null) {
-                    partyFinderGui = PartyFinderGUI()
-                }
-                UScreen.displayScreen(partyFinderGui!!)
-                SBOEvent.emit(PartyFinderOpenEvent())
-            }
+            openSboPf()
         }
 
         Register.command("sboachievements") {

--- a/src/main/kotlin/net/sbo/mod/settings/categories/Diana.kt
+++ b/src/main/kotlin/net/sbo/mod/settings/categories/Diana.kt
@@ -87,6 +87,7 @@ object Diana : CategoryKt("Diana") {
     init {
         separator {
             this.title = "Diana Warp"
+            this.description = "You must configure the warp keys from vanilla Minecraft settings, under (ESC) -> Options -> Controls -> Key Binds... scroll till you find SBO - Keybinds and configure it from there."
         }
     }
 

--- a/src/main/kotlin/net/sbo/mod/settings/categories/PartyFinder.kt
+++ b/src/main/kotlin/net/sbo/mod/settings/categories/PartyFinder.kt
@@ -1,6 +1,7 @@
 package net.sbo.mod.settings.categories
 
 import com.teamresourceful.resourcefulconfigkt.api.CategoryKt
+import net.sbo.mod.guis.Guis
 
 object PartyFinder : CategoryKt("PartyFinder") {
     var autoInvite by boolean(true) {
@@ -25,5 +26,16 @@ object PartyFinder : CategoryKt("PartyFinder") {
         this.description = Literal("Change the size of the icons")
         this.range = -20f..20f
         this.slider = true
+    }
+
+    init {
+        button {
+            title = "Open Party Finder"
+            text = "Open Party Finder"
+            description = "Opens the Party Finder, alternatively use /sbopf. NOTE: You need to be in Skyblock for it to open!"
+            onClick {
+                Guis.openSboPf(true)
+            }
+        }
     }
 }

--- a/src/main/kotlin/net/sbo/mod/utils/waypoint/WarpPoint.kt
+++ b/src/main/kotlin/net/sbo/mod/utils/waypoint/WarpPoint.kt
@@ -35,5 +35,5 @@ enum class AdditionalHubWarps {
     STONKS,
     DA,
     TAYLOR,
-    Museum
+    MUSEUM
 }


### PR DESCRIPTION
- Added a !help command in case people might not know about /sbopartycommands Only includes the commands that were in /sbopartycommands, which has the most popularly used diana commands, but might lack newly added commands Refactor needed in future to replace the giant when block with a hashmap and generate list of help commands from that map dynamically A data object containing name, aliases, onExecute lambda, and helpDesc (for <playername> etc argument descriptions) would be good as a future refactor

 For now, this minimal change would be fine to have a functioning !help command.
- Add a note to Diana Warp section telling the keys must be set in vanilla MC controls menu to avoid confusion
- Add a button to open Party Finder in Party Finder settings category in case new users do not know /sbopf command Shows a toast when called from GUI instead of chat message to circumvent no output when clicking the button from main menu via mod menu mod list -> sbo -> settings
- Rename Museum --> MUSEUM to match other enum constants and name style standards