### PR TITLE
Fix crash when bad custom sound path

### DIFF
--- a/src/main/kotlin/net/sbo/mod/general/PartyCommands.kt
+++ b/src/main/kotlin/net/sbo/mod/general/PartyCommands.kt
@@ -71,6 +71,7 @@ object PartyCommands {
         "!playtime",
         "!mobs",
         "!burrows",
+        "!mf",
         "!stats <playername>",
         "!since (chim, chimls, relic, stick, inq, king, manti, core, corels, wool, woolls)"
     )

--- a/src/main/kotlin/net/sbo/mod/partyfinder/PartyCheck.kt
+++ b/src/main/kotlin/net/sbo/mod/partyfinder/PartyCheck.kt
@@ -1,6 +1,7 @@
 package net.sbo.mod.partyfinder
 
 import net.sbo.mod.SBOKotlin.API_URL
+import net.sbo.mod.SBOKotlin.logger
 import net.sbo.mod.diana.achievements.AchievementManager.trackWithCheckPlayer
 import net.sbo.mod.utils.chat.Chat
 import net.sbo.mod.utils.Helper
@@ -87,7 +88,9 @@ object PartyCheck {
                 }
             }
             .error { error ->
-                Chat.chat("§6[SBO] §eError checking party members: ${error.message ?: "Unknown error"}")
+                logger.error("Error whilst checking party members", error) // print full error with stacktrace to logs
+
+                Chat.chat("§6[SBO] §eError checking party members: ${error.message ?: "Unknown error"}. More information might be available in your logs!")
             }
     }
 

--- a/src/main/kotlin/net/sbo/mod/settings/categories/Customization.kt
+++ b/src/main/kotlin/net/sbo/mod/settings/categories/Customization.kt
@@ -276,4 +276,51 @@ object Customization : CategoryKt("Customization") {
         this.range = 0.0f..1.0f
         this.slider = true
     }
+
+    fun resetSoundCustomizationToDefaults() {
+        Customization.rareMobSound = arrayOf("exporb")
+        Customization.rareMobVolume = 1.0f
+
+        Customization.inqSound = arrayOf("")
+        Customization.inqVolume = 1.0f
+
+        Customization.sphinxSound = arrayOf("")
+        Customization.sphinxVolume = 1.0f
+
+        Customization.kingSound = arrayOf("")
+        Customization.kingVolume = 1.0f
+
+        Customization.mantiSound = arrayOf("")
+        Customization.mantiVolume = 1.0f
+
+        Customization.cocoonSound = arrayOf("")
+        Customization.cocoonVolume = 1.0f
+
+        Customization.burrowSound = arrayOf("")
+        Customization.burrowVolume = 1.0f
+
+        Customization.chimSound = arrayOf("")
+        Customization.chimVolume = 1.0f
+
+        Customization.bfSound = arrayOf("")
+        Customization.bfVolume = 1.0f
+
+        Customization.coreSound = arrayOf("")
+        Customization.coreVolume = 1.0f
+
+        Customization.stingerSound = arrayOf("")
+        Customization.stingerVolume = 1.0f
+
+        Customization.woolSound = arrayOf("")
+        Customization.woolVolume = 1.0f
+
+        Customization.relicSound = arrayOf("")
+        Customization.relicVolume = 1.0f
+
+        Customization.stickSound = arrayOf("")
+        Customization.stickVolume = 1.0f
+
+        Customization.sprSound = arrayOf("")
+        Customization.sprVolume = 1.0f
+    }
 }

--- a/src/main/kotlin/net/sbo/mod/utils/SoundHandler.kt
+++ b/src/main/kotlin/net/sbo/mod/utils/SoundHandler.kt
@@ -6,9 +6,12 @@ import net.minecraft.client.sound.PositionedSoundInstance
 import net.minecraft.resource.ResourceType
 import net.minecraft.sound.SoundEvent
 import net.minecraft.util.Identifier
+import net.minecraft.util.InvalidIdentifierException
 import net.sbo.mod.SBOKotlin.MOD_ID
 import net.sbo.mod.SBOKotlin.mc
+import net.sbo.mod.SBOKotlin.logger
 import net.sbo.mod.utils.chat.Chat
+import net.sbo.mod.settings.categories.Customization
 import java.io.File
 
 object SoundHandler {
@@ -118,7 +121,18 @@ object SoundHandler {
     fun playCustomSound(sound: String, volume: Float, pitch: Float = 1f) {
         val packManager = mc.resourcePackManager
         val packId = "file/SBO Custom Sounds Data Pack"
-        val id = Identifier.of(MOD_ID, sound.lowercase())
+
+        val id = try {
+            Identifier.of(MOD_ID, sound.lowercase())
+        } catch (invalidIdentifierError: InvalidIdentifierException) {
+            Customization.resetSoundCustomizationToDefaults()
+
+            Chat.chat("§6[SBO] §cYou had an error with your custom sound configuration, your custom sound settings will automatically reset to protect from crashes. More information might be available in your logs.")
+            logger.error("Error with the user supplied custom sound ID", invalidIdentifierError) // print full error with stacktrace to logs
+
+            return
+        }
+
         val event = SoundEvent.of(id)
 
         if (!packManager.enabledIds.contains(packId) && sound.isNotEmpty()) Chat.chat("§6[SBO] §cCustom sound pack is not enabled. Please enable it in the resource packs menu.")


### PR DESCRIPTION
Catch the InvalidIdentifierException to prevent the game from crashing and reset users custom sound settings to prevent error from being spammed since it wont crash anymore.

Tested and works; see the attached image. To test, put a sound with space to "Burrow Found Sound", e.g: "hello world". The "You had an error with your custom sound configuration ..." text will appear, your custom sound settings will reset and the error wont happen again (unless you re-put "hello world" to config again where it will reset again).

<img width="607" height="55" alt="image" src="https://github.com/user-attachments/assets/26aa5819-6706-40ad-a89d-59cd9afb830c" />

Also added logging of the full error to PartyCheck as someone had a rendersystem called from wrong thread error there, but I've looked through code and all Chat methods seem to be called via mc.execute. Must be something else, we need full stacktrace to see what file and line the error comes from.

Also added !mf to list of available diana party commands in help text since i was too lazy to make another branch and pr for that little change