### PR TITLE
New chat based cocoon detection

### DIFF
--- a/src/main/kotlin/net/sbo/mod/diana/DianaMobDetect.kt
+++ b/src/main/kotlin/net/sbo/mod/diana/DianaMobDetect.kt
@@ -82,6 +82,17 @@ object DianaMobDetect {
     fun init() {
         mobHpOverlay.init()
         noShurikenOverlay.init()
+        Register.onChatMessage(
+            Regex("^§a§lCAUGHT!.*?You cocooned a (?<name>.+?)!.*$")
+        ) { _, matchResult ->
+            val name = matchResult.groups["name"]?.value ?: return@onChatMessage
+            val rare = RareDianaMob.fromName(name)
+
+            if (rare != null) {
+                // Cocooned a rare mob if rare != null
+                announceCocoon(DetectionType.CHAT_MESSAGE, rare.display)
+            }
+        }
         Register.onTick(1) {
             val world = mc.level ?: return@onTick
             val player = mc.player ?: return@onTick
@@ -205,7 +216,7 @@ object DianaMobDetect {
     }
 
     private fun checkCocoon(entity: ArmorStand, now: Long) {
-        if (World.getWorld() != "Hub") return
+        if (!Diana.legacyCocoonDetection || World.getWorld() != "Hub") return
         val recentDeath = listOf(lastInqDeath, lastKingDeath, lastSphinxDeath, lastMantiDeath)
             .any { getSecondsPassed(it) < DEATH_WINDOW_SECONDS }
 
@@ -220,13 +231,26 @@ object DianaMobDetect {
         if (texture == null) return
         if (texture == COCOON_TEXTURE && lastCocoon + COCOON_COOLDOWN_MS < now) {
             lastCocoon = now
-            if (Diana.announceCocoon) {
-                sleep(CHAT_DELAY_MS) { Chat.command("pc Cocoon!") }
-            }
-            if (Diana.cocoonTitle) {
-                showTitle("§r§6§l<§b§l§kO§6§l> §b§lCOCOON! §6§l<§b§l§kO§6§l>", null, 10, 40, 10)
-                playCustomSound(Customization.cocoonSound[0], Customization.cocoonVolume)
-            }
+            announceCocoon(DetectionType.TEXTURE)
+        }
+    }
+
+    private enum class DetectionType {
+        TEXTURE, CHAT_MESSAGE
+    }
+
+    private fun announceCocoon(detectionType: DetectionType, mobName: String? = null) {
+        if (detectionType == DetectionType.TEXTURE && !Diana.legacyCocoonDetection) {
+            return
+        }
+
+        if (Diana.announceCocoon) {
+            sleep(CHAT_DELAY_MS) { Chat.command("pc " + if (mobName != null) "Cocooned a ${mobName}!" else "Cocoon!") }
+        }
+        if (Diana.cocoonTitle) {
+            val subtitle = if (mobName != null) "§b${mobName}" else null
+            showTitle("§r§6§l<§b§l§kO§6§l> §b§lCOCOON! §6§l<§b§l§kO§6§l>", subtitle, 10, 40, 10)
+            playCustomSound(Customization.cocoonSound[0], Customization.cocoonVolume)
         }
     }
 

--- a/src/main/kotlin/net/sbo/mod/settings/categories/Diana.kt
+++ b/src/main/kotlin/net/sbo/mod/settings/categories/Diana.kt
@@ -458,6 +458,11 @@ object Diana : CategoryKt("Diana") {
         this.description = Literal("Shows a title on cocoon")
     }
 
+    var legacyCocoonDetection by boolean(false) {
+        this.name = Literal("Legacy Cocoon Detection")
+        this.description = Literal("Uses egg sac player head texture to detect cocoon instead of the new cocoon chat message when enabled. Only enable if chat detection does not work.")
+    }
+
     var hpAlert by double(0.0) {
         this.name = Literal("HP Alert")
         this.description = Literal("Sends a title alert when a Rare Mob is below the set HP value in Million (0 to disable)")


### PR DESCRIPTION
Hypixel added a chat message on cocoon, so the old method is not needed anymore.

Added an option to still enable the old detection method just in case, but from my limited testing (1 cocooned inquisitor) it worked fine.

When not using the legacy method, announceCocoon was also modified to show cocooned mob type in the party chat message and as subtitle on scren.