### PR TITLE
More OverlayTextLine perf tweaks

### DIFF
--- a/src/main/kotlin/net/sbo/mod/utils/overlay/OverlayTextLine.kt
+++ b/src/main/kotlin/net/sbo/mod/utils/overlay/OverlayTextLine.kt
@@ -11,41 +11,12 @@ import net.minecraft.network.chat.Component
 import java.awt.Color
 
 class OverlayTextLine(
-    text: String,
+    var text: String,
     var shadow: Boolean = true,
     var linebreak: Boolean = true
 ) {
-    private var orderedText: FormattedCharSequence = Component.nullToEmpty(text).visualOrderText // to avoid nullable OrderedText?
-
-    private var cachedWidth: Int = -1 // filler value used to differenate non-init vs actual width
-        private get() {
-            val isInit = field != -1 // check if actual width
-
-            if (isInit) {
-                return field
-            }
-
-            val width = mc.font.width(orderedText)
-            field = width
-
-            return field
-        }
-
-    var text: String = text
-        set(value) {
-            val oldValue = field
-            val newValue = value
-
-            // update cached values only when the actual text changes
-            if (newValue != oldValue) {
-                field = newValue
-
-                orderedText = Component.nullToEmpty(value).visualOrderText
-
-                @Suppress("UNNECESSARY_SAFE_CALL") // the warning is wrong; game crashes with NPE if we remove the safe call - font is definitely nullable in this specific code path.
-                cachedWidth = mc.font?.width(orderedText) ?: -1 // textRenderer is null at init time
-            }
-        }
+    private var orderedText: FormattedCharSequence? = null
+    private var orderedTextSource: String? = null
 
     var mouseEnterAction: (() -> Unit)? = null
     var mouseLeaveAction: (() -> Unit)? = null
@@ -54,10 +25,42 @@ class OverlayTextLine(
     var isHovered: Boolean = false
     var x: Int = 0
     var y: Int = 0
-    var width: Int = 0
+
+    var width: Int = -1
+        get() {
+            val currentText = text
+
+            if (orderedTextSource == currentText && field != -1) {
+                return field
+            }
+
+            val computedWidth = mc.font.width(getOrderedText())
+            field = computedWidth
+
+            return computedWidth
+        }
+        private set
+
     private var height: Int = 0
     var renderDebugBox: Boolean = false
     private var condition: () -> Boolean = { true }
+
+    private fun getOrderedText(): FormattedCharSequence { // we return FormattedCharSequence instead of FormattedCharSequence? so this can't be a property getter
+        val currentText = text
+        val cachedText = orderedTextSource
+        val cachedOrderedText = orderedText
+
+        if (cachedOrderedText != null && currentText == cachedText) {
+            return cachedOrderedText
+        }
+
+        val computed = Component.nullToEmpty(currentText).visualOrderText
+
+        orderedText = computed
+        orderedTextSource = currentText
+
+        return computed
+    }
 
     fun setCondition(condition: () -> Boolean): OverlayTextLine {
         this.condition = condition
@@ -126,7 +129,7 @@ class OverlayTextLine(
     }
 
     private fun isMouseOver(mouseX: Double, mouseY: Double, x: Float, y: Float, textRenderer: Font, scale: Float): Boolean {
-        val textWidth = cachedWidth * scale
+        val textWidth = width * scale
         val textHeight = (textRenderer.lineHeight + 1) * scale - 1
 
         return mouseX >= x && mouseX <= x + textWidth && mouseY >= y && mouseY <= y + textHeight
@@ -157,13 +160,12 @@ class OverlayTextLine(
 
         this.x = x
         this.y = y
-        this.width = cachedWidth
         this.height = textRenderer.lineHeight
 
         if (renderDebugBox) {
             drawContext.fill(x, y, x + width, y + height + 1, Color(128, 128, 128, 130).rgb)
         }
 
-        drawContext.drawString(textRenderer, orderedText, x, y, -1, shadow)
+        drawContext.drawString(textRenderer, getOrderedText(), x, y, -1, shadow)
     }
 }


### PR DESCRIPTION
- Avoids computing visualOrderText eargly on construction time
- Avoids computing with when only the visualOrderText was needed to be computed
- Avoids duplicate compute work if setText called multiple times before render (Previously, we recomputed each mutation, now we recompute if necessary on read instead, so if multiple mutations happen before a read, only the latest value is computed)