### PR TITLE
Fix minotaur being referenced as minos

### DIFF
--- a/src/main/kotlin/net/sbo/mod/overlays/DianaStats.kt
+++ b/src/main/kotlin/net/sbo/mod/overlays/DianaStats.kt
@@ -30,7 +30,7 @@ object DianaStats : DirtyFlushableOverlay() {
             OverlayTextLine("$GRAY - ${LIGHT_PURPLE}Mobs since Sphinx: $AQUA${sboData.mobsSinceSphinx}"),
             OverlayTextLine("$GRAY - ${DARK_PURPLE}Sphinxes since Food: $AQUA${sboData.sphinxSinceFood}$GRAY, ${DARK_PURPLE}since §7[§bLS§7]: $AQUA${sboData.sphinxSinceLsFood}"),
             OverlayTextLine("$GRAY - ${DARK_PURPLE}Champs since Relic: $AQUA${Helper.formatNumber(sboData.champsSinceRelic, true)}"),
-            OverlayTextLine("$GRAY - ${GOLD}Minos since Stick: $AQUA${Helper.formatNumber(sboData.minotaursSinceStick, true)}"),
+            OverlayTextLine("$GRAY - ${GOLD}Minotaurs since Stick: $AQUA${Helper.formatNumber(sboData.minotaursSinceStick, true)}"),
         )
     }
 }


### PR DESCRIPTION
In the since display, minotaurs since stick is referred to as "Minos since stick". It could be confusing due to nearly all diana mobs name starting with "minos".