### PR TITLE
Bump mod version to 0.3.0-beta

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -47,7 +47,7 @@ dgt.loom.loader.use=false
 # Mod properties
 mod.name=SBO
 mod.id=sbo
-mod.version=0.2.1-beta
+mod.version=0.3.0-beta
 mod.group=net.sbo.mod
 mod.description=SBO is the ultimate diana mod for diana nons! FPS friendly, and packed with QOL features!
 


### PR DESCRIPTION
Bumps the mod version to 0.3.0-beta (This is release is too large to be 0.2.2-beta - 26.1 addition, yarn to mojang mappings, config and backup filesystem handling changes, etc.,)

In the next release we can probably drop the -beta suffix as most bugs are fixed now, but for this release since it has big changes I decided to keep it.

Please create the PR to merge Diana-V2 to main and the GitHub/Modrinth releases after merging all open non-draft PRs first.
 Per how it is done in previous releases, mark GitHub release as non-prerelease and Modrinth as a beta release (like said once the -beta suffix is dropped, next release can be declared as stable in Modrinth as well).

Recommended release notes below written by me (will edit to update and unmark as draft once other pending PRs are merged):

# READ: For upgrading users
It is advised to backup your .minecraft/config/SBO folder (or your instance folder if you are not using the official launcher) somewhere else before upgrading to this version as there was a change to how filesystem directories regarding the folders in config directory are handled, and another change about how your backups (for past events data) are handled. These changes should not cause issues, but better safe than be sorry.

Renamed Museum --> MUSEUM to match other entries and name style standards. If you have disabled the museum warp, you might need to re-disable it after updating to this version.

# Minecraft 26.1, 26.1.1 and 26.1.2 Support
Added Minecraft 26.1, 26.1.1 and 26.1.2 support. While less tested than the 1.21.11 and 1.21.10 versions, please test and give feedback.

# First-Time User Experience Improvements
- Added a !help command in case people do not know about /sbopartycommands.
- Added a note to Diana Warp section telling the keys must be set in vanilla MC controls menu to avoid confusion.
- Added a button to open Party Finder in Party Finder settings category in case new users do not know /sbopf command.

# More Diana-V2 Polishing
- Added amount of dropped Mythological Dyes, Shimmering Wools, Shimmering Wools (LS), Manti-cores, Manti-cores (LS) and killed Minos Kings, Minos Kings (LS), Mantis, Mantis (LS) to /sbopastevents.

# Bugs Fixed
## 1.21.11-specific
- Fixed line to closest burrow not rendering in 1.21.11.

## 1.21.10-specific
- Fixed red outline for hud elements not being accurately sized when scale of the hud element is changed in 1.21.10.

## All versions
- Fixed diana detection without always diana debug option when diana is minister.
- Fixed party commands not working when Hypixel language is set to anything else than English.
- Fixed InvalidIdentifierException crash when your customization settings has a bad custom sound path.
- Fixed not being able to Change View or Instasell/Sell offer when your Minecraft language is set to anything else than English.
- Fixed duplicate directories in .minecraft/config when your filesystem is case-sensitive.
- Fixed 0-byte zips and empty folders in the backup directory from non-atomic backup system.
- Fixed trying to refresh mayor data every 1 second instead of every 1 minute when all previous refresh requests were failed. (Thanks lunaynx for the fix)
- Fixed /ct reload being mentioned in Party Finder FAQ, replaced with suggestion to enable all API in SkyBlock settings instead now.
- Fixed spaces in party finder notes showing up as %20.
- Fixed Myth the Fish tracking not working.

# New Optimizations
- Optimized total width and height to be only calculated when needed using kotlin lazy.
- Optimized various components related to ordered text, regex, system time millis, and short-circuiting conditionals.

# Other Misc Changes
- Removed 1.21.5 and 1.21.7 entirely from the codebase as Hypixel dropped support.
- Bundle 1.21.11 version of hm-api in 1.21.11.
- Update checker log messages changed from german to english.
- Enhanced mod metadata with issues link and added bundled dependencies to dependencies section.
- Migrated the project to Mojang mappings from Yarn.
- Bump bundled universalcraft and elementa versions.
