### PR TITLE
Fix Myth the Fish tracking not working

### DIFF
--- a/src/main/kotlin/net/sbo/mod/diana/DianaTracker.kt
+++ b/src/main/kotlin/net/sbo/mod/diana/DianaTracker.kt
@@ -785,7 +785,7 @@ object DianaTracker {
 
     fun trackMythTheFish() {
         Register.onChatMessage(Regex("^(.*?) §eYou just dug out(.*?)$")) { message, matchResult ->
-            if (matchResult.groupValues[1].contains("Myth the Fish")) {
+            if (matchResult.groupValues[2].contains("Myth the Fish")) {
                 onRareDropFromMob("Myth the Fish", false, true, false, 0)
                 unlockAchievement(119)
             }


### PR DESCRIPTION
Previous dianas I have gotten some but it wasn't in my tracker, looked through code and saw the potential mistake. Hypixel sends the message in this format from what I remember: "WOW! You just dug out a Myth the Fish!"

.groupValues[0] will have the whole string.
.groupValues[1] will have "WOW!" (causing the bug since it doesn't contain Myth the Fish) .groupValues[2] will have "a Myth the Fish!"

By changing index from 1 to 2, the bug should be fixed.