### PR TITLE
Fix reset session command

### DIFF
--- a/src/main/kotlin/net/sbo/mod/diana/DianaTracker.kt
+++ b/src/main/kotlin/net/sbo/mod/diana/DianaTracker.kt
@@ -49,10 +49,8 @@ object DianaTracker {
 
     fun init() {
         Register.command("sboresetsession") {
-            dianaTrackerSession.reset().save()
+            DianaLoot.resetSession()
             Chat.chat("§6[SBO] §aDiana session tracker has been reset.")
-            DianaMobs.updateLines()
-            DianaLoot.updateLines()
         }
 
         Register.command("sboresetmayortracker") {

--- a/src/main/kotlin/net/sbo/mod/overlays/DianaLoot.kt
+++ b/src/main/kotlin/net/sbo/mod/overlays/DianaLoot.kt
@@ -62,12 +62,16 @@ object DianaLoot {
         hoverText = "$RED${UNDERLINE}Reset Session",
         defaultText = "${RED}Reset Session",
         onClick = {
-            SboTimerManager.timerSession.reset()
-            SBOConfigBundle.dianaTrackerSessionData.reset().save()
-            updateLines()
-            DianaMobs.updateLines()
+            DianaLoot.resetSession()
         }
     )
+
+    fun resetSession() {
+        SboTimerManager.timerSession.reset()
+        SBOConfigBundle.dianaTrackerSessionData.reset().save()
+        updateLines()
+        DianaMobs.updateLines()
+    }
 
     private val LOOT_ITEMS = listOf<LootItemData>(
         LootItemData("MYTHOLOGICAL_DYE", "Mythological Dye", RED),


### PR DESCRIPTION
Makes it use the same code path as the "Reset Session" button under Diana Loot hud to fix it, since that one was working.

I haven't investigated the root cause of the issue. Probably something related to resetting through SBOConfigBundle vs DianaTracker or the extra timerSession reset call? Not sure.