### PR TITLE
Replace mention of ct reload

### DIFF
--- a/src/main/kotlin/net/sbo/mod/guis/partyfinder/pages/Help.kt
+++ b/src/main/kotlin/net/sbo/mod/guis/partyfinder/pages/Help.kt
@@ -38,7 +38,7 @@ class Help(private val parent: PartyFinderGUI) {
                             "   ・ Enable private Messages!\n\n" +
                             "   ・ /settings -> Social Settings.\n\n" +
                             "・ Requirements don't update?\n\n" +
-                            "   ・ Wait 10mins and do /ct reload.\n\n" +
+                            "   ・ Wait 10mins and make sure you have all API enabled in SkyBlock settings.\n\n" +
                             "・ Text or Icons too small or too big?\n\n" +
                             "   ・ Open party finder settings\n\n" +
                             "・ Not seeing your party in the list?\n\n" +


### PR DESCRIPTION
Won't do anything for a kotlin mod

Replaced it with a suggestion to enable all API in SkyBlock settings instead.