### PR TITLE
Fix past events gui overlapping after wool addition

### DIFF
--- a/src/main/kotlin/net/sbo/mod/guis/PastEventsGui.kt
+++ b/src/main/kotlin/net/sbo/mod/guis/PastEventsGui.kt
@@ -236,7 +236,7 @@ class PastEventsGui : WindowScreen(ElementaVersion.V10) {
             eventBlock.setColor(Color(10,10,10,255))
 
             val leftText = UIBlock().constrain {
-                x = 10.pixels; y = 10.pixels; width = SubtractiveConstraint(ChildBasedSizeConstraint(), 40.pixels); height = ChildBasedSizeConstraint()
+                x = 10.pixels; y = 10.pixels; width = ChildBasedSizeConstraint(); height = ChildBasedSizeConstraint()
             }.setColor(Color(0,0,0,0)) childOf eventBlock
 
             val rightText = UIBlock().constrain {


### PR DESCRIPTION
Right text side was being slightly inside the left text side.

This change fixes it.