### PR TITLE
Make warp key work without diana

### DIFF
--- a/src/main/kotlin/net/sbo/mod/utils/waypoint/WaypointManager.kt
+++ b/src/main/kotlin/net/sbo/mod/utils/waypoint/WaypointManager.kt
@@ -27,6 +27,7 @@ import kotlin.math.roundToInt
 import kotlin.text.get
 import net.fabricmc.fabric.api.client.rendering.v1.world.WorldRenderContext
 import net.fabricmc.fabric.api.client.rendering.v1.world.WorldRenderEvents
+import net.sbo.mod.utils.game.World
 
 object WaypointManager {
     var guessWp: Waypoint? = null
@@ -438,7 +439,7 @@ object WaypointManager {
 
     var tryWarp: Boolean = false
     fun executeWarpCommand(warp: String) {
-        if (!checkDiana()) return
+        if (World.getWorld() != "Hub") return
         if (Diana.warpDelay > 0 && System.currentTimeMillis() - PreciseGuessBurrow.lastGuessTime < Diana.warpDelay) return
         if (warp.isNotEmpty() && !tryWarp) {
             tryWarp = true

--- a/src/main/kotlin/net/sbo/mod/utils/waypoint/WaypointManager.kt
+++ b/src/main/kotlin/net/sbo/mod/utils/waypoint/WaypointManager.kt
@@ -439,7 +439,7 @@ object WaypointManager {
 
     var tryWarp: Boolean = false
     fun executeWarpCommand(warp: String) {
-        if (World.getWorld() != "Hub") return
+        if (World.getWorld() != "Hub" || !Helper.hasSpade) return
         if (Diana.warpDelay > 0 && System.currentTimeMillis() - PreciseGuessBurrow.lastGuessTime < Diana.warpDelay) return
         if (warp.isNotEmpty() && !tryWarp) {
             tryWarp = true


### PR DESCRIPTION
It gets asked a lot "why my warp key is not working even though everything else does", often solved by waiting 5-10 minutes for mayor api to update or restarting game, and if still not solved enabling the debug option to force always diana.

It however does not make sense to me either, if spade guesses, HUDs, rare mob waypoints and everything else works without checkDiana() - making the key work as well isn't too far. The key won't do anything if there's no closest thing to warp to anyways, and the user can always choose a key that they won't press accidentally, and unbinding the key is also an option; so the checkDiana() here seems kind of redundant.

Therefore I decided to replace it with a is in Hub check; this way if something goes horribly wrong and there's a closest burrow not cleared in memory and user is in dungeons for example they won't warp themselves out by accident. That should never happen, but I didn't want to just remove checkDiana() and make it conditionless warp on key press either.