### PR TITLE
Fix empty magic find text

### DIFF
--- a/src/main/kotlin/net/sbo/mod/utils/Helper.kt
+++ b/src/main/kotlin/net/sbo/mod/utils/Helper.kt
@@ -457,6 +457,7 @@ object Helper {
             .replace("{percentage}", "%.2f".format(info.percentage) + "%")
             .replace("{mf}", if (magicFind > 0) "$magicFind" else "")
             .replace('&', '§')
+            .replace("+ ✯ Magic Find ", "") // prevent nonsense magic find when hypixel doesn't put it into the message (mob killed by someone else)
 
         return Pair(true, resultText)
     }


### PR DESCRIPTION
Will only work for the default custom chim message or if the user uses "+{mf} ✯ Magic Find " exactly, but better than nothing.

This is does not affect the default announcer if you have custom message options disabled.