### PR TITLE
Enhance mod metadata

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -79,10 +79,34 @@ tasks.named<ProcessResources>("processResources") {
     val fabricLanguageKotlinVersion = mcData.dependencies.fabric.fabricLanguageKotlinVersion
     val javaVersionMajor = mcData.version.javaVersion.majorVersion
 
+    val elementaVersion = project.property("elementa.version")
+    val hmApiVersion = when (mcData.version) {
+        MinecraftVersions.VERSION_1_21_11 -> project.property("hmapi.version.1.21.11")
+        MinecraftVersions.VERSION_1_21_10 -> project.property("hmapi.version.1.21.10")
+        else -> throw AssertionError("build.gradle.kts needs updating for ${mcData.version}")
+    }
+    val resourcefulConfigVersion = when (mcData.version) {
+        MinecraftVersions.VERSION_1_21_11 -> project.property("rconfig.version.1.21.11")
+        MinecraftVersions.VERSION_1_21_10 -> project.property("rconfig.version.1.21.10")
+        else -> throw AssertionError("build.gradle.kts needs updating for ${mcData.version}")
+    }
+    val resourcefulConfigKtVersion = when (mcData.version) {
+        MinecraftVersions.VERSION_1_21_11 -> project.property("rconfigkt.version.1.21.11")
+        MinecraftVersions.VERSION_1_21_10 -> project.property("rconfigkt.version.1.21.10")
+        else -> throw AssertionError("build.gradle.kts needs updating for ${mcData.version}")
+    }
+    val universalCraftVersion = project.property("uc.version")
+
     inputs.property("fabric_loader_version", fabricLoaderVersion)
     inputs.property("fabric_api_version", fabricApiVersion)
     inputs.property("fabric_language_kotlin_version", fabricLanguageKotlinVersion)
     inputs.property("java_version_major", javaVersionMajor)
+
+    inputs.property("elementa_version", elementaVersion)
+    inputs.property("hm_api_version", hmApiVersion)
+    inputs.property("resourcefulconfig_version", resourcefulConfigVersion)
+    inputs.property("resourcefulconfigkt_version", resourcefulConfigKtVersion)
+    inputs.property("universalcraft_version", universalCraftVersion)
 
     filesMatching("fabric.mod.json") {
         expand(
@@ -90,7 +114,13 @@ tasks.named<ProcessResources>("processResources") {
                 "fabric_loader_version" to fabricLoaderVersion,
                 "fabric_api_version" to fabricApiVersion,
                 "fabric_language_kotlin_version" to fabricLanguageKotlinVersion,
-                "java_version_major" to javaVersionMajor
+                "java_version_major" to javaVersionMajor,
+
+                "elementa_version" to elementaVersion,
+                "hm_api_version" to hmApiVersion,
+                "resourcefulconfig_version" to resourcefulConfigVersion,
+                "resourcefulconfigkt_version" to resourcefulConfigKtVersion,
+                "universalcraft_version" to universalCraftVersion
             ) + inputs.properties
         )
     }
@@ -123,7 +153,7 @@ dependencies {
             modImplementation(include("gg.essential:universalcraft-1.21.9-fabric:${property("uc.version")}")!!)
             compileOnly("maven.modrinth:iris:${property("iris.version.1.21.10")}+1.21.10-fabric")
         }
-        else -> {}
+        else -> throw AssertionError("build.gradle.kts needs updating for ${mcData.version}")
     }
 
     implementation(project(":event-processor"))
