### PR TITLE
Misc improvements

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,6 +3,7 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
 import org.jetbrains.kotlin.buildtools.api.ExperimentalBuildToolsApi
 import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
 import net.fabricmc.loom.task.RemapJarTask
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
     java
@@ -10,7 +11,6 @@ plugins {
     kotlin("plugin.serialization") version "2.3.21"
     id("gg.essential.loom") version "1.15.50"
     id("dev.deftu.gradle.multiversion")
-    id("dev.deftu.gradle.tools")
     id("dev.deftu.gradle.tools.bloom")
     id("com.google.devtools.ksp") version "2.3.7"
 }
@@ -114,6 +114,8 @@ repositories {
     maven("https://api.modrinth.com/maven")
 }
 
+val jarName = project.property("mod.name").toString() + "-" + project.property("mod.version").toString() + "+" + project.name
+
 afterEvaluate {
     val newBuildDestinationDirectory by lazy {
         rootProject.layout.buildDirectory.asFile.get().resolve("versions")
@@ -122,11 +124,13 @@ afterEvaluate {
     tasks {
         jar {
             destinationDirectory.set(newBuildDestinationDirectory)
+            archiveBaseName.set(jarName)
         }
 
         if ("26.1-fabric" != project.name) {
             named<RemapJarTask>("remapJar") {
                 destinationDirectory.set(newBuildDestinationDirectory)
+                archiveBaseName.set(jarName)
             }
         }
     }
@@ -135,6 +139,10 @@ afterEvaluate {
 tasks.withType<JavaCompile> {
   options.release = Integer.parseInt(versionedProperty("java.version"))
   options.encoding = StandardCharsets.UTF_8.toString()
+}
+
+tasks.withType<KotlinJvmCompile> {
+    compilerOptions.jvmTarget.set(JvmTarget.fromTarget(versionedProperty("java.version")))
 }
 
 tasks.withType<AbstractArchiveTask> {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -6,19 +6,11 @@ pluginManagement {
         maven("https://maven.deftu.dev/releases")
         maven("https://maven.deftu.dev/snapshots")
 
-        maven("https://jitpack.io/")
         maven("https://maven.fabricmc.net")
         maven("https://maven.architectury.dev/")
         maven("https://maven.minecraftforge.net")
 
-        maven("https://maven.terraformersmc.com/")
         maven("https://repo.essential.gg/repository/maven-public")
-        maven("https://server.bbkr.space/artifactory/libs-release/")
-    }
-
-    plugins {
-        kotlin("jvm") version("2.3.21")
-        id("dev.deftu.gradle.multiversion-root") version("2.73.0")
     }
 }
 

--- a/src/main/java/net/sbo/mod/mixin/PauseScreenMixin.java
+++ b/src/main/java/net/sbo/mod/mixin/PauseScreenMixin.java
@@ -25,10 +25,10 @@ public abstract class PauseScreenMixin extends Screen {
         PauseScreen self = (PauseScreen)(Object)this;
 
         Button button = Button.builder(Component.literal("SBO"), b -> SBOKotlin.mc.schedule(() -> {
-            if (Guis.INSTANCE.getAchievementsGui$SBO() == null) {
-                Guis.INSTANCE.setAchievementsGui$SBO(new AchievementsGUI());
+            if (Guis.INSTANCE.getAchievementsGui() == null) {
+                Guis.INSTANCE.setAchievementsGui(new AchievementsGUI());
             }
-            UScreen.displayScreen(Guis.INSTANCE.getAchievementsGui$SBO());
+            UScreen.displayScreen(Guis.INSTANCE.getAchievementsGui());
         })).bounds(self.width / 2 + 104, self.height / 4 + 32, 30, 20).build();
 
         this.addRenderableWidget(button);

--- a/src/main/kotlin/net/sbo/mod/diana/DianaMobDetect.kt
+++ b/src/main/kotlin/net/sbo/mod/diana/DianaMobDetect.kt
@@ -100,7 +100,7 @@ object DianaMobDetect {
                     continue
                 }
 
-                checkCocoon(entity)
+                checkCocoon(entity, now)
 
                 val name = entity.customName?.formattedString() ?: entity.name.formattedString()
                 if (name.contains("§2✿", ignoreCase = true)) {
@@ -204,7 +204,7 @@ object DianaMobDetect {
         }
     }
 
-    private fun checkCocoon(entity: ArmorStand) {
+    private fun checkCocoon(entity: ArmorStand, now: Long) {
         if (World.getWorld() != "Hub") return
         val recentDeath = listOf(lastInqDeath, lastKingDeath, lastSphinxDeath, lastMantiDeath)
             .any { getSecondsPassed(it) < DEATH_WINDOW_SECONDS }
@@ -218,7 +218,6 @@ object DianaMobDetect {
         val texture: String? = profileComponent?.partialProfile()?.properties?.get("textures")?.firstOrNull()?.value
 
         if (texture == null) return
-        val now = System.currentTimeMillis()
         if (texture == COCOON_TEXTURE && lastCocoon + COCOON_COOLDOWN_MS < now) {
             lastCocoon = now
             if (Diana.announceCocoon) {

--- a/src/main/kotlin/net/sbo/mod/guis/Guis.kt
+++ b/src/main/kotlin/net/sbo/mod/guis/Guis.kt
@@ -18,7 +18,7 @@ import net.minecraft.ChatFormatting
 object Guis {
     private var partyFinderGui: PartyFinderGUI? = null
     private var pastEventsGui: PastEventsGui? = null
-    internal var achievementsGui: AchievementsGUI? = null
+    public var achievementsGui: AchievementsGUI? = null
 //    private var vexelGui: VexelTest? = null
     private var updating = false
     private var lastUpdate = 0L

--- a/src/main/kotlin/net/sbo/mod/utils/Helper.kt
+++ b/src/main/kotlin/net/sbo/mod/utils/Helper.kt
@@ -78,7 +78,7 @@ object Helper {
         }
 
         Register.onTick(20) { // maybe better way to register this
-            hasSpade = playerHasItem("ANCESTRAL_SPADE") || playerHasItem("ARCHAIC_SPADE") || playerHasItem("DEIFIC_SPADE")
+            hasSpade = playerHasItem("DEIFIC_SPADE") || playerHasItem("ARCHAIC_SPADE") || playerHasItem("ANCESTRAL_SPADE")
         }
 
         Register.onTick(20 * 60 * 5) {
@@ -428,10 +428,9 @@ object Helper {
         return false
     }
 
-    fun checkDiana(): Boolean {
-        val diana = (Debug.itsAlwaysDiana || (((Mayor.perks.contains("Mythological Ritual") || Mayor.ministerPerk == "Mythological Ritual") || Mayor.mayor == "Jerry" || Mayor.mayor == "Aura") && hasSpade && World.getWorld() == "Hub"))
-        return diana
-    }
+    private fun hasMythologicalRitualActive(): Boolean = Mayor.mayor == "Jerry" || Mayor.mayor == "Aura" || Mayor.ministerPerk == "Mythological Ritual" || Mayor.perks.contains("Mythological Ritual")
+
+    fun checkDiana(): Boolean = Debug.itsAlwaysDiana || hasSpade && Helper.hasMythologicalRitualActive() && World.getWorld() == "Hub"
 
     fun getGuiName(): String {
         return currentScreen?.title?.string ?: ""

--- a/src/main/kotlin/net/sbo/mod/utils/Player.kt
+++ b/src/main/kotlin/net/sbo/mod/utils/Player.kt
@@ -7,7 +7,7 @@ import java.util.UUID
 
 object Player {
     fun getLastPosition(): SboVec {
-        val player = mc.player ?: return SboVec(0.0, 0.0, 0.0)
+        val player = mc.player ?: return SboVec.ZERO
         return SboVec(player.x, player.y, player.z)
     }
 

--- a/src/main/kotlin/net/sbo/mod/utils/game/ScoreBoard.kt
+++ b/src/main/kotlin/net/sbo/mod/utils/game/ScoreBoard.kt
@@ -9,6 +9,8 @@ object ScoreBoard {
         .reversed()
         .thenComparing({ obj: PlayerScoreEntry -> obj.owner() }, CASE_INSENSITIVE_ORDER)
 
+    private val FORMATTING_REGEX: Regex = "§[^a-f0-9]".toRegex()
+
     /**
      * Retrieves the lines from the scoreboard sidebar.
      * It returns a list of formatted strings representing the scoreboard entries.
@@ -30,7 +32,7 @@ object ScoreBoard {
                 ).string
             }
             .map { decoratedText ->
-                decoratedText.replace("§[^a-f0-9]".toRegex(), "")
+                decoratedText.replace(FORMATTING_REGEX, "")
             }
             .asReversed()
     }

--- a/src/main/kotlin/net/sbo/mod/utils/game/TabList.kt
+++ b/src/main/kotlin/net/sbo/mod/utils/game/TabList.kt
@@ -5,6 +5,7 @@ import net.minecraft.network.chat.Component
 import net.sbo.mod.SBOKotlin.mc
 import net.sbo.mod.utils.events.Register
 import java.util.Collections
+import java.util.ArrayList
 
 object TabList {
     /**
@@ -26,16 +27,16 @@ object TabList {
      * Updates tab list cache by fetching, filtering and mapping the tab list.
      */
     private fun updateCache() {
-        val tabLines = mutableListOf<String>()
+        val tabEntries = getTabEntries()
+        val tabLines = ArrayList<String>(tabEntries.size)
 
-        for (entry in getTabEntries()) {
+        for (entry in tabEntries) {
             if (entry == null) continue
 
             val displayName = entry.tabListDisplayName
             val profile = entry.profile
-            val profileName = profile.name?.let { Component.literal(it) }
 
-            val text = displayName ?: profileName ?: continue
+            val text = displayName ?: profile.name?.let { Component.literal(it) } ?: continue
             tabLines.add(text.string.trim())
         }
 

--- a/src/main/kotlin/net/sbo/mod/utils/math/SboVec.kt
+++ b/src/main/kotlin/net/sbo/mod/utils/math/SboVec.kt
@@ -112,6 +112,8 @@ data class SboVec(var x: Double, var y: Double, var z: Double) {
     fun scale(scalar: Double): SboVec = SboVec(scalar * x, scalar * y, scalar * z)
 
     companion object {
+        val ZERO: SboVec = BlockPos.ZERO.toSboVec()
+
         fun fromArray(arr: List<Double>): SboVec {
             require(arr.size >= 3) { "Array must contain at least 3 elements for x, y, z." }
             return SboVec(arr[0], arr[1], arr[2])

--- a/src/main/kotlin/net/sbo/mod/utils/overlay/OverlayManager.kt
+++ b/src/main/kotlin/net/sbo/mod/utils/overlay/OverlayManager.kt
@@ -55,7 +55,7 @@ object OverlayManager {
         val scaleFactor = mc.window.guiScale
         val mouseX = mc.mouseHandler.xpos() / scaleFactor
         val mouseY = mc.mouseHandler.ypos() / scaleFactor
-        for (overlay in overlays.toList()) {
+        for (overlay in overlays) {
             if (renderScreen == null && !mc.options.keyPlayerList.isDown && !mc.options.hideGui)
                 overlay.render(drawContext, mouseX, mouseY)
         }
@@ -66,7 +66,7 @@ object OverlayManager {
         val scaleFactor = mc.window.guiScale
         val mouseX = mc.mouseHandler.xpos() / scaleFactor
         val mouseY = mc.mouseHandler.ypos() / scaleFactor
-        for (overlay in overlays.toList()) {
+        for (overlay in overlays) {
             if (overlay.allowedScreens.any { it(renderScreen) } && !mc.options.hideGui)
                 overlay.render(drawContext, mouseX, mouseY)
         }

--- a/src/main/kotlin/net/sbo/mod/utils/overlay/OverlayTextLine.kt
+++ b/src/main/kotlin/net/sbo/mod/utils/overlay/OverlayTextLine.kt
@@ -33,13 +33,18 @@ class OverlayTextLine(
 
     var text: String = text
         set(value) {
-            field = value
+            val oldValue = field
+            val newValue = value
 
-            // update cached values when text changes
-            orderedText = Component.nullToEmpty(value).visualOrderText
+            // update cached values only when the actual text changes
+            if (newValue != oldValue) {
+                field = newValue
 
-            @Suppress("UNNECESSARY_SAFE_CALL") // the warning is wrong; game crashes with NPE if we remove the safe call - font is definitely nullable in this specific code path.
-            cachedWidth = mc.font?.width(orderedText) ?: -1 // textRenderer is null at init time
+                orderedText = Component.nullToEmpty(value).visualOrderText
+
+                @Suppress("UNNECESSARY_SAFE_CALL") // the warning is wrong; game crashes with NPE if we remove the safe call - font is definitely nullable in this specific code path.
+                cachedWidth = mc.font?.width(orderedText) ?: -1 // textRenderer is null at init time
+            }
         }
 
     var mouseEnterAction: (() -> Unit)? = null


### PR DESCRIPTION
- Only recompute the visualOrderText and width when the text actually changed by comparing newValue and oldValue in OverlayTextLine.text
- Remove .toList() copy when iterating in OverlayManager There's only 1 place that does .add() and both seem to run in render thread, comodification is not possible. Even if it was, CopyOnWriteArrayList needs to be used instead of .toList copy.
- Cache SboVec.ZERO from BlockPos.ZERO and use it in Player#getLastPosition
- Pre-size the list created for tabLines in TabList.kt based on .size of getTabEntries result Also a slight optimization to avoid creating a new Component.literal if displayName was not null already
- Fix non-cached regex in ScoreBoard.kt for formatting codes, use a new private val FORMATTING_REGEX.
- Reorder conditions in Helper.kt: Check Deific Spade, Archaic Spade and then Ancestral Spade instead of the other way around, as people are most likely to have T2/T3 spade so checking those first short-circuits the condition (slight performance improvement)

 The same condition reordering is done for checkDiana and simplified the method for better understandability by splitting it into 2 methods. Since Mayor.perks.contains does a HashSet#contains, whereas the Jerry/Aura/ministerPerk == comparisions do String#equals, we improve performance a little by checking for those first; since String#equals is faster than HashSet#contains. hasSpade is an already computed field, so it is cheaper to check that first before String#equals and HashSet#contains, so moved that in front.
- Fix relying on Kotlin-internal mangled name for Guis.achievementsGui access from a Java Mixin internal and public are the same thing in Java-side except Kotlin compiler does name mangling. Making it public if we are going to access it from Java side is reasonable.
- Pass already-computed System.currentTimeMillis() now value into checkCocoon method in DianaMobDetect.kt. Calling System.currentTimeMillis() inside a loop is not free as it has to do a syscall and go through the vdso layer to get the information from the system clock. Even with TSC instead of HPET, this is still a performance improvement.
- Remove unnecessary pluginManagement repositories and plugins block from settings.gradle.kts multiversion-root is only supposed to exist in root.gradle.kts. The jitpack, terraformersmc and server.bbkr.space repos were unused; the last one (server.bbkr.space) even being offline (out of service). The kotlin jvm plugin does not need to be applied in this context in settings.gradle.kts, so removed that as well.
- Removed relying on the deftu tools plugin. We set the jar name ourselves now.
- Set Kotlin JvmTarget in addition to JavaCompile target to make sure resulting .jar files can work in Java 21 since we build on Java 25 now and target 25 for 26.1.