### PR TITLE
Fix cocooned mobs not counting towards tracker and achievements

### DIFF
--- a/src/main/kotlin/net/sbo/mod/diana/DianaMobDetect.kt
+++ b/src/main/kotlin/net/sbo/mod/diana/DianaMobDetect.kt
@@ -11,6 +11,7 @@ import net.sbo.mod.SBOKotlin.mc
 import net.sbo.mod.settings.categories.Customization
 import net.sbo.mod.settings.categories.Diana
 import net.sbo.mod.utils.Helper
+import net.sbo.mod.utils.Helper.removeFormatting
 import net.sbo.mod.utils.Helper.getSecondsPassed
 import net.sbo.mod.utils.Helper.lastCocoon
 import net.sbo.mod.utils.Helper.lastInqDeath
@@ -64,8 +65,6 @@ object DianaMobDetect {
         }
     }
 
-
-
     private fun parseHealthFromName(name: String): Double? =
         healthRegex.find(name)?.groupValues?.get(1)?.let { raw ->
             when {
@@ -79,6 +78,14 @@ object DianaMobDetect {
 
     private fun shouldAlertForMob(name: String) = RareDianaMob.fromName(name) != null && Diana.hpAlert > 0.0
 
+    val prefixes = listOf("Empyrean", "Exalted", "Runic", "Venerable", "Stalwart", "Blessed")
+
+    private fun fallbackRemovePrefix(mobName: String): String {
+        return prefixes.firstOrNull { mobName.startsWith("$it ") }
+            ?.let { mobName.removePrefix("$it ") }
+            ?: mobName
+    }
+
     fun init() {
         mobHpOverlay.init()
         noShurikenOverlay.init()
@@ -86,11 +93,24 @@ object DianaMobDetect {
             Regex("^§a§lCAUGHT!.*?You cocooned a (?<name>.+?)!.*$")
         ) { _, matchResult ->
             val name = matchResult.groups["name"]?.value ?: return@onChatMessage
-            val rare = RareDianaMob.fromName(name)
+            val cleanName = name.removeFormatting()
+
+            val rare = RareDianaMob.fromName(cleanName)
+            val displayName = if (rare != null) rare.display else fallbackRemovePrefix(cleanName) // rare.display returns already without prefix; otherwise the fallback would remove the prefix
+
+            // Check if cocooned mob is a diana mob by checking if its either a rare mob or has the diana mob prefix like empyrean
+            if (rare != null || prefixes.firstOrNull { cleanName.startsWith("$it ")} != null) {
+                // We need this check otherwise it could track a mob that you cocooned but someone else spawned.
+                if (DianaTracker.lastSpawnedMob == displayName) {
+                    // Count as a new spawned mob, exactly as if it was received as spawned by a regular burrow, so that achievements and mob tracking work.
+                    // This will give an error in chat if we pass a string that matches no mob name in the tracker handler code.
+                    DianaTracker.trackMobOnSpawnAndSave(displayName, fromCocoon = true)
+                }
+            }
 
             if (rare != null) {
                 // Cocooned a rare mob if rare != null
-                announceCocoon(DetectionType.CHAT_MESSAGE, rare.display)
+                announceCocoon(DetectionType.CHAT_MESSAGE, displayName)
             }
         }
         Register.onTick(1) {

--- a/src/main/kotlin/net/sbo/mod/diana/DianaTracker.kt
+++ b/src/main/kotlin/net/sbo/mod/diana/DianaTracker.kt
@@ -49,6 +49,8 @@ object DianaTracker {
     private var lootAnnouncerBool: Boolean = false
     private var allowScavTracking: Boolean = true
 
+    var lastSpawnedMob: String? = null
+
     fun init() {
         Register.command("sboresetsession") {
             DianaLoot.resetSession()
@@ -165,139 +167,152 @@ object DianaTracker {
         Register.onChatMessageCancable(Pattern.compile("(.*?) §eYou dug (.*?)§2(.*?)§e!(.*?)$", Pattern.DOTALL)) { message, matchResult ->
             val mob = matchResult.group(3)
             if (isMobOnCooldown.getOrDefault(mob, false)) return@onChatMessageCancable !QOL.dianaMessageHider
-            when (mob) {
-                "King Minos" -> {
-                    DianaMobDetect.onRareSpawn(mob)
-                    trackMob(mob, 1)
 
-                    sboData.kingSinceWool += 1
-                    if (Diana.sendSinceMessage) {
-                        val timeSinceKing = Helper.formatTime(dianaTrackerTotal.items.TIME - sboData.lastKingDate)
-                        if (sboData.lastKingDate != 0L) {
-                            Chat.chat("§6[SBO] §eTook §c${sboData.mobsSinceKing} §eMobs and §c$timeSinceKing §eto get a King!")
-                        } else {
-                            Chat.chat("§6[SBO] §eTook §c${sboData.mobsSinceKing} §eMobs to get a King!")
-                        }
-                    }
-                    sboData.lastKingDate = dianaTrackerTotal.items.TIME
+            trackMobOnSpawnAndSave(mob)
 
-                    if (sboData.b2bKing && sboData.mobsSinceKing == 1) {
-                        Chat.chat("§6[SBO] §cb2b2b King Minos!")
-                        unlockAchievement(117) // b2b2b king
-                    }
-                    if (sboData.mobsSinceKing == 1 && !sboData.b2bKing) {
-                        Chat.chat("§6[SBO] §cb2b King Minos!")
-                        unlockAchievement(87) // b2b king
-                        sboData.b2bKing = true
-                    }
-                    if (sboData.kingSinceWool >= 2) sboData.b2bWool = false
-                    if (sboData.kingSinceWool >= 2) sboData.b2bWoolLs = false
-                    sboData.mobsSinceKing = 0
-                }
-                "Manticore" -> {
-                    DianaMobDetect.onRareSpawn(mob)
-                    trackMob(mob, 1)
-
-                    sboData.mantiSinceCore += 1
-                    sboData.mantiSinceStinger += 1
-
-                    if (Diana.sendSinceMessage) {
-                        val timeSinceManti = Helper.formatTime(dianaTrackerTotal.items.TIME - sboData.lastMantiDate)
-                        if (sboData.lastMantiDate != 0L) {
-                            Chat.chat("§6[SBO] §eTook §c${sboData.mobsSinceManti} §eMobs and §c$timeSinceManti §eto get a Manticore!")
-                        } else {
-                            Chat.chat("§6[SBO] §eTook §c${sboData.mobsSinceManti} §eMobs to get a Manticore!")
-                        }
-                    }
-                    sboData.lastMantiDate = dianaTrackerTotal.items.TIME
-
-                    if (sboData.b2bManti && sboData.mobsSinceManti == 1) {
-                        Chat.chat("§6[SBO] §cb2b2b Manticore!")
-                        unlockAchievement(110)
-                    }
-                    if (sboData.mobsSinceManti == 1 && !sboData.b2bManti) {
-                        Chat.chat("§6[SBO] §cb2b Manticore!")
-                        unlockAchievement(109) // b2b manti
-                        sboData.b2bManti = true
-                    }
-                    if (sboData.mantiSinceCore >= 2) sboData.b2bCore = false
-                    if (sboData.mantiSinceStinger >= 2) sboData.b2bStinger = false
-                    sboData.mobsSinceManti = 0
-                }
-                "Minos Inquisitor" -> {
-                    DianaMobDetect.onRareSpawn(mob)
-                    trackMob(mob, 1)
-
-                    sboData.inqsSinceChim += 1
-
-                    if (Diana.sendSinceMessage) {
-                        val timeSinceInq = Helper.formatTime(dianaTrackerTotal.items.TIME - sboData.lastInqDate)
-                        if (sboData.lastInqDate != 0L) {
-                            Chat.chat("§6[SBO] §eTook §c${sboData.mobsSinceInq} §eMobs and §c$timeSinceInq §eto get an Inquis!")
-                        } else {
-                            Chat.chat("§6[SBO] §eTook §c${sboData.mobsSinceInq} §eMobs to get an Inquis!")
-                        }
-                    }
-                    sboData.lastInqDate = dianaTrackerTotal.items.TIME
-
-                    if (sboData.b2bInq && sboData.mobsSinceInq == 1) {
-                        Chat.chat("§6[SBO] §cb2b2b Inquisitor!")
-                        unlockAchievement(7) // b2b2b inq
-                    }
-                    if (sboData.mobsSinceInq == 1 && !sboData.b2bInq) {
-                        Chat.chat("§6[SBO] §cb2b Inquisitor!")
-                        unlockAchievement(6) // b2b inq
-                        sboData.b2bInq = true
-                    }
-                    if (sboData.inqsSinceChim >= 2) sboData.b2bChim = false
-                    sboData.mobsSinceInq = 0
-                }
-                "Sphinx" -> {
-                    DianaMobDetect.onRareSpawn(mob)
-                    trackMob(mob, 1)
-
-                    sboData.sphinxSinceFood += 1
-
-                    if (Diana.sendSinceMessage) {
-                        val timeSinceSphinx = Helper.formatTime(dianaTrackerTotal.items.TIME - sboData.lastSphinxDate)
-                        if (sboData.lastSphinxDate != 0L) {
-                            Chat.chat("§6[SBO] §eTook §c${sboData.mobsSinceSphinx} §eMobs and §c$timeSinceSphinx §eto get a Sphinx!")
-                        } else {
-                            Chat.chat("§6[SBO] §eTook §c${sboData.mobsSinceSphinx} §eMobs to get a Sphinx!")
-                        }
-                    }
-                    sboData.lastSphinxDate = dianaTrackerTotal.items.TIME
-
-                    if (sboData.b2bSphinx && sboData.mobsSinceSphinx == 1) {
-                        Chat.chat("§6[SBO] §cb2b2b Sphinx!")
-                        unlockAchievement(108)
-                    }
-                    if (sboData.mobsSinceSphinx == 1 && !sboData.b2bSphinx) {
-                        Chat.chat("§6[SBO] §cb2b Sphinx!")
-                        unlockAchievement(107)
-                        sboData.b2bSphinx = true
-                    }
-                    if (sboData.sphinxSinceFood >= 2) sboData.b2bFood = false
-                    sboData.mobsSinceSphinx = 0
-                }
-                "Minos Champion" -> {
-                    sboData.champsSinceRelic += 1
-                    trackMob(mob, 1)
-                }
-                "Minotaur" -> {
-                    sboData.minotaursSinceStick += 1
-                    if (sboData.minotaursSinceStick >= 2) sboData.b2bStick = false
-                    trackMob(mob, 1)
-                }
-                "Gaia Construct" -> trackMob(mob, 1)
-                "Harpy" -> trackMob(mob, 1)
-                "Cretan Bull" -> trackMob(mob, 1)
-                "Stranded Nymph" -> trackMob(mob, 1)
-                "Siamese Lynxes" -> trackMob(mob, 1)
-                "Minos Hunter" -> trackMob(mob, 1)
-            }
-            SboDataObject.save("SboData")
             !QOL.dianaMessageHider
+        }
+    }
+
+    fun trackMobOnSpawnAndSave(mob: String, fromCocoon: Boolean = false) {
+        onMobSpawn(mob, fromCocoon)
+        SboDataObject.save("SboData")
+    }
+
+    fun onMobSpawn(mob: String, fromCocoon: Boolean = false) {
+        lastSpawnedMob = mob
+        if (fromCocoon) Chat.chat("§6[SBO] §eTracking cocooned mob: ${mob}")
+        when (mob) {
+            "King Minos" -> {
+                DianaMobDetect.onRareSpawn(mob)
+                trackMob(mob, 1)
+
+                sboData.kingSinceWool += 1
+                if (Diana.sendSinceMessage) {
+                    val timeSinceKing = Helper.formatTime(dianaTrackerTotal.items.TIME - sboData.lastKingDate)
+                    if (sboData.lastKingDate != 0L) {
+                        Chat.chat("§6[SBO] §eTook §c${sboData.mobsSinceKing} §eMobs and §c$timeSinceKing §eto get a King!")
+                    } else {
+                        Chat.chat("§6[SBO] §eTook §c${sboData.mobsSinceKing} §eMobs to get a King!")
+                    }
+                }
+                sboData.lastKingDate = dianaTrackerTotal.items.TIME
+
+                if (sboData.b2bKing && sboData.mobsSinceKing == 1) {
+                    Chat.chat("§6[SBO] §cb2b2b King Minos!")
+                    unlockAchievement(117) // b2b2b king
+                }
+                if (sboData.mobsSinceKing == 1 && !sboData.b2bKing) {
+                    Chat.chat("§6[SBO] §cb2b King Minos!")
+                    unlockAchievement(87) // b2b king
+                    sboData.b2bKing = true
+                }
+                if (sboData.kingSinceWool >= 2) sboData.b2bWool = false
+                if (sboData.kingSinceWool >= 2) sboData.b2bWoolLs = false
+                sboData.mobsSinceKing = 0
+            }
+            "Manticore" -> {
+                DianaMobDetect.onRareSpawn(mob)
+                trackMob(mob, 1)
+
+                sboData.mantiSinceCore += 1
+                sboData.mantiSinceStinger += 1
+
+                if (Diana.sendSinceMessage) {
+                    val timeSinceManti = Helper.formatTime(dianaTrackerTotal.items.TIME - sboData.lastMantiDate)
+                    if (sboData.lastMantiDate != 0L) {
+                        Chat.chat("§6[SBO] §eTook §c${sboData.mobsSinceManti} §eMobs and §c$timeSinceManti §eto get a Manticore!")
+                    } else {
+                        Chat.chat("§6[SBO] §eTook §c${sboData.mobsSinceManti} §eMobs to get a Manticore!")
+                    }
+                }
+                sboData.lastMantiDate = dianaTrackerTotal.items.TIME
+
+                if (sboData.b2bManti && sboData.mobsSinceManti == 1) {
+                    Chat.chat("§6[SBO] §cb2b2b Manticore!")
+                    unlockAchievement(110)
+                }
+                if (sboData.mobsSinceManti == 1 && !sboData.b2bManti) {
+                    Chat.chat("§6[SBO] §cb2b Manticore!")
+                    unlockAchievement(109) // b2b manti
+                    sboData.b2bManti = true
+                }
+                if (sboData.mantiSinceCore >= 2) sboData.b2bCore = false
+                if (sboData.mantiSinceStinger >= 2) sboData.b2bStinger = false
+                sboData.mobsSinceManti = 0
+            }
+            "Minos Inquisitor" -> {
+                DianaMobDetect.onRareSpawn(mob)
+                trackMob(mob, 1)
+
+                sboData.inqsSinceChim += 1
+
+                if (Diana.sendSinceMessage) {
+                    val timeSinceInq = Helper.formatTime(dianaTrackerTotal.items.TIME - sboData.lastInqDate)
+                    if (sboData.lastInqDate != 0L) {
+                        Chat.chat("§6[SBO] §eTook §c${sboData.mobsSinceInq} §eMobs and §c$timeSinceInq §eto get an Inquis!")
+                    } else {
+                        Chat.chat("§6[SBO] §eTook §c${sboData.mobsSinceInq} §eMobs to get an Inquis!")
+                    }
+                }
+                sboData.lastInqDate = dianaTrackerTotal.items.TIME
+
+                if (sboData.b2bInq && sboData.mobsSinceInq == 1) {
+                    Chat.chat("§6[SBO] §cb2b2b Inquisitor!")
+                    unlockAchievement(7) // b2b2b inq
+                }
+                if (sboData.mobsSinceInq == 1 && !sboData.b2bInq) {
+                    Chat.chat("§6[SBO] §cb2b Inquisitor!")
+                    unlockAchievement(6) // b2b inq
+                    sboData.b2bInq = true
+                }
+                if (sboData.inqsSinceChim >= 2) sboData.b2bChim = false
+                sboData.mobsSinceInq = 0
+            }
+            "Sphinx" -> {
+                DianaMobDetect.onRareSpawn(mob)
+                trackMob(mob, 1)
+
+                sboData.sphinxSinceFood += 1
+
+                if (Diana.sendSinceMessage) {
+                    val timeSinceSphinx = Helper.formatTime(dianaTrackerTotal.items.TIME - sboData.lastSphinxDate)
+                    if (sboData.lastSphinxDate != 0L) {
+                        Chat.chat("§6[SBO] §eTook §c${sboData.mobsSinceSphinx} §eMobs and §c$timeSinceSphinx §eto get a Sphinx!")
+                    } else {
+                        Chat.chat("§6[SBO] §eTook §c${sboData.mobsSinceSphinx} §eMobs to get a Sphinx!")
+                    }
+                }
+                sboData.lastSphinxDate = dianaTrackerTotal.items.TIME
+
+                if (sboData.b2bSphinx && sboData.mobsSinceSphinx == 1) {
+                    Chat.chat("§6[SBO] §cb2b2b Sphinx!")
+                    unlockAchievement(108)
+                }
+                if (sboData.mobsSinceSphinx == 1 && !sboData.b2bSphinx) {
+                    Chat.chat("§6[SBO] §cb2b Sphinx!")
+                    unlockAchievement(107)
+                    sboData.b2bSphinx = true
+                }
+                if (sboData.sphinxSinceFood >= 2) sboData.b2bFood = false
+                sboData.mobsSinceSphinx = 0
+            }
+            "Minos Champion" -> {
+                sboData.champsSinceRelic += 1
+                trackMob(mob, 1)
+            }
+            "Minotaur" -> {
+                sboData.minotaursSinceStick += 1
+                if (sboData.minotaursSinceStick >= 2) sboData.b2bStick = false
+                trackMob(mob, 1)
+            }
+            "Gaia Construct" -> trackMob(mob, 1)
+            "Harpy" -> trackMob(mob, 1)
+            "Cretan Bull" -> trackMob(mob, 1)
+            "Stranded Nymph" -> trackMob(mob, 1)
+            "Siamese Lynxes" -> trackMob(mob, 1)
+            "Minos Hunter" -> trackMob(mob, 1)
+            else -> Chat.chat("§6[SBO] §cUnknown diana mob spawned: ${mob}. Please report this.")
         }
     }
 


### PR DESCRIPTION
Best-effort fix:
 - If you spawn and cocoon your own mob; will add to the mob spawn amount counter and give the relevant b2b spawn or drop achievements.
 - If you spawn but someone else cocoons your mob; will not add to the tracker and will not give the relevant b2b spawn or drop achievements (not sure if we can fix this in any way).
 - If someone else spawns and you cocoon it; will not add to the tracker (as intended) since lastSpawnedMob would be different for you, unless a rare scenario happens where lastMobSpawned is same as the other guy's.

I'm not sure if we can do any better than this, so this a best-effort fix.