### PR TITLE
fix: refresh mayor data every 1 minute instead of 1 second

### DIFF
--- a/src/main/kotlin/net/sbo/mod/utils/game/Mayor.kt
+++ b/src/main/kotlin/net/sbo/mod/utils/game/Mayor.kt
@@ -29,7 +29,7 @@ object Mayor {
 
     fun init() {
         refreshMayorData()
-        Register.onTick(20) {
+        Register.onTick(20 * 60) {
             refreshMayorData()
         }
     }


### PR DESCRIPTION
Prevents the mod from spam retrying failed election API calls every second, causing to a perpetual 403 loop, also breaking other mods' functionality in the process.

Logs: https://mclo.gs/14kWN31