### PR TITLE
Try to improve performance of build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,7 @@
 
 name: build
 permissions:
+  contents: read
   pull-requests: write
 on: [pull_request, push]
 
@@ -32,7 +33,7 @@ jobs:
       - name: build
         run: ./gradlew build --scan
       - name: capture build artifacts
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: Artifacts
           path: build/versions/

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,10 @@
 import java.nio.charset.StandardCharsets
 import dev.deftu.gradle.utils.version.MinecraftVersions
+import org.gradle.jvm.toolchain.JavaLanguageVersion
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
+import org.jetbrains.kotlin.buildtools.api.ExperimentalBuildToolsApi
+import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
 
 plugins {
     java
@@ -26,6 +31,28 @@ loom {
     }
 }
 
+tasks.withType<KotlinJvmCompile>().configureEach {
+    compilerOptions {
+        val args = mutableListOf<String>()
+        args.addAll(freeCompilerArgs.get())
+
+        args.addAll(
+            listOf(
+                "-Xbackend-threads=0", // 0 means use 1 thread per core. Default value is 1 which is single threaded and doesn't scale, often bottlenecks compilation
+                "-jvm-default=no-compatibility", // this not a library mod or API, no need to generate additional DefaultImpls classes (which is bigger jar size and more compile time)
+            )
+        )
+
+        freeCompilerArgs = args
+    }
+}
+
+kotlin {
+    // This improves build performance as it supports incremental compilation among other things with the BTA API
+    @OptIn(ExperimentalBuildToolsApi::class, ExperimentalKotlinGradlePluginApi::class)
+    compilerVersion = "2.2.10"
+}
+
 repositories {
     maven("https://pkgs.dev.azure.com/djtheredstoner/DevAuth/_packaging/public/maven/v1")
     maven("https://repo.essential.gg/repository/maven-public")
@@ -40,9 +67,6 @@ toolkitMultiversion {
 }
 
 tasks.withType<JavaCompile> {
-  options.release.set(21)
-  options.compilerArgs.addAll(listOf("-Xlint:all,-processing", "-g", "-parameters"))
-
   options.encoding = StandardCharsets.UTF_8.toString()
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,5 @@
 import java.nio.charset.StandardCharsets
 import dev.deftu.gradle.utils.version.MinecraftVersions
-import org.gradle.jvm.toolchain.JavaLanguageVersion
-import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
 import org.jetbrains.kotlin.buildtools.api.ExperimentalBuildToolsApi
 import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,9 +1,23 @@
 # Gradle configuration
 
 # JVM flags to improve performance of the build
-# Some references: https://openjdk.org/jeps/8359211 , https://www.evanjones.ca/java-bytebuffer-leak.html , https://www.evanjones.ca/jvm-mmap-pause.html , https://openjdk.org/jeps/450
-org.gradle.jvmargs=-Xms1m -XX:SoftMaxHeapSize=1536m -Xmx2g -XX:MaxDirectMemorySize=2g -Djdk.nio.maxCachedBufferSize=262144 -XX:AllocatePrefetchStyle=3 -XX:+UseStringDeduplication -XX:+UseZGC -XX:+PerfDisableSharedMem -XX:+DisableExplicitGC -Djdk.util.jar.enableMultiRelease=force -Djava.net.preferIPv4Stack=true -Dkotlinx.coroutines.debug=off -Dsun.misc.URLClassPath.disableJarChecking=true -XX:-PrintWarnings -XX:ThreadPriorityPolicy=1 -XX:+UnlockExperimentalVMOptions -XX:+TrustFinalNonStaticFields -XX:+IgnoreUnrecognizedVMOptions -XX:+UseCompactObjectHeaders
-kotlin.daemon.jvmargs=-Xms1m -XX:SoftMaxHeapSize=1536m -Xmx2g -XX:MaxDirectMemorySize=2g -Djdk.nio.maxCachedBufferSize=262144 -XX:AllocatePrefetchStyle=3 -XX:+UseStringDeduplication -XX:+UseZGC -XX:+PerfDisableSharedMem -XX:+DisableExplicitGC -Djdk.util.jar.enableMultiRelease=force -Djava.net.preferIPv4Stack=true -Dkotlinx.coroutines.debug=off -Dsun.misc.URLClassPath.disableJarChecking=true -XX:-PrintWarnings -XX:ThreadPriorityPolicy=1 -XX:+UnlockExperimentalVMOptions -XX:+TrustFinalNonStaticFields -XX:+IgnoreUnrecognizedVMOptions -XX:+UseCompactObjectHeaders
+
+# Some references: https://openjdk.org/jeps/8359211 (lower Xms is faster JVM startup), https://www.evanjones.ca/java-bytebuffer-leak.html (prevents high native off heap memory), https://www.evanjones.ca/jvm-mmap-pause.html (prevents disk I/O for writing perf counters), https://openjdk.org/jeps/450 (compact object headers), https://openjdk.org/jeps/522 (ParallelGC is faster for pure throughput workloads)
+
+# C2 compiler threads often compete with gradle threads heavily for CPU-time
+# Gradle daemon is not a server application; while it does stay alive between builds and benefit from some optimization (C1-tier) it eventually shutdowns, no need to generate C2 compiled code, so we use TieredStopAtLevel=1
+
+# The JVM option -XX:+PrintFlagsFinal can be used to find out default values of each flag before changing it.
+org.gradle.jvmargs=-Xms1m -XX:SoftMaxHeapSize=1536m -Xmx2g -XX:MaxDirectMemorySize=1536m -XX:ReservedCodeCacheSize=384m -Djdk.nio.maxCachedBufferSize=262144 -XX:AllocatePrefetchStyle=3 -XX:+UseStringDeduplication -XX:+UseParallelGC -XX:+PerfDisableSharedMem -XX:+DisableExplicitGC -Djdk.util.jar.enableMultiRelease=force -Djava.net.preferIPv4Stack=true -Dkotlinx.coroutines.debug=off -Dsun.misc.URLClassPath.disableJarChecking=true -XX:-PrintWarnings -XX:ThreadPriorityPolicy=1 -XX:TieredStopAtLevel=1 -XX:+HeapDumpOnOutOfMemoryError -XX:+UnlockExperimentalVMOptions -XX:+TrustFinalNonStaticFields -XX:+IgnoreUnrecognizedVMOptions -XX:+UseCompactObjectHeaders
+
+# Forking a dedicated process for Kotlin causes double JIT warmup and double the memory usage
+# Each JVM also has its own JIT caches and native off-heap memory, causing unnecessary resource usage.
+kotlin.compiler.execution.strategy=in-process
+
+# Incremental compilation speeds up builds heavily.
+kotlin.incremental=true
+ksp.incremental=true
+ksp.incremental.intermodule=true
 
 # Run tasks in parallel when possible
 org.gradle.parallel=true
@@ -18,8 +32,9 @@ org.gradle.configureondemand=true
 loom.ignoreDependencyLoomVersionValidation=true
 loom.multiProjectOptimisation=true
 
-# 1.21.10+ workaround
+# essential loom
 essential.loom.disableUnpick=true
+essential.loom.dropNonIntermediateRootMethods=true
 
 # DGT
 dgt.minecraft.revision=4

--- a/src/main/kotlin/net/sbo/mod/SBOKotlin.kt
+++ b/src/main/kotlin/net/sbo/mod/SBOKotlin.kt
@@ -77,7 +77,7 @@ object SBOKotlin {
 
 		mcVersion = FabricLoader.getInstance().getModContainer("minecraft")
 			.map { it.metadata.version.friendlyString }
-			.orElse("unknown-test-build-time-after-changing-kotlin-source")
+			.orElse("unknown")
 
 
 

--- a/src/main/kotlin/net/sbo/mod/SBOKotlin.kt
+++ b/src/main/kotlin/net/sbo/mod/SBOKotlin.kt
@@ -77,7 +77,7 @@ object SBOKotlin {
 
 		mcVersion = FabricLoader.getInstance().getModContainer("minecraft")
 			.map { it.metadata.version.friendlyString }
-			.orElse("unknown")
+			.orElse("unknown-test-build-time-after-changing-kotlin-source")
 
 
 


### PR DESCRIPTION
Seems to cut down from 6.5-7.5 minute builds down to under 3 minutes in my local machine. Tested with ./gradlew --stop && ./gradlew build --rerun-tasks to run all tasks ignoring build cache and up-to-date tasks and with a fresh started Gradle Daemon, but we will see how it affects GitHub Actions CI.

- Uses -Xbackend-threads=0 to start 1 kotlin compiler thread per CPU core; gread speedups for compileKotlin task. The default is 1 which sucks since it does not scale and is single threaded even if you got lot of CPU cores.
- Also use -jvm-default=no-compatibility to skip generating additional DefaultImpls classes and additional methods, we don't need those since this not a library or API mod.
- Uses (Experimental) BTA (Build Tools API) which seems to affect build speed positively; this was stabilized in Kotlin 2.3.20 anyways, were only 1-2 versions behind (2.2.10) so this stable enough most probably.
- Remove unneeded (for now) .release.set(21) since the build runs with Java 21 at the moment anyways, but this will be re-added when compiling 1.21.11 and 26.1 at same time to set bytecode target to 25 for 26.1 and 21 for 1.21.11.
- Removed Xlint g and parameters javac options because the only java code in the project is Mixins so they werent doing much anyways
- Added in-process kotlin compilation to avoid kotlin daemon being a seperate java process from the gradle daemon process, causing double the memory usage and JIT compilation overhead
- Now using ParallelGC instead of ZGC because as per jep 522 near the end JDK developers note that ParallelGC is still faster than all other GCs for pure throughput workloads. Gradle daemon is something that only the total build time matters, latency is not a metric we need to optimize here.
- Turned on incremental kotlin compilation and ksp processing

Due to the build.gradle.kts and gradle.properties being changed the CI build might be slower than other PRs that only change kotlin source code, but will see.