### PR TITLE
Fix party commands not working when localized

### DIFF
--- a/src/main/kotlin/net/sbo/mod/general/PartyCommands.kt
+++ b/src/main/kotlin/net/sbo/mod/general/PartyCommands.kt
@@ -26,7 +26,7 @@ import java.util.Date
 
 object PartyCommands {
 
-    val commandRegex = Regex("^§[0-9a-fk-or]Party §[0-9a-fk-or]> (.*?)§[0-9a-fk-or]*: ?(.*)$")
+    val commandRegex = Regex("^§9[^§]+ §[0-9a-fk-or]> (.*?)§[0-9a-fk-or]*: ?(.*)$")
 
     val settings = PartyCommands
     val carrot = listOf(

--- a/src/main/kotlin/net/sbo/mod/utils/events/Register.kt
+++ b/src/main/kotlin/net/sbo/mod/utils/events/Register.kt
@@ -77,7 +77,7 @@ object Register {
         noFormatting: Boolean = false,
         action: (message: Text, matchResult: MatchResult) -> Unit
     ) {
-        ClientReceiveMessageEvents.GAME.register { message, _ ->
+        ClientReceiveMessageEvents.ALLOW_GAME.register { message, _ ->
             var text = message.formattedString()
 
             if (noFormatting) text = text.removeFormatting()
@@ -85,6 +85,8 @@ object Register {
             regex.find(text)?.let { result ->
                 action(message, result)
             }
+
+            true
         }
     }
 

--- a/src/main/kotlin/net/sbo/mod/utils/events/SBOEvent.kt
+++ b/src/main/kotlin/net/sbo/mod/utils/events/SBOEvent.kt
@@ -68,8 +68,9 @@ object SBOEvent {
          * Chat Message Event
          * Fired when a chat message is received.
          */
-        ClientReceiveMessageEvents.GAME.register { message, signed ->
+        ClientReceiveMessageEvents.ALLOW_GAME.register { message, signed ->
             emit(ChatMessageEvent(message, signed))
+            true
         }
         /**
          * Chat Message Allow Event


### PR DESCRIPTION
Weakens the strict Regex to accept any string instead of "Party", as that can be localized when Hypixel language is not set to English.

To not listen for messages like Guild, I added a mandatory §9 to match only blue text, but it does accept all text after that, for example Party means "Parti" (last character different) in Turkish, and different for each language.

Hypixel seems to have added an auto detect language from IP (not sure if it existed before), so this will only cause issues for more users as time goes on.

<img width="825" height="613" alt="image" src="https://github.com/user-attachments/assets/959ed05e-f208-4a6a-9678-219857576304" />

---

I've also still pulled the changes from my older PR #125 just in case, because another user was reporting it got fixed after removing Zen/KIC mods, so it seems the issue could be both due to a mod conflict and hypixel language.

See Fabric API code in regards to triggering the chat events, the ALLOW_GAME is called first with the original message which can cancel the message (but it still runs the remaining listeners even if cancelled); then MODIFY_GAME is called which can modify the message; and then finally the GAME which we were using gets called with the final updated/modified message from MODIFY_GAME. So by using ALLOW_GAME, we guarantee our listener runs before MODIFY_GAME and GAME with the original message, and for cancelled messages as well, which should fix any mod conflict. If a mod is still conflicting it is likely using a custom Mixin instead of Fabric events and that should be fixed on that mod, not SBO.