### PR TITLE
Dont render waypoints out of hub

### DIFF
--- a/src/main/kotlin/net/sbo/mod/utils/waypoint/WaypointManager.kt
+++ b/src/main/kotlin/net/sbo/mod/utils/waypoint/WaypointManager.kt
@@ -15,7 +15,7 @@ import net.sbo.mod.utils.Helper
 import net.sbo.mod.utils.Helper.checkDiana
 import net.sbo.mod.utils.Helper.sleep
 import net.sbo.mod.utils.Player
-import net.sbo.mod.utils.World
+import net.sbo.mod.utils.game.World
 import net.sbo.mod.utils.SoundHandler.playCustomSound
 import net.sbo.mod.utils.events.Register
 import net.sbo.mod.utils.events.annotations.SboEvent

--- a/src/main/kotlin/net/sbo/mod/utils/waypoint/WaypointManager.kt
+++ b/src/main/kotlin/net/sbo/mod/utils/waypoint/WaypointManager.kt
@@ -15,6 +15,7 @@ import net.sbo.mod.utils.Helper
 import net.sbo.mod.utils.Helper.checkDiana
 import net.sbo.mod.utils.Helper.sleep
 import net.sbo.mod.utils.Player
+import net.sbo.mod.utils.World
 import net.sbo.mod.utils.SoundHandler.playCustomSound
 import net.sbo.mod.utils.events.Register
 import net.sbo.mod.utils.events.annotations.SboEvent
@@ -206,6 +207,10 @@ object WaypointManager {
      * @param context The world render context.
      */
     fun renderAllWaypoints(context: WorldRenderContext) {
+        if (World.getWorld() != "Hub") {
+            return
+        }
+
         this.forEachWaypoint { waypoint ->
             waypoint.render(context)
         }

--- a/src/main/kotlin/net/sbo/mod/utils/waypoint/WaypointManager.kt
+++ b/src/main/kotlin/net/sbo/mod/utils/waypoint/WaypointManager.kt
@@ -15,7 +15,6 @@ import net.sbo.mod.utils.Helper
 import net.sbo.mod.utils.Helper.checkDiana
 import net.sbo.mod.utils.Helper.sleep
 import net.sbo.mod.utils.Player
-import net.sbo.mod.utils.game.World
 import net.sbo.mod.utils.SoundHandler.playCustomSound
 import net.sbo.mod.utils.events.Register
 import net.sbo.mod.utils.events.annotations.SboEvent


### PR DESCRIPTION
The waypoints are not cleared, they will re-appear once joining hub.

Some people consider showing the waypoints on other islands, e.g, nether, is a bug of mod thinking you are in hub/mythological ritual active island, but the check was never there to start with, so more of an enhancement rather than bug fix.