### PR TITLE
Try using ALLOW_GAME instead of GAME to catch all messages

### DIFF
--- a/src/main/kotlin/net/sbo/mod/utils/events/Register.kt
+++ b/src/main/kotlin/net/sbo/mod/utils/events/Register.kt
@@ -77,7 +77,7 @@ object Register {
         noFormatting: Boolean = false,
         action: (message: Text, matchResult: MatchResult) -> Unit
     ) {
-        ClientReceiveMessageEvents.GAME.register { message, _ ->
+        ClientReceiveMessageEvents.ALLOW_GAME.register { message, _ ->
             var text = message.formattedString()
 
             if (noFormatting) text = text.removeFormatting()
@@ -85,6 +85,8 @@ object Register {
             regex.find(text)?.let { result ->
                 action(message, result)
             }
+
+            true
         }
     }
 

--- a/src/main/kotlin/net/sbo/mod/utils/events/SBOEvent.kt
+++ b/src/main/kotlin/net/sbo/mod/utils/events/SBOEvent.kt
@@ -68,8 +68,9 @@ object SBOEvent {
          * Chat Message Event
          * Fired when a chat message is received.
          */
-        ClientReceiveMessageEvents.GAME.register { message, signed ->
+        ClientReceiveMessageEvents.ALLOW_GAME.register { message, signed ->
             emit(ChatMessageEvent(message, signed))
+            true
         }
         /**
          * Chat Message Allow Event


### PR DESCRIPTION
Experimenting with a fix for party commands not working for some people. Will mark as draft

Why this could fix the issue:
 - The GAME event is not called when another mod cancels the message
 - The GAME event is ran with the modified message if another mod modifies the message
 
Per my interpration of the Fabric API code, the event is triggered like this:
1. The ALLOW_GAME event is first ran for all listeners. If any of them cancelled then GAME_CANCELLED is ran instead and the message wont appear (GAME is not ran)
2. If ALLOW_GAME not cancelled, MODIFY_GAME runs, letting all listeners modify the message if applicable, then GAME runs with the modified message.

So, always using ALLOW_GAME even if we are never going to cancel the event should fix the issue in theory if another mod modifies party chat messages or cancels them.