### PR TITLE
Add assume muted option to settings

### DIFF
--- a/src/main/kotlin/net/sbo/mod/diana/DianaMobDetect.kt
+++ b/src/main/kotlin/net/sbo/mod/diana/DianaMobDetect.kt
@@ -245,7 +245,7 @@ object DianaMobDetect {
         }
 
         if (Diana.announceCocoon) {
-            sleep(CHAT_DELAY_MS) { Chat.command("pc " + if (mobName != null) "Cocooned a ${mobName}!" else "Cocoon!") }
+            sleep(CHAT_DELAY_MS) { Chat.pc("" + if (mobName != null) "Cocooned a ${mobName}!" else "Cocoon!") }
         }
         if (Diana.cocoonTitle) {
             val subtitle = if (mobName != null) "§b${mobName}" else null
@@ -277,7 +277,7 @@ object DianaMobDetect {
 
             if (mobType !in Diana.ShareMobs) return
             val playerPos = SboPlayer.getLastPosition()
-            Chat.command("pc x: ${playerPos.x.roundToInt()}, y: ${playerPos.y.roundToInt() - 1}, z: ${playerPos.z.roundToInt()} | $mob")
+            Chat.pc("x: ${playerPos.x.roundToInt()}, y: ${playerPos.y.roundToInt() - 1}, z: ${playerPos.z.roundToInt()} | $mob")
         }
 
         when (mob) {
@@ -285,7 +285,7 @@ object DianaMobDetect {
                 Diana.announceInqText.firstOrNull()?.let { killText ->
                     if (killText.isNotBlank()) {
                         val message = Helper.getSpawnMessage(Diana.announceInqText[0], "inq")
-                        sleep(ANNOUNCE_DELAY_MS) { Chat.command("pc $message") }
+                        sleep(ANNOUNCE_DELAY_MS) { Chat.pc("$message") }
                     }
                 }
             }
@@ -294,7 +294,7 @@ object DianaMobDetect {
                 Diana.announceSphinxText.firstOrNull()?.let { killText ->
                     if (killText.isNotBlank()) {
                         val message = Helper.getSpawnMessage(Diana.announceSphinxText[0], "sphinx")
-                        sleep(ANNOUNCE_DELAY_MS) { Chat.command("pc $message") }
+                        sleep(ANNOUNCE_DELAY_MS) { Chat.pc("$message") }
                     }
                 }
             }
@@ -303,7 +303,7 @@ object DianaMobDetect {
                 Diana.announceMantiText.firstOrNull()?.let { killText ->
                     if (killText.isNotBlank()) {
                         val message = Helper.getSpawnMessage(Diana.announceMantiText[0], "manti")
-                        sleep(ANNOUNCE_DELAY_MS) { Chat.command("pc $message") }
+                        sleep(ANNOUNCE_DELAY_MS) { Chat.pc("$message") }
                     }
                 }
             }
@@ -312,7 +312,7 @@ object DianaMobDetect {
                 Diana.announceKingText.firstOrNull()?.let { killText ->
                     if (killText.isNotBlank()) {
                         val message = Helper.getSpawnMessage(Diana.announceKingText[0], "king")
-                        sleep(ANNOUNCE_DELAY_MS) { Chat.command("pc $message") }
+                        sleep(ANNOUNCE_DELAY_MS) { Chat.pc("$message") }
                     }
                 }
             }

--- a/src/main/kotlin/net/sbo/mod/diana/DianaTracker.kt
+++ b/src/main/kotlin/net/sbo/mod/diana/DianaTracker.kt
@@ -662,7 +662,7 @@ object DianaTracker {
 
         if (replaceDropMessage) {
             if (customMsg != null) Chat.chat(customMsg)
-            Chat.command("pc $msg")
+            Chat.pc("$msg")
         } else {
             lootAnnouncerBuffer.add(msg)
             if (!lootAnnouncerBool) {
@@ -679,7 +679,7 @@ object DianaTracker {
         if (lootAnnouncerBuffer.isEmpty()) return
         val msg = lootAnnouncerBuffer.joinToString(", ")
         lootAnnouncerBuffer.clear()
-        Chat.command("pc [SBO] RARE DROP! $msg")
+        Chat.pc("[SBO] RARE DROP! $msg")
     }
 
     fun getB2BMessage(itemName: String, streak: Int): String? { // not used yet

--- a/src/main/kotlin/net/sbo/mod/general/PartyCommands.kt
+++ b/src/main/kotlin/net/sbo/mod/general/PartyCommands.kt
@@ -135,21 +135,21 @@ object PartyCommands {
                     val randomIndex = (carrot.indices).random()
                     val response = carrot[randomIndex]
                     sleep(200) {
-                        Chat.command("pc $response")
+                        Chat.pc("$response")
                     }
                 }
                 "!time" -> {
                     if (!settings.timeCommand) return@onChatMessage
                     sleep(200) {
                         val currentTime = SimpleDateFormat("HH:mm:ss").format(Date())
-                        Chat.command("pc $currentTime")
+                        Chat.pc("$currentTime")
                     }
                 }
                 "!tps" -> {
                     if (!settings.tpsCommand) return@onChatMessage
                     sleep(200) {
                         val tps = ServerStats.getTps()
-                        Chat.command("pc ${"%.2f".format(tps)} TPS")
+                        Chat.pc("${"%.2f".format(tps)} TPS")
                     }
                 }
                 "!chim", "!chimera", "!chims", "!chimeras", "!book", "!books" -> {
@@ -158,13 +158,13 @@ object PartyCommands {
                     val chimeraLsCount = dianaTrackerMayor.items.CHIMERA_LS
                     val percent = calcPercentOne(dianaTrackerMayor.items, dianaTrackerMayor.mobs, "CHIMERA", "MINOS_INQUISITOR")
                     sleep(200) {
-                        Chat.command("pc Chimera: $chimeraCount ($percent%) +$chimeraLsCount LS")
+                        Chat.pc("Chimera: $chimeraCount ($percent%) +$chimeraLsCount LS")
                     }
                 }
                 "!inqsls", "!inquisitorls", "!inquisls", "!lsinq", "!lsinqs", "!lsinquisitor", "!lsinquis" -> {
                     if (!settings.dianaPartyCommands) return@onChatMessage
                     sleep(200) {
-                        Chat.command("pc Inquisitor LS: ${dianaTrackerMayor.mobs.MINOS_INQUISITOR_LS}")
+                        Chat.pc("Inquisitor LS: ${dianaTrackerMayor.mobs.MINOS_INQUISITOR_LS}")
                     }
                 }
                 "!inq", "!inqs", "!inquisitor", "!inquis" -> {
@@ -172,7 +172,7 @@ object PartyCommands {
                     val inquisCount = dianaTrackerMayor.mobs.MINOS_INQUISITOR
                     val percent = calcPercentOne(dianaTrackerMayor.items, dianaTrackerMayor.mobs, "MINOS_INQUISITOR")
                     sleep(200) {
-                        Chat.command("pc Inquisitor: $inquisCount ($percent%)")
+                        Chat.pc("Inquisitor: $inquisCount ($percent%)")
                     }
                 }
                 "!burrows", "!burrow" -> {
@@ -181,7 +181,7 @@ object PartyCommands {
                     val timer = SboTimerManager.timerMayor
                     val burrowsPerHr = Helper.getBurrowsPerHr(dianaTrackerMayor, timer)
                     sleep(200) {
-                        Chat.command("pc Burrows: $burrows ($burrowsPerHr/h)")
+                        Chat.pc("Burrows: $burrows ($burrowsPerHr/h)")
                     }
                 }
                 "!relic", "!relics" -> {
@@ -189,7 +189,7 @@ object PartyCommands {
                     val relicCount = dianaTrackerMayor.items.MINOS_RELIC
                     val percent = calcPercentOne(dianaTrackerMayor.items, dianaTrackerMayor.mobs, "MINOS_RELIC", "MINOS_CHAMPION")
                     sleep(200) {
-                        Chat.command("pc Relics: $relicCount ($percent%)")
+                        Chat.pc("Relics: $relicCount ($percent%)")
                     }
                 }
                 "!chimls", "!chimerals", "!bookls", "!lschim", "!lsbook", "!lootsharechim", "!lschimera" -> {
@@ -197,7 +197,7 @@ object PartyCommands {
                     val chimsLs = dianaTrackerMayor.items.CHIMERA_LS
                     val percent = calcPercentOne(dianaTrackerMayor.items, dianaTrackerMayor.mobs, "CHIMERALS", "MINOS_INQUISITOR_LS")
                     sleep(200) {
-                        Chat.command("pc Chimera LS: $chimsLs ($percent%)")
+                        Chat.pc("Chimera LS: $chimsLs ($percent%)")
                     }
                 }
                 "!core", "!manticore" -> {
@@ -205,7 +205,7 @@ object PartyCommands {
                     val coreCount = dianaTrackerMayor.items.MANTI_CORE
                     val percent = calcPercentOne(dianaTrackerMayor.items, dianaTrackerMayor.mobs, "MANTI_CORE", "MANTICORE")
                     sleep(200) {
-                        Chat.command("pc Cores: $coreCount ($percent%)")
+                        Chat.pc("Cores: $coreCount ($percent%)")
                     }
                 }
                 "!corels", "!manticorels", "!lscore", "!lsmanticore" -> {
@@ -213,7 +213,7 @@ object PartyCommands {
                     val coreLsCount = dianaTrackerMayor.items.MANTI_CORE_LS
                     val percent = calcPercentOne(dianaTrackerMayor.items, dianaTrackerMayor.mobs, "MANTI_CORE_LS", "MANTICORE_LS")
                     sleep(200) {
-                        Chat.command("pc Core LS: $coreLsCount ($percent%)")
+                        Chat.pc("Core LS: $coreLsCount ($percent%)")
                     }
                 }
                 "!stinger", "!fatefulstinger" -> {
@@ -221,7 +221,7 @@ object PartyCommands {
                     val stingerCount = dianaTrackerMayor.items.FATEFUL_STINGER
                     val percent = calcPercentOne(dianaTrackerMayor.items, dianaTrackerMayor.mobs, "FATEFUL_STINGER", "MANTICORE")
                     sleep(200) {
-                        Chat.command("pc Stingers: $stingerCount ($percent%)")
+                        Chat.pc("Stingers: $stingerCount ($percent%)")
                     }
                 }
                 "!stingerls", "!fatefulstingerls", "!lsstinger", "!lsfatefulstinger" -> {
@@ -229,7 +229,7 @@ object PartyCommands {
                     val stingerLsCount = dianaTrackerMayor.items.FATEFUL_STINGER_LS
                     val percent = calcPercentOne(dianaTrackerMayor.items, dianaTrackerMayor.mobs, "FATEFUL_STINGER_LS", "MANTICORE_LS")
                     sleep(200) {
-                        Chat.command("pc Stinger LS: $stingerLsCount ($percent%)")
+                        Chat.pc("Stinger LS: $stingerLsCount ($percent%)")
                     }
                 }
                 "!wool", "!shimmering", "!shimmeringwool" -> {
@@ -237,7 +237,7 @@ object PartyCommands {
                     val woolCount = dianaTrackerMayor.items.SHIMMERING_WOOL
                     val percent = calcPercentOne(dianaTrackerMayor.items, dianaTrackerMayor.mobs, "SHIMMERING_WOOL", "KING_MINOS")
                     sleep(200) {
-                        Chat.command("pc Wool: $woolCount ($percent%)")
+                        Chat.pc("Wool: $woolCount ($percent%)")
                     }
                 }
                 "!woolls", "!shimmeringwoolls", "!lsshimmering", "!lsshimmeringwool" -> {
@@ -245,7 +245,7 @@ object PartyCommands {
                     val woolLsCount = dianaTrackerMayor.items.SHIMMERING_WOOL_LS
                     val percent = calcPercentOne(dianaTrackerMayor.items, dianaTrackerMayor.mobs, "SHIMMERING_WOOL_LS", "KING_MINOS_LS")
                     sleep(200) {
-                        Chat.command("pc Wool LS: $woolLsCount ($percent%)")
+                        Chat.pc("Wool LS: $woolLsCount ($percent%)")
                     }
                 }
                 "!food", "!brainfood", "!brain" -> {
@@ -253,7 +253,7 @@ object PartyCommands {
                     val foodCount = dianaTrackerMayor.items.BRAIN_FOOD
                     val percent = calcPercentOne(dianaTrackerMayor.items, dianaTrackerMayor.mobs, "BRAIN_FOOD", "SPHINX")
                     sleep(200) {
-                        Chat.command("pc Brain Food: $foodCount ($percent%)")
+                        Chat.pc("Brain Food: $foodCount ($percent%)")
                     }
                 }
                 "!foodls", "!brainfoodls", "!lsbrainfood", "!lsbrain" -> {
@@ -261,7 +261,7 @@ object PartyCommands {
                     val foodLsCount = dianaTrackerMayor.items.BRAIN_FOOD_LS
                     val percent = calcPercentOne(dianaTrackerMayor.items, dianaTrackerMayor.mobs, "BRAIN_FOOD_LS", "SPHINX_LS")
                     sleep(200) {
-                        Chat.command("pc Brain Food LS: $foodLsCount ($percent%)")
+                        Chat.pc("Brain Food LS: $foodLsCount ($percent%)")
                     }
                 }
                 "!kingshard", "!kingshards" -> {
@@ -269,7 +269,7 @@ object PartyCommands {
                     val kingShardCount = dianaTrackerMayor.items.KING_MINOS_SHARD
                     val percent = calcPercentOne(dianaTrackerMayor.items, dianaTrackerMayor.mobs, "KING_MINOS_SHARD", "KING_MINOS")
                     sleep(200) {
-                        Chat.command("pc King Shards: $kingShardCount ($percent%)")
+                        Chat.pc("King Shards: $kingShardCount ($percent%)")
                     }
                 }
                 "!sphinxshard", "!sphinxshards" -> {
@@ -277,7 +277,7 @@ object PartyCommands {
                     val sphinxShardCount = dianaTrackerMayor.items.SPHINX_SHARD
                     val percent = calcPercentOne(dianaTrackerMayor.items, dianaTrackerMayor.mobs, "SPHINX_SHARD", "SPHINX")
                     sleep(200) {
-                        Chat.command("pc Sphinx Shards: $sphinxShardCount ($percent%)")
+                        Chat.pc("Sphinx Shards: $sphinxShardCount ($percent%)")
                     }
                 }
                 "!minotaurshard", "!minotaurshards" -> {
@@ -285,7 +285,7 @@ object PartyCommands {
                     val minotaurShardCount = dianaTrackerMayor.items.MINOTAUR_SHARD
                     val percent = calcPercentOne(dianaTrackerMayor.items, dianaTrackerMayor.mobs, "MINOTAUR_SHARD", "MINOTAUR")
                     sleep(200) {
-                        Chat.command("pc Minotaur Shards: $minotaurShardCount ($percent%)")
+                        Chat.pc("Minotaur Shards: $minotaurShardCount ($percent%)")
                     }
                 }
                 "!certanshard", "!certanshards" -> {
@@ -293,14 +293,14 @@ object PartyCommands {
                     val certanShardCount = dianaTrackerMayor.items.CRETAN_BULL_SHARD
                     val percent = calcPercentOne(dianaTrackerMayor.items, dianaTrackerMayor.mobs, "CRETAN_BULL_SHARD", "CRETAN_BULL")
                     sleep(200) {
-                        Chat.command("pc Certan Shards: $certanShardCount ($percent%)")
+                        Chat.pc("Certan Shards: $certanShardCount ($percent%)")
                     }
                 }
                 "!mythofrag", "!frags" -> {
                     if (!settings.dianaPartyCommands) return@onChatMessage
                     val mythoFragCount = dianaTrackerMayor.items.MYTHOS_FRAGMENT
                     sleep(200) {
-                        Chat.command("pc Mytho Frags: $mythoFragCount")
+                        Chat.pc("Mytho Frags: $mythoFragCount")
                     }
                 }
                 "!urns", "!urn", "!cretanurn" -> {
@@ -308,7 +308,7 @@ object PartyCommands {
                     val urnCount = dianaTrackerMayor.items.CRETAN_URN
                     val percent = calcPercentOne(dianaTrackerMayor.items, dianaTrackerMayor.mobs, "CRETAN_URN", "CRETAN_BULL")
                     sleep(200) {
-                        Chat.command("pc Urns: $urnCount ($percent%)")
+                        Chat.pc("Urns: $urnCount ($percent%)")
                     }
                 }
                 "!hilt", "!hiltofrevelations" -> {
@@ -316,7 +316,7 @@ object PartyCommands {
                     val hiltCount = dianaTrackerMayor.items.HILT_OF_REVELATIONS
                     val percent = calcPercentOne(dianaTrackerMayor.items, dianaTrackerMayor.mobs, "HILT_OF_REVELATIONS", "MINOS_HUNTER")
                     sleep(200) {
-                        Chat.command("pc Hilts: $hiltCount ($percent%)")
+                        Chat.pc("Hilts: $hiltCount ($percent%)")
                     }
                 }
                 "!sticks", "!stick" -> {
@@ -324,20 +324,20 @@ object PartyCommands {
                     val stickCount = dianaTrackerMayor.items.DAEDALUS_STICK
                     val percent = calcPercentOne(dianaTrackerMayor.items, dianaTrackerMayor.mobs, "DAEDALUS_STICK", "MINOTAUR")
                     sleep(200) {
-                        Chat.command("pc Sticks: $stickCount ($percent%)")
+                        Chat.pc("Sticks: $stickCount ($percent%)")
                     }
                 }
                 "!feathers", "!feather" -> {
                     if (!settings.dianaPartyCommands) return@onChatMessage
                     val featherCount = dianaTrackerMayor.items.GRIFFIN_FEATHER
                     sleep(200) {
-                        Chat.command("pc Feathers: $featherCount")
+                        Chat.pc("Feathers: $featherCount")
                     }
                 }
                 "!coins", "!coin" -> {
                     if (!settings.dianaPartyCommands) return@onChatMessage
                     sleep(200) {
-                        Chat.command("pc Coins: ${formatNumber(dianaTrackerMayor.items.COINS, withCommas = true)}")
+                        Chat.pc("Coins: ${formatNumber(dianaTrackerMayor.items.COINS, withCommas = true)}")
                     }
                 }
                 "!mobs", "!mob" -> {
@@ -346,19 +346,19 @@ object PartyCommands {
                     val timer = SboTimerManager.timerMayor
                     val mobsPerHr = Helper.getMobsPerHr(dianaTrackerMayor, timer)
                     sleep(200) {
-                        Chat.command("pc Mobs: $totalMobs ($mobsPerHr/h)")
+                        Chat.pc("Mobs: $totalMobs ($mobsPerHr/h)")
                     }
                 }
                 "!mf", "!magicfind" -> {
                     if (!settings.dianaPartyCommands) return@onChatMessage
                     sleep(200) {
-                        Chat.command("pc Chims (${sboData.highestChimMagicFind}% ✯) Sticks (${sboData.highestStickMagicFind}% ✯)")
+                        Chat.pc("Chims (${sboData.highestChimMagicFind}% ✯) Sticks (${sboData.highestStickMagicFind}% ✯)")
                     }
                 }
                 "!playtime" -> {
                     if (!settings.dianaPartyCommands) return@onChatMessage
                     sleep(200) {
-                        Chat.command("pc Playtime: ${formatTime(dianaTrackerMayor.items.TIME)}")
+                        Chat.pc("Playtime: ${formatTime(dianaTrackerMayor.items.TIME)}")
                     }
                 }
                 "!profits", "!profit" -> {
@@ -369,7 +369,7 @@ object PartyCommands {
                         val profit = DianaLoot.totalProfit(dianaTrackerMayor)
                         val offerType = Diana.bazaarSettingDiana.toString()
                         val profitHour = profit / playTimeHrs
-                        Chat.command("pc Profit: ${formatNumber(profit)} (${Helper.toTitleCase(offerType)}) ${formatNumber(profitHour)}/h")
+                        Chat.pc("Profit: ${formatNumber(profit)} (${Helper.toTitleCase(offerType)}) ${formatNumber(profitHour)}/h")
                     }
                 }
                 "!stats", "!stat" -> {
@@ -400,42 +400,42 @@ object PartyCommands {
                     val secondArg = messageParts.getOrNull(1)?.lowercase()
                     when (secondArg) {
                         "chimera", "chim", "chims", "chimeras", "book", "books" -> sleep(200) {
-                            Chat.command("pc Inqs since chim: ${sboData.inqsSinceChim}")
+                            Chat.pc("Inqs since chim: ${sboData.inqsSinceChim}")
                         }
                         "stick", "sticks" -> sleep(200) {
-                            Chat.command("pc Minos since stick: ${sboData.minotaursSinceStick}")
+                            Chat.pc("Minos since stick: ${sboData.minotaursSinceStick}")
                         }
                         "relic", "relics" -> sleep(200) {
-                            Chat.command("pc Champs since relic: ${sboData.champsSinceRelic}")
+                            Chat.pc("Champs since relic: ${sboData.champsSinceRelic}")
                         }
                         "inq", "inqs", "inquisitor", "inquisitors", "inquis" -> sleep(200) {
-                            Chat.command("pc Mobs since inq: ${sboData.mobsSinceInq}")
+                            Chat.pc("Mobs since inq: ${sboData.mobsSinceInq}")
                         }
                         "lschim", "chimls", "lschimera", "chimerals", "lsbook", "bookls", "lootsharechim" -> sleep(200) {
-                            Chat.command("pc Inqs since lootshare chim: ${sboData.inqsSinceLsChim}")
+                            Chat.pc("Inqs since lootshare chim: ${sboData.inqsSinceLsChim}")
                         }
                         "kings", "king" -> sleep(200) {
-                            Chat.command("pc Mobs since king: ${sboData.mobsSinceKing}")
+                            Chat.pc("Mobs since king: ${sboData.mobsSinceKing}")
                         }
                         "manti" -> sleep(200) {
-                            Chat.command("pc Mobs since manti: ${sboData.mobsSinceManti}")
+                            Chat.pc("Mobs since manti: ${sboData.mobsSinceManti}")
                         }
                         "core", "cores" -> sleep(200) {
-                            Chat.command("pc Mantis since core: ${sboData.mantiSinceCore}")
+                            Chat.pc("Mantis since core: ${sboData.mantiSinceCore}")
                         }
                         "wool", "wools" -> sleep(200) {
-                            Chat.command("pc Kings since wool: ${sboData.kingSinceWool}")
+                            Chat.pc("Kings since wool: ${sboData.kingSinceWool}")
                         }
                         "corels", "lscore" -> sleep(200) {
-                            Chat.command("pc Mantis since lootshare core: ${sboData.mantiSinceLsCore}")
+                            Chat.pc("Mantis since lootshare core: ${sboData.mantiSinceLsCore}")
                         }
                         "woolls", "lswool" -> sleep(200) {
-                            Chat.command("pc Kings since lootshare wool: ${sboData.kingSinceLsWool}")
+                            Chat.pc("Kings since lootshare wool: ${sboData.kingSinceLsWool}")
                         }
                     }
                     if (secondArg == null) {
                         sleep(200) {
-                            Chat.command("pc Mobs since inq: ${sboData.mobsSinceInq}")
+                            Chat.pc("Mobs since inq: ${sboData.mobsSinceInq}")
                         }
                     }
                 }
@@ -446,12 +446,12 @@ object PartyCommands {
 
                         // Also send in party chat in case someone is curious what diana party commands SBO has without having SBO
                         val commands = helpCommands.joinToString(",")
-                        Chat.command("pc Available diana party commands: $commands")
+                        Chat.pc("Available diana party commands: $commands")
                     }
                 }
                 "!version" -> {
                     sleep(200) {
-                        Chat.command("pc SBO version: ${SBOKotlin.version} | Minecraft version: ${SBOKotlin.mcVersion}")
+                        Chat.pc("SBO version: ${SBOKotlin.version} | Minecraft version: ${SBOKotlin.mcVersion}")
                     }
                 }
             }

--- a/src/main/kotlin/net/sbo/mod/partyfinder/PartyFinderManager.kt
+++ b/src/main/kotlin/net/sbo/mod/partyfinder/PartyFinderManager.kt
@@ -251,7 +251,7 @@ object PartyFinderManager {
 
                     Chat.chat("§6[SBO] §eParty created successfully! Time taken: ${timeTaken}ms")
 
-                    if (isInParty) Chat.command("pc [SBO] Party now in queue.")
+                    if (isInParty) Chat.pc("[SBO] Party now in queue.")
                 } else {
                     val errorMessage = response.error ?: "Unknown error"
                     Chat.chat("§6[SBO] §4Failed to create party: ${errorMessage.replace("&", "§")}")

--- a/src/main/kotlin/net/sbo/mod/settings/categories/General.kt
+++ b/src/main/kotlin/net/sbo/mod/settings/categories/General.kt
@@ -51,4 +51,9 @@ object General : CategoryKt("General") {
         this.name = Literal("Waypoints From Chat")
         this.description = Literal("Creates waypoints from chat messages (format: x: 20, y: 60, z: 80)")
     }
+
+    var assumeMuted by boolean(false) {
+        this.name = Literal("Assume Muted")
+        this.description = Literal("Assumes you are muted and instead of running /pc to send mod messages always prefers to send them client-side to yourself only.")
+    }
 }

--- a/src/main/kotlin/net/sbo/mod/utils/chat/Chat.kt
+++ b/src/main/kotlin/net/sbo/mod/utils/chat/Chat.kt
@@ -7,8 +7,29 @@ import net.minecraft.network.chat.HoverEvent
 import net.minecraft.network.chat.Style
 import net.minecraft.ChatFormatting
 import net.sbo.mod.utils.events.ClickActionManager
+import net.sbo.mod.settings.categories.General
 
 object Chat {
+
+    /**
+     * Sends a text to party chat via the /pc command, or
+     * sends it locally if the user opted-in to the "Assume Muted"
+     * option for accessibility, so that they can still see the message
+     * and/or possibly copy and share the message in another platform such as Discord.
+     *
+     * @param text The text to send to party chat if possible or otherwise locally.
+     */
+    fun pc(text: String) {
+        if (General.assumeMuted) {
+            // User is muted (or we assume it bc of the opt-in setting thats false by default)
+            // trying send message will show up a huge output about the remaining mute time,
+            // server rules and all that yapping with no other output about the text we want
+            // to send, so send locally instead via the chat method. We can have color since it's regular chat.
+            Chat.chat("§6[SBO] §e${text}")
+        } else {
+            Chat.command("pc ${text}")
+        }
+    }
 
     /**
      * Sends a command to the server.

--- a/src/main/kotlin/net/sbo/mod/utils/waypoint/WaypointManager.kt
+++ b/src/main/kotlin/net/sbo/mod/utils/waypoint/WaypointManager.kt
@@ -52,9 +52,9 @@ object WaypointManager {
         Register.command("sbosendping") { args ->
             val playerPos = Player.getLastPosition()
             if (args.isNotEmpty()) {
-                Chat.command("pc x: ${playerPos.x.roundToInt()}, y: ${playerPos.y.roundToInt() - 1}, z: ${playerPos.z.roundToInt()} | ${args.joinToString(" ")}")
+                Chat.pc("x: ${playerPos.x.roundToInt()}, y: ${playerPos.y.roundToInt() - 1}, z: ${playerPos.z.roundToInt()} | ${args.joinToString(" ")}")
             } else
-                Chat.command("pc x: ${playerPos.x.roundToInt()}, y: ${playerPos.y.roundToInt() - 1}, z: ${playerPos.z.roundToInt()}")
+                Chat.pc("x: ${playerPos.x.roundToInt()}, y: ${playerPos.y.roundToInt() - 1}, z: ${playerPos.z.roundToInt()}")
         }
 
         Register.onChatMessage(


### PR DESCRIPTION
Also centralizes the duplicate "pc <message>" text to a single method in the Chat class to reduce duplication.

This should help accessibility for muted users in the short term till an alternative solution is found.