### PR TITLE
Fix spaces in party finder notes

### DIFF
--- a/src/main/kotlin/net/sbo/mod/guis/partyfinder/PartyFinderGUI.kt
+++ b/src/main/kotlin/net/sbo/mod/guis/partyfinder/PartyFinderGUI.kt
@@ -525,7 +525,7 @@ class PartyFinderGUI : WindowScreen(ElementaVersion.V10) {
                     width = 90.percent()
                     height = 100.percent()
                 }.setColor(Color(0, 0, 0, 0))
-                    .addChild(UIWrappedText("&bNote: &7" + party.note).constrain {
+                    .addChild(UIWrappedText("&bNote: &7" + party.note.replace("%20", " ")).constrain {
                         x = 0.pixels
                         y = CenterConstraint()
                         width = 100.percent()


### PR DESCRIPTION
Spaces are replaced with %20 so that a Http request can be sent with the note query parameter when creating the party, but they are never replaced back with actual spaces when displaying the party note in /sbopf GUI, causing confusiong among users.

This change should fix it.