### PR TITLE
Fix not being able to change view when localized

### DIFF
--- a/src/main/kotlin/net/sbo/mod/diana/DianaMobDetect.kt
+++ b/src/main/kotlin/net/sbo/mod/diana/DianaMobDetect.kt
@@ -50,8 +50,8 @@ object DianaMobDetect {
     private val defeated = mutableSetOf<Int>()
     private val warned = mutableSetOf<Int>()
 
-    private val mobHpOverlay: Overlay = Overlay("mythosMobHp", 10f, 10f, 1f, listOf("Chat screen"), OverlayExamples.mythosMobHpExample).setCondition { Diana.mythosMobHp }
-    private val noShurikenOverlay: Overlay = Overlay("noShuriken", 10f, 10f, 3f, listOf("Chat screen"), OverlayExamples.dianaStarlessMobExample).setCondition { Diana.noShurikenOverlay }
+    private val mobHpOverlay: Overlay = Overlay(name = "mythosMobHp", x = 10f, y = 10f, scale = 1f, exampleView = OverlayExamples.mythosMobHpExample).setCondition { Diana.mythosMobHp }
+    private val noShurikenOverlay: Overlay = Overlay(name = "noShuriken", x = 10f, y = 10f, scale = 3f, exampleView = OverlayExamples.dianaStarlessMobExample).setCondition { Diana.noShurikenOverlay }
 
     internal enum class RareDianaMob(val display: String) {
         INQ("Minos Inquisitor"),

--- a/src/main/kotlin/net/sbo/mod/general/Pickuplog.kt
+++ b/src/main/kotlin/net/sbo/mod/general/Pickuplog.kt
@@ -11,6 +11,8 @@ import net.sbo.mod.utils.data.Item
 import net.sbo.mod.utils.events.annotations.SboEvent
 import net.sbo.mod.utils.events.impl.game.InventorySlotUpdateEvent
 import net.sbo.mod.utils.overlay.Overlay
+import net.sbo.mod.utils.overlay.CHAT_SCREEN_FILTER
+import net.sbo.mod.utils.overlay.CRAFTING_PLAYER_INVENTORY_FILTER
 import net.sbo.mod.utils.overlay.OverlayExamples
 import net.sbo.mod.utils.overlay.OverlayTextLine
 import java.util.regex.Pattern
@@ -26,7 +28,7 @@ object Pickuplog {
 
     private val regex = Regex("""\+([\d,]+) ([^(]+)""")
 
-    private val overlay: Overlay = Overlay("pickuplog", 5f, 5f, 1f, listOf("Chat screen", "Crafting"), OverlayExamples.pickupLogExample)
+    private val overlay: Overlay = Overlay("pickuplog", 5f, 5f, 1f, listOf(CHAT_SCREEN_FILTER, CRAFTING_PLAYER_INVENTORY_FILTER), OverlayExamples.pickupLogExample)
 
     private val itemsShowAdded: MutableList<MutableMap<String, OverlayLineData>> = mutableListOf()
     private val itemsShowRemoved: MutableList<MutableMap<String, OverlayLineData>> = mutableListOf()

--- a/src/main/kotlin/net/sbo/mod/overlays/DianaLoot.kt
+++ b/src/main/kotlin/net/sbo/mod/overlays/DianaLoot.kt
@@ -2,6 +2,9 @@ package net.sbo.mod.overlays
 
 import net.sbo.mod.settings.categories.Diana
 import net.sbo.mod.utils.overlay.Overlay
+import net.sbo.mod.utils.overlay.isCraftingScreenOpen
+import net.sbo.mod.utils.overlay.CHAT_SCREEN_FILTER
+import net.sbo.mod.utils.overlay.CRAFTING_PLAYER_INVENTORY_FILTER
 import net.sbo.mod.utils.overlay.OverlayTextLine
 import net.minecraft.util.Formatting.*
 import net.sbo.mod.SBOKotlin.mc
@@ -22,7 +25,7 @@ import java.util.concurrent.TimeUnit
 object DianaLoot {
     private var isSellTypeHovered = false
     val timerLine: OverlayTextLine = OverlayTextLine("")
-    val overlay = Overlay("Diana Loot", 10f, 10f, 1f, listOf("Chat screen", "Crafting"))
+    val overlay = Overlay("Diana Loot", 10f, 10f, 1f, listOf(CHAT_SCREEN_FILTER, CRAFTING_PLAYER_INVENTORY_FILTER))
         .setCondition { Diana.lootTracker != Diana.Tracker.OFF && (Helper.checkDiana() || Helper.hasSpade) }
 
     val changeView: OverlayTextLine = OverlayUtils.createClickableTextLine(
@@ -102,23 +105,19 @@ object DianaLoot {
         Register.onTick(1) { updateTimerText() }
     }
 
-    private const val CRAFTING_GUI_TITLE = "Crafting"
-
     @SboEvent
     fun onGuiClose(event: GuiCloseEvent) {
-        if (event.screen.title.string == CRAFTING_GUI_TITLE) {
+        if (CRAFTING_PLAYER_INVENTORY_FILTER(event.screen)) {
             overlay.removeLines(listOf(changeView, delimiter, changeSellType, resetSession))
         }
     }
 
     @SboEvent
     fun onGuiOpen(event: GuiOpenEvent) {
-        if (event.screen.title.string == CRAFTING_GUI_TITLE) {
+        if (CRAFTING_PLAYER_INVENTORY_FILTER(event.screen)) {
             updateLines(isCraftingOpen = true)
         }
     }
-
-    private fun isCraftingScreenOpen(): Boolean = mc.currentScreen?.title?.string == CRAFTING_GUI_TITLE
 
     fun hideLine(name: String) {
         if (!isCraftingScreenOpen()) return
@@ -140,7 +139,7 @@ object DianaLoot {
         val line = OverlayTextLine(formattedText).onClick { hideLine(itemName) }
             .setCondition {
                 val meetsZeroValueCondition = amount > 0 || !Diana.hideUnobtainedItems
-                val meetsManualHideCondition = !(mc.currentScreen?.title?.string != CRAFTING_GUI_TITLE && SBOConfigBundle.sboData.hideTrackerLines.contains(itemName))
+                val meetsManualHideCondition = !(!isCraftingScreenOpen() && SBOConfigBundle.sboData.hideTrackerLines.contains(itemName))
                 meetsZeroValueCondition && meetsManualHideCondition
             }
         if (SBOConfigBundle.sboData.hideTrackerLines.contains(itemName)) {
@@ -172,7 +171,7 @@ object DianaLoot {
         val line = OverlayTextLine(combinedText).onClick { hideLine(itemNameBase) }
             .setCondition {
                 val meetsZeroValueCondition = totalAmount > 0 || !Diana.hideUnobtainedItems
-                val meetsManualHideCondition = !(mc.currentScreen?.title?.string != CRAFTING_GUI_TITLE && SBOConfigBundle.sboData.hideTrackerLines.contains(itemNameBase))
+                val meetsManualHideCondition = !(!isCraftingScreenOpen() && SBOConfigBundle.sboData.hideTrackerLines.contains(itemNameBase))
                 meetsZeroValueCondition && meetsManualHideCondition
             }
             .onHover { drawContext, textRenderer ->

--- a/src/main/kotlin/net/sbo/mod/overlays/DianaMobs.kt
+++ b/src/main/kotlin/net/sbo/mod/overlays/DianaMobs.kt
@@ -6,6 +6,9 @@ package net.sbo.mod.overlays
 */
 import net.sbo.mod.settings.categories.Diana
 import net.sbo.mod.utils.overlay.Overlay
+import net.sbo.mod.utils.overlay.isCraftingScreenOpen
+import net.sbo.mod.utils.overlay.CHAT_SCREEN_FILTER
+import net.sbo.mod.utils.overlay.CRAFTING_PLAYER_INVENTORY_FILTER
 import net.sbo.mod.utils.overlay.OverlayTextLine
 import net.minecraft.util.Formatting.*
 import net.sbo.mod.SBOKotlin.mc
@@ -21,7 +24,7 @@ import java.math.RoundingMode
 import java.util.concurrent.TimeUnit
 
 object DianaMobs {
-    val overlay = Overlay("Diana Mobs", 10f, 10f, 1f, listOf("Chat screen", "Crafting")).setCondition { Diana.mobTracker != Diana.Tracker.OFF && (Helper.checkDiana() || Helper.hasSpade) }
+    val overlay = Overlay("Diana Mobs", 10f, 10f, 1f, listOf(CHAT_SCREEN_FILTER, CRAFTING_PLAYER_INVENTORY_FILTER)).setCondition { Diana.mobTracker != Diana.Tracker.OFF && (Helper.checkDiana() || Helper.hasSpade) }
     val changeView: OverlayTextLine = OverlayTextLine("${YELLOW}Change View")
         .onClick {
             Diana.mobTracker = Diana.mobTracker.next()
@@ -41,21 +44,21 @@ object DianaMobs {
 
     @SboEvent
     fun onGuiClose(event: GuiCloseEvent) {
-        if (event.screen.title.string == "Crafting") {
+        if (CRAFTING_PLAYER_INVENTORY_FILTER(event.screen)) {
             overlay.removeLine(changeView)
         }
     }
 
     @SboEvent
     fun onGuiOpen(event: GuiOpenEvent) {
-        if (event.screen.title.string == "Crafting") {
-            updateLines("CraftingOpen")
+        if (CRAFTING_PLAYER_INVENTORY_FILTER(event.screen)) {
+            updateLines(true)
         }
     }
 
     fun createLine(name: String, formattedText: String, amount: Int) : OverlayTextLine {
         val line = OverlayTextLine(formattedText).onClick {
-            if (mc.currentScreen?.title?.string != "Crafting") return@onClick
+            if (!isCraftingScreenOpen()) return@onClick
             if (SBOConfigBundle.sboData.hideTrackerLines.contains(name)) {
                 SBOConfigBundle.sboData.hideTrackerLines.remove(name)
             } else {
@@ -65,7 +68,7 @@ object DianaMobs {
         }
             .setCondition {
                 val meetsZeroValueCondition = amount > 0 || !Diana.hideUnobtainedItems
-                val meetsManualHideCondition = !(mc.currentScreen?.title?.string != "Crafting" && SBOConfigBundle.sboData.hideTrackerLines.contains(name))
+                val meetsManualHideCondition = !(!isCraftingScreenOpen() && SBOConfigBundle.sboData.hideTrackerLines.contains(name))
                 meetsZeroValueCondition && meetsManualHideCondition
             }
         if (SBOConfigBundle.sboData.hideTrackerLines.contains(name)) {
@@ -74,7 +77,7 @@ object DianaMobs {
         return line
     }
 
-    fun updateLines(screen: String = "") {
+    fun updateLines(isCraftingOpen: Boolean = false) {
         val lines = mutableListOf<OverlayTextLine>()
         val type = Diana.mobTracker
         val tracker = when (type) {
@@ -103,7 +106,7 @@ object DianaMobs {
             BigDecimal(tracker.mobs.TOTAL_MOBS.toDouble() / playTimeHrs).setScale(2, RoundingMode.HALF_UP).toDouble()
         } else 0.0
 
-        if (screen == "CraftingOpen" || mc.currentScreen?.title?.string == "Crafting") {
+        if (isCraftingOpen || isCraftingScreenOpen()) {
             lines.add(changeView)
         }
 

--- a/src/main/kotlin/net/sbo/mod/overlays/DianaStats.kt
+++ b/src/main/kotlin/net/sbo/mod/overlays/DianaStats.kt
@@ -8,7 +8,7 @@ import net.sbo.mod.utils.Helper
 import net.sbo.mod.utils.data.SboDataObject.sboData
 
 object DianaStats {
-    val overlay = Overlay("Diana Stats", 10f, 10f, 1f, listOf("Chat screen")).setCondition { Diana.statsTracker && (Helper.checkDiana() || Helper.hasSpade)}
+    val overlay = Overlay("Diana Stats", 10f, 10f, 1f).setCondition { Diana.statsTracker && (Helper.checkDiana() || Helper.hasSpade)}
 
     fun init() {
         overlay.init()

--- a/src/main/kotlin/net/sbo/mod/utils/overlay/Overlay.kt
+++ b/src/main/kotlin/net/sbo/mod/utils/overlay/Overlay.kt
@@ -1,12 +1,34 @@
 package net.sbo.mod.utils.overlay
 
+import net.minecraft.screen.PlayerScreenHandler
 import net.minecraft.client.gui.DrawContext
+import net.minecraft.client.gui.screen.Screen
+import net.minecraft.client.gui.screen.ChatScreen
+import net.minecraft.client.gui.screen.ingame.InventoryScreen
 import net.sbo.mod.SBOKotlin.mc
 import net.sbo.mod.utils.Helper
 import net.sbo.mod.utils.game.World
 import net.sbo.mod.utils.data.OverlayValues
 import net.sbo.mod.utils.data.SboDataObject.overlayData
 import java.awt.Color
+
+fun isCraftingScreenOpen(): Boolean {
+    return CRAFTING_PLAYER_INVENTORY_FILTER(mc.currentScreen)
+}
+
+val CHAT_SCREEN_FILTER = fun(screen: Screen?): Boolean {
+    return screen is ChatScreen
+}
+
+val CRAFTING_PLAYER_INVENTORY_FILTER = fun(screen: Screen?): Boolean {
+    if (screen !is InventoryScreen) return false
+
+    val handler = screen.screenHandler
+
+    if (handler !is PlayerScreenHandler) return false // PlayerScreenHandler extends AbstractCraftingScreenHandler, but checking AbstractCraftingScreenHandler will also match the full 3x3 crafting inventory.
+
+    return true // could also check for handler.slots.size == 46 but checking for PlayerScreenHandler seems to work already. 46 is because 27 inventory slots, 9 hotbar slots, 4 armor slots, 4 crafting input slots, 1 crafting output slot and 1 offhand/shield slot, totalling 46. when a chest/large chest (which hypixel uses for menus) is open, only the 27 inventory slots + the chest size is considered; so .size in these cases are 63 (regular chest) or 90 (double chest), because 27 inventory + 9 hotbar + 27 chest, and 27 inventory + 9 hotbar + 54 double chest (which is 27*2).
+}
 
 /**
  * Represents an overlay that can display text lines on the screen.
@@ -16,14 +38,14 @@ import java.awt.Color
  * @property x The x-coordinate of the overlay.
  * @property y The y-coordinate of the overlay.
  * @property scale The scale of the overlay, default is 1.0f.
- * @property allowedGuis The list of GUI names where the overlay is allowed to render.
+ * @property allowedScreens The list of screens where the overlay is allowed to render.
  */
 class Overlay(
     var name: String,
     var x: Float,
     var y: Float,
     var scale: Float = 1.0f,
-    var allowedGuis: List<String> = listOf("Chat screen"),
+    val allowedScreens: List<(screen: Screen?) -> Boolean> = listOf(CHAT_SCREEN_FILTER),
     var exampleView: List<OverlayTextLine> = listOf()
 ) {
     private var lines = mutableListOf<OverlayTextLine>()
@@ -89,7 +111,7 @@ class Overlay(
 
     fun overlayClicked(mouseX: Double, mouseY: Double) {
         if (!World.isInSkyblock()) return
-        if (Helper.getGuiName() !in allowedGuis) return
+        if (!allowedScreens.any { it(mc.currentScreen) }) return
         val textRenderer = mc.textRenderer ?: return
         if (!isOverOverlay(mouseX, mouseY)) return
 
@@ -173,9 +195,11 @@ class Overlay(
             drawContext.fill(currentX.toInt(), currentY.toInt(), (currentX + totalWidth).toInt(), (currentY + totalHeight).toInt(), Color(0, 0, 0, 100).rgb)
         }
 
+        val shouldRender by lazy(LazyThreadSafetyMode.NONE) { allowedScreens.any { it(mc.currentScreen) } }
+
         for (line in getLines()) {
             if (!line.checkCondition()) continue
-            if (Helper.getGuiName() in allowedGuis) line.updateMouseInteraction(mouseX, mouseY, currentX * scale, currentY * scale, textRenderer, scale, drawContext)
+            if (shouldRender) line.updateMouseInteraction(mouseX, mouseY, currentX * scale, currentY * scale, textRenderer, scale, drawContext)
             line.draw(drawContext, currentX.toInt(), currentY.toInt(), textRenderer)
             if (line.linebreak) {
                 currentY += textRenderer.fontHeight + 1

--- a/src/main/kotlin/net/sbo/mod/utils/overlay/OverlayManager.kt
+++ b/src/main/kotlin/net/sbo/mod/utils/overlay/OverlayManager.kt
@@ -47,16 +47,16 @@ object OverlayManager {
 
     @SboEvent
     fun onRender(event: RenderEvent) {
-        render(event.context,  mc.currentScreen?.title?.string ?: "")
+        render(event.context, mc.currentScreen)
     }
 
-    fun render(drawContext: DrawContext, renderScreen: String = "") {
+    fun render(drawContext: DrawContext, renderScreen: Screen? = null) {
         if (!World.isInSkyblock()) return
         val scaleFactor = mc.window.scaleFactor
         val mouseX = mc.mouse.x / scaleFactor
         val mouseY = mc.mouse.y / scaleFactor
         for (overlay in overlays.toList()) {
-            if (renderScreen == "" && !mc.options.playerListKey.isPressed && !mc.options.hudHidden)
+            if (renderScreen == null && !mc.options.playerListKey.isPressed && !mc.options.hudHidden)
                 overlay.render(drawContext, mouseX, mouseY)
         }
     }
@@ -67,7 +67,7 @@ object OverlayManager {
         val mouseX = mc.mouse.x / scaleFactor
         val mouseY = mc.mouse.y / scaleFactor
         for (overlay in overlays.toList()) {
-            if (renderScreen.title.string in overlay.allowedGuis && !mc.options.hudHidden)
+            if (overlay.allowedScreens.any { it(renderScreen) } && !mc.options.hudHidden)
                 overlay.render(drawContext, mouseX, mouseY)
         }
     }


### PR DESCRIPTION
When having the Minecraft language set to anything but English, the Change View | Sell offer text above the Diana Loot and Change View in Diana Mobs won't show.

This PR fixes it, by making it not depend on the hardcoded "Crafting" gui title.

It also corrects this for the "Chat screen" gui title, so the HUDs will now also render when language != English and chat is open.

We check if the currentScreen is ChatScreen or the InventoryScreen (and it's handler is PlayerScreenHandler). This seems to match the existing behaviour but works on languages other than English as well per my testing.

To not duplicate code, I also changed it from a List\<String\> allowedGuis into a filter-based allowedScreens.

The built-in CHAT_SCREEN_FILTER and CRAFTING_PLAYER_INVENTORY_FILTER is now defined in a central place in Overlay.kt and other files simply reference it instead of hardcoding the filter inline.

The mc.currentScreen?.title?.string ?: "" and renderScreen == "" comparision was simplified for better understanding as well into passing just the screen and checking if that is null.

I've also did general cleanup to remove the confusing "CraftingOpen" magic string and replaced it with a boolean.