@@ -133,6 +163,6 @@ dependencies {
 tasks.findByName("preprocessCode")?.apply {
     when (mcData.version) {
         MinecraftVersions.VERSION_1_21_11 -> dependsOn(":1.21.10-fabric:kspKotlin")
-        else -> {}
+        else -> throw AssertionError("build.gradle.kts needs updating for ${mcData.version}")
     }
 }

--- a/src/main/kotlin/net/sbo/mod/SBOKotlin.kt
+++ b/src/main/kotlin/net/sbo/mod/SBOKotlin.kt
@@ -51,7 +51,9 @@ import net.sbo.mod.utils.game.InventoryUtils
 import net.sbo.mod.utils.game.TabList
 import net.sbo.mod.utils.version.UpdateChecker
 
-object SBOKotlin {
+import net.fabricmc.api.ClientModInitializer
+
+object SBOKotlin : ClientModInitializer {
 	@JvmField
 	val mc: MinecraftClient = MinecraftClient.getInstance()
 
@@ -69,8 +71,7 @@ object SBOKotlin {
 
 	fun id(path: String): Identifier = Identifier.of(MOD_ID, path)
 
-	@JvmStatic
-	fun onInitializeClient() {
+	override fun onInitializeClient() {
 		version = FabricLoader.getInstance().getModContainer(MOD_ID)
 			.map { it.metadata.version.friendlyString }
 			.orElse("unknown")

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -20,27 +20,37 @@
 	],
 	"contact": {
 		"homepage": "https://skyblockoverhaul.com/",
-		"sources": "https://github.com/SkyblockOverhaul/SBO-Kotlin"
+		"sources": "https://github.com/SkyblockOverhaul/SBO-Kotlin",
+		"issues": "https://github.com/SkyblockOverhaul/SBO-Kotlin/issues"
 	},
 	"license": "Apache License 2.0",
 	"icon": "assets/sbo-kotlin/icon.png",
 	"environment": "client",
-	"entrypoints": {
-		"client": [
-			{
-				"value": "${mod_group}.SBOKotlin::onInitializeClient"
-			}
-		]
-	},
-	"mixins": [
-		"mixins.sbo-kotlin.json"
-	],
+    "entrypoints": {
+      "client": [
+        {
+          "adapter": "kotlin",
+          "value": "${mod_group}.SBOKotlin"
+        }
+      ]
+    },
+    "mixins": [
+      {
+        "config": "sbo-kotlin.mixins.json",
+        "environment": "client"
+      }
+    ],
 	"accessWidener": "sbo-kotlin.accesswidener",
 	"depends": {
 		"fabricloader": ">=${fabric_loader_version}",
 		"minecraft": ">=${mc_version}",
 		"java": ">=${java_version_major}",
 		"fabric-api": ">=${fabric_api_version}",
-		"fabric-language-kotlin": ">=${fabric_language_kotlin_version}"
+		"fabric-language-kotlin": ">=${fabric_language_kotlin_version}",
+		"elementa": ">=${elementa_version}",
+		"hm-api": ">=${hm_api_version}",
+		"resourcefulconfig": ">=${resourcefulconfig_version}",
+		"resourcefulconfigkt": ">=${resourcefulconfigkt_version}",
+		"universalcraft": ">=${universalcraft_version}"
 	}
 }

--- a/src/main/resources/sbo-kotlin.mixins.json
+++ b/src/main/resources/sbo-kotlin.mixins.json
@@ -1,5 +1,9 @@
 {
   "required": true,
+  "minVersion": "0.8.7",
+  "mixinextras": {
+    "minVersion": "0.5.0"
+  },
   "package": "net.sbo.mod.mixin",
   "compatibilityLevel": "JAVA_21",
   "client": [
@@ -14,5 +18,8 @@
   ],
   "injectors": {
     "defaultRequire": 1
+  },
+  "overwrites": {
+    "requireAnnotations": true
   }
 }


### PR DESCRIPTION
Depends on #131 (for both build failure to be fixed and to use the versioned hm-api from gradle.properties)

- Throw AssertionError to fail the build if mcData.version has an unexpected value
- Expose new properties elementa_version, hm_api_version, resourcefulconfig_version, resourcefulconfigkt_version, universalcraft_version to be used
- Make SBOKotlin properly extend ClientModInitializer and override onInitializeClient function rather than relying on `@JvmStatic`
- Add issues section to contact in fabric.mod.json.
- Specify Kotlin as the language adapter for client entrypoint in fabric.mod.json
- Restrict mixins to client environment.
- Rename mixin file to sbo-kotlin.mixins.json from mixins.sbo-kotlin.json.
- Use the exposed new properties in fabric.mod.json to depend on the full set of dependencies and their exact versions for that MC version we use and depend on. While we bundle these with Jar-In-Jar in the META-INF/jars folder, this still makes Fabric look for and load those explicitly before us (even if another mod bundles a different version - our version constraints will be respected) and guarantee that they are loaded, and otherwise complain at start-up.