### PR TITLE
Rename focused color and improve closest guess selection

### DIFF
--- a/src/main/kotlin/net/sbo/mod/settings/categories/Customization.kt
+++ b/src/main/kotlin/net/sbo/mod/settings/categories/Customization.kt
@@ -48,10 +48,10 @@ object Customization : CategoryKt("Customization") {
         this.allowAlpha = true
     }
     
-    var focusedColor by color(
+    var closestColor by color(
         Color(0.6f, 0.2f, 0.8f).rgb) {
-        this.name = Literal("Focused Color")
-        this.description = Literal("Pick a color for your focused guess")
+        this.name = Literal("Closest Color")
+        this.description = Literal("Pick a color for your closest burrow")
         this.allowAlpha = true
     }
 

--- a/src/main/kotlin/net/sbo/mod/utils/render/RenderUtils3D.kt
+++ b/src/main/kotlin/net/sbo/mod/utils/render/RenderUtils3D.kt
@@ -39,8 +39,7 @@ object RenderUtils3D {
         throughWalls: Boolean,
         drawLine: Boolean,
         lineWidth: Float,
-        renderBeam: Boolean,
-        lineColor: FloatArray? = null
+        renderBeam: Boolean
     ) {
         drawFilledBox(
             context,
@@ -54,7 +53,7 @@ object RenderUtils3D {
             drawLineFromCursor(
                 context,
                 pos,
-                lineColor ?: colorComponents,
+                colorComponents,
                 lineWidth,
                 throughWalls,
                 alpha

--- a/src/main/kotlin/net/sbo/mod/utils/render/RenderUtils3D.kt
+++ b/src/main/kotlin/net/sbo/mod/utils/render/RenderUtils3D.kt
@@ -39,7 +39,8 @@ object RenderUtils3D {
         throughWalls: Boolean,
         drawLine: Boolean,
         lineWidth: Float,
-        renderBeam: Boolean
+        renderBeam: Boolean,
+        lineColor: FloatArray? = null
     ) {
         drawFilledBox(
             context,
@@ -53,7 +54,7 @@ object RenderUtils3D {
             drawLineFromCursor(
                 context,
                 pos,
-                colorComponents,
+                lineColor ?: colorComponents,
                 lineWidth,
                 throughWalls,
                 alpha

--- a/src/main/kotlin/net/sbo/mod/utils/waypoint/Waypoint.kt
+++ b/src/main/kotlin/net/sbo/mod/utils/waypoint/Waypoint.kt
@@ -53,14 +53,15 @@ class Waypoint(
     var distanceText: String = ""
     var formattedText: String = ""
     var warp: String? = null
+    var isClosest = false
 
     fun distanceToPlayer(): Double {
         val playerPos = Player.getLastPosition()
         return sqrt((playerPos.x - this.pos.x).pow(2) + (playerPos.y - this.pos.y).pow(2) + (playerPos.z - this.pos.z).pow(2))
     }
 
-    private fun setWarpText(isBestGuess: Boolean = true) {
-        if (isBestGuess) {
+    private fun setWarpText() {
+        if (isClosest) {
             this.warp = WaypointManager.getClosestWarp(this.pos)
             this.formattedText = this.warp?.let {
                 "$text§7 (warp $it)${this.distanceText}"
@@ -72,16 +73,15 @@ class Waypoint(
 
     fun format(
         inqWaypoints: List<Waypoint>,
-        closestBurrowDistance: Double,
-        isBestGuess: Boolean = false
+        closestBurrowDistance: Double
     ) {
         this.distanceRaw = distanceToPlayer()
         this.distanceText = if (distance) " §b[${distanceRaw.roundToInt()}m]" else ""
 
         when (this.type) {
             "guess", "arrow" -> {
-                this.color = Color(if (WaypointManager.getBestGuess() == this) Customization.closestColor else Customization.guessColor)
-                this.line = Diana.guessLine && closestBurrowDistance > 60 && inqWaypoints.isEmpty() && isBestGuess
+                this.color = Color(if (isClosest) Customization.closestColor else Customization.guessColor)
+                this.line = Diana.guessLine && inqWaypoints.isEmpty() && isClosest
                 this.r = color.red / 255f
                 this.g = color.green / 255f
                 this.b = color.blue / 255f
@@ -90,7 +90,11 @@ class Waypoint(
                 WaypointManager.waypointExists("burrow", this.pos).let { (exists, wp) ->
                     if (exists && wp != null) this.hidden = wp.distanceToPlayer() < 60
                 }
-                setWarpText(isBestGuess)
+                setWarpText()
+            }
+            "burrow" -> {
+                this.line = Diana.guessLine && inqWaypoints.isEmpty() && isClosest
+                setWarpText()
             }
             "rareMob" -> {
                 if (inqWaypoints.lastOrNull() == this) {
@@ -115,10 +119,6 @@ class Waypoint(
         return this
     }
 
-    private fun extractColorComponents(color: Color): FloatArray {
-        return floatArrayOf(color.red / 255f, color.green / 255f, color.blue / 255f)
-    }
-
     fun render(context: WorldRenderContext) {
         if (!this.formatted || this.hidden) return
         if (this.type == "guess" && this.distanceRaw <= Diana.removeGuessDistance) return
@@ -133,8 +133,7 @@ class Waypoint(
             true,
             this.line,
             Diana.dianaLineWidth.toFloat(),
-            this.beam,
-            lineColor = if (WaypointManager.getBestGuess() == this) extractColorComponents(Color(Customization.closestColor)) else null
+            this.beam
         )
     }
 }

--- a/src/main/kotlin/net/sbo/mod/utils/waypoint/Waypoint.kt
+++ b/src/main/kotlin/net/sbo/mod/utils/waypoint/Waypoint.kt
@@ -80,7 +80,7 @@ class Waypoint(
 
         when (this.type) {
             "guess", "arrow" -> {
-                this.color = Color(Customization.guessColor)
+                this.color = Color(if (WaypointManager.getBestGuess() == this) Customization.focusedColor else Customization.guessColor)
                 this.line = Diana.guessLine && closestBurrowDistance > 60 && inqWaypoints.isEmpty() && isBestGuess
                 this.r = color.red / 255f
                 this.g = color.green / 255f
@@ -115,6 +115,10 @@ class Waypoint(
         return this
     }
 
+    private fun extractColorComponents(color: Color): FloatArray {
+        return floatArrayOf(color.red / 255, color.green / 255, color.blue / 255)
+    }
+
     fun render(context: WorldRenderContext) {
         if (!this.formatted || this.hidden) return
         if (this.type == "guess" && this.distanceRaw <= Diana.removeGuessDistance) return
@@ -129,7 +133,8 @@ class Waypoint(
             true,
             this.line,
             Diana.dianaLineWidth.toFloat(),
-            this.beam
+            this.beam,
+            lineColor = if (WaypointManager.getBestGuess() == this) extractColorComponents(Color(Customization.focusedColor)) else null
         )
     }
 }

--- a/src/main/kotlin/net/sbo/mod/utils/waypoint/Waypoint.kt
+++ b/src/main/kotlin/net/sbo/mod/utils/waypoint/Waypoint.kt
@@ -80,7 +80,7 @@ class Waypoint(
 
         when (this.type) {
             "guess", "arrow" -> {
-                this.color = Color(if (WaypointManager.getBestGuess() == this) Customization.focusedColor else Customization.guessColor)
+                this.color = Color(if (WaypointManager.getBestGuess() == this) Customization.closestColor else Customization.guessColor)
                 this.line = Diana.guessLine && closestBurrowDistance > 60 && inqWaypoints.isEmpty() && isBestGuess
                 this.r = color.red / 255f
                 this.g = color.green / 255f
@@ -116,7 +116,7 @@ class Waypoint(
     }
 
     private fun extractColorComponents(color: Color): FloatArray {
-        return floatArrayOf(color.red / 255, color.green / 255, color.blue / 255)
+        return floatArrayOf(color.red / 255f, color.green / 255f, color.blue / 255f)
     }
 
     fun render(context: WorldRenderContext) {
@@ -134,7 +134,7 @@ class Waypoint(
             this.line,
             Diana.dianaLineWidth.toFloat(),
             this.beam,
-            lineColor = if (WaypointManager.getBestGuess() == this) extractColorComponents(Color(Customization.focusedColor)) else null
+            lineColor = if (WaypointManager.getBestGuess() == this) extractColorComponents(Color(Customization.closestColor)) else null
         )
     }
 }

--- a/src/main/kotlin/net/sbo/mod/utils/waypoint/Waypoint.kt
+++ b/src/main/kotlin/net/sbo/mod/utils/waypoint/Waypoint.kt
@@ -52,7 +52,6 @@ class Waypoint(
     var distanceRaw: Double = 0.0
     var distanceText: String = ""
     var formattedText: String = ""
-    var warp: String? = null
     var isClosest = false
 
     fun distanceToPlayer(): Double {
@@ -62,8 +61,7 @@ class Waypoint(
 
     private fun setWarpText() {
         if (isClosest) {
-            this.warp = WaypointManager.getClosestWarp(this.pos)
-            this.formattedText = this.warp?.let {
+            this.formattedText = WaypointManager.getClosestWarp(this.pos)?.let {
                 "$text§7 (warp $it)${this.distanceText}"
             } ?: "${this.text}${this.distanceText}"
         } else {
@@ -72,8 +70,7 @@ class Waypoint(
     }
 
     fun format(
-        inqWaypoints: List<Waypoint>,
-        closestBurrowDistance: Double
+        inqWaypoints: List<Waypoint>
     ) {
         this.distanceRaw = distanceToPlayer()
         this.distanceText = if (distance) " §b[${distanceRaw.roundToInt()}m]" else ""
@@ -97,10 +94,13 @@ class Waypoint(
                 setWarpText()
             }
             "rareMob" -> {
-                if (inqWaypoints.lastOrNull() == this) {
+                val newest = inqWaypoints.lastOrNull() == this
+
+                if (newest) {
                     setWarpText()
-                    this.line = Diana.inqLine
                 }
+
+                this.line = newest && Diana.inqLine
             }
             else -> {
                 this.formattedText = "$text$distanceText"

--- a/src/main/kotlin/net/sbo/mod/utils/waypoint/WaypointManager.kt
+++ b/src/main/kotlin/net/sbo/mod/utils/waypoint/WaypointManager.kt
@@ -151,7 +151,7 @@ object WaypointManager {
             val rareWp = getWaypointsOfType("rareMob")
             if (Diana.removeRareMobwaypoint) {
                 val rareMobsToRemove = rareWp
-                    .filter { waypoint -> waypoint.distanceToPlayer() < 3.0 }
+                    .filter { waypoint -> waypoint.distanceToPlayer() < 8.0 }
                     .toList()
                 rareMobsToRemove.forEach { waypoint -> removeWaypoint(waypoint) }
             }
@@ -284,13 +284,14 @@ object WaypointManager {
             guessWp = Waypoint("Guess", 100.0, 100.0, 100.0, 0.0f, 0.964f, 1.0f, 0,"guess")
         }
         guessWp?.apply {
-            val (exists, wp) = waypointExists("burrow", this.pos)
-            if (exists && wp != null) {
-                this.hidden = wp.distanceToPlayer() < 60
-            } else {
-                this.hidden = false
-            }
-            this.pos = pos
+            val position = pos
+            this.pos = position
+
+            val (exists, wp) = waypointExists("burrow", position)
+
+            // The shovel "precise" guess will be hidden if we have a known treasure/mob burrow at the same location as the guess and the player is 60 blocks nearby,
+            // or otherwise if the player is in the removeGuessDistance blocks of the guess (8 by default)
+            this.hidden = exists && wp != null && (wp.distanceToPlayer() < 60 || this.distanceToPlayer() < Diana.removeGuessDistance)
         }
     }
 
@@ -339,7 +340,6 @@ object WaypointManager {
 
     /**
      * Retrieves all waypoints of a specific type.
-     * Returns a COPY of the list to ensure thread safety during iteration.
      * @param type The type of waypoints to retrieve.
      * @return A list of waypoints of the specified type.
      */
@@ -347,12 +347,12 @@ object WaypointManager {
         return waypoints[type.lowercase()] ?: emptyList()
     }
 
-    private fun getBestGuess(): Waypoint? {
-        val preciseGuesses = getWaypointsOfType("guess")
-        val arrowGuesses = getWaypointsOfType("arrow")
-        val validPrecise = preciseGuesses.firstOrNull() { !it.hidden }
-        if (validPrecise != null) return  validPrecise
-        return arrowGuesses.minByOrNull { it.distanceToPlayer()  }
+    fun getBestGuess(): Waypoint? {
+        return (
+            getWaypointsOfType("burrow") +
+            getWaypointsOfType("arrow") +
+            getWaypointsOfType("guess").filter { !it.hidden }
+        ).minByOrNull { it.distanceToPlayer() }
     }
 
     /**

--- a/src/main/kotlin/net/sbo/mod/utils/waypoint/WaypointManager.kt
+++ b/src/main/kotlin/net/sbo/mod/utils/waypoint/WaypointManager.kt
@@ -22,9 +22,7 @@ import net.sbo.mod.utils.events.impl.game.WorldChangeEvent
 import net.sbo.mod.utils.math.SboVec
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.CopyOnWriteArrayList
-import kotlin.collections.iterator
 import kotlin.math.roundToInt
-import kotlin.text.get
 import net.fabricmc.fabric.api.client.rendering.v1.world.WorldRenderContext
 import net.fabricmc.fabric.api.client.rendering.v1.world.WorldRenderEvents
 import net.sbo.mod.utils.game.World
@@ -32,8 +30,7 @@ import net.sbo.mod.utils.game.World
 object WaypointManager {
     var guessWp: Waypoint? = null
     private val waypoints = ConcurrentHashMap<String, CopyOnWriteArrayList<Waypoint>>()
-    var closestBurrow: Pair<Waypoint?, Double> = null to 1000.0
-    var closestGuess: Pair<Waypoint?, Double> = null to 1000.0
+    var closestWaypoint: Pair<Waypoint?, Double> = null to 1000.0
     val rareMobs: List<String> = listOf(
         "minos inquisitor",
         "inquisitor",
@@ -59,7 +56,7 @@ object WaypointManager {
 
         Register.onChatMessage(
             Regex("^(?<channel>.*> )?(?<playerName>.+?)[§&]f: (?:[§&]r)?x: (?<x>[^ ,]+),? y: (?<y>[^ ,]+),? z: (?<z>[^ ,]+)(?<trailing>.*)$")
-        ) { message, match ->
+        ) { _, match ->
             val channel = match.groups["channel"]?.value ?: "Unknown"
             val player = match.groups["playerName"]?.value ?: "Unknown"
             val world = SBOKotlin.mc.level ?: return@onChatMessage
@@ -120,20 +117,10 @@ object WaypointManager {
 
         Register.onTick(1) { _ ->
             val playerPos = Player.getLastPosition()
-            closestBurrow = getClosestWaypointFrom(playerPos) ?: (null to 1000.0)
+            closestWaypoint = getClosestWaypointFrom(playerPos) ?: (null to 1000.0)
 
             val preciseGuesses = getWaypointsOfType("guess")
             val arrowGuesses = getWaypointsOfType("arrow")
-
-            val logicPrecise = preciseGuesses.minByOrNull { it.distanceToPlayer() }
-            val logicArrow = arrowGuesses.minByOrNull { it.distanceToPlayer() }
-            closestGuess = if (logicPrecise != null && logicArrow != null) {
-                if (logicPrecise.distanceToPlayer() < logicArrow.distanceToPlayer()) logicPrecise to logicPrecise.distanceToPlayer()
-                else logicArrow to logicArrow.distanceToPlayer()
-            } else {
-                val wp = logicPrecise ?: logicArrow
-                wp?.let { it to it.distanceToPlayer() } ?: (null to 1000.0)
-            }
 
             val bestGuessWp = getBestGuess()
 
@@ -166,13 +153,20 @@ object WaypointManager {
                 }
 
                 waypoint.isClosest = waypoint == bestGuessWp
-                waypoint.format(rareWp, closestBurrow.second)
+                waypoint.format(rareWp)
+            }
+
+            guessWp?.let { wp ->
+                if (wp.distanceToPlayer() < Diana.removeGuessDistance) {
+                    removeWaypoint(wp)
+                    guessWp = null
+                }
             }
 
             val shouldLegacyHaveLine = bestGuessWp != null && bestGuessWp.type == "guess" && !bestGuessWp.hidden
 
             guessWp?.isClosest = shouldLegacyHaveLine
-            guessWp?.format(rareWp, closestBurrow.second)
+            guessWp?.format(rareWp)
         }
 
         WorldRenderEvents.BEFORE_TRANSLUCENT.register(WaypointRenderer)
@@ -229,8 +223,8 @@ object WaypointManager {
      * @param waypoint The waypoint to remove.
      */
     fun removeWaypoint(waypoint: Waypoint) {
-        if (closestBurrow.first == waypoint) {
-            closestBurrow = null to 1000.0
+        if (closestWaypoint.first == waypoint) {
+            closestWaypoint = null to 1000.0
         }
         waypoints[waypoint.type.lowercase()]?.remove(waypoint)
     }
@@ -245,8 +239,8 @@ object WaypointManager {
         val waypoint = list?.find { it.pos == pos }
         if (waypoint != null) {
             list.remove(waypoint)
-            if (closestBurrow.first == waypoint) {
-                closestBurrow = null to 1000.0
+            if (closestWaypoint.first == waypoint) {
+                closestWaypoint = null to 1000.0
             }
         }
     }
@@ -287,10 +281,7 @@ object WaypointManager {
             this.pos = position
 
             val (exists, wp) = waypointExists("burrow", position)
-
-            // The shovel "precise" guess will be hidden if we have a known treasure/mob burrow at the same location as the guess and the player is 60 blocks nearby,
-            // or otherwise if the player is in the removeGuessDistance blocks of the guess (8 by default)
-            this.hidden = exists && wp != null && (wp.distanceToPlayer() < 60 || this.distanceToPlayer() < Diana.removeGuessDistance)
+            this.hidden = exists && wp != null && wp.distanceToPlayer() < 60
         }
     }
 
@@ -334,7 +325,7 @@ object WaypointManager {
      * @param action The action to apply to each waypoint.
      */
     fun forEachWaypoint(action: (Waypoint) -> Unit) {
-        waypoints.values.flatten().filterNotNull().forEach(action)
+        waypoints.values.flatten().forEach(action)
     }
 
     /**
@@ -377,6 +368,8 @@ object WaypointManager {
         var closestDistance = Double.MAX_VALUE
 
         for (waypoint in waypoints) {
+            if (waypoint.hidden) continue
+
             val distance = pos.distanceTo(waypoint.pos)
             if (distance < closestDistance) {
                 closestDistance = distance
@@ -415,7 +408,7 @@ object WaypointManager {
         }
 
         val condition1 = playerDistance > (closestDistance + Diana.warpDiff)
-        val condition2 = condition1 && (closestBurrow.second > 60 || getWaypointsOfType("rareMob").isNotEmpty())
+        val condition2 = condition1 && (closestWaypoint.second > 60 || getWaypointsOfType("rareMob").isNotEmpty())
 
         val condition = if (Diana.dontWarpIfBurrowClose) condition2 else condition1
 

--- a/src/main/kotlin/net/sbo/mod/utils/waypoint/WaypointManager.kt
+++ b/src/main/kotlin/net/sbo/mod/utils/waypoint/WaypointManager.kt
@@ -118,9 +118,9 @@ object WaypointManager {
             }
         }
 
-        Register.onTick(5) { _ ->
+        Register.onTick(1) { _ ->
             val playerPos = Player.getLastPosition()
-            closestBurrow = getClosestWaypoint(playerPos, "burrow") ?: (null to 1000.0)
+            closestBurrow = getClosestWaypointFrom(playerPos) ?: (null to 1000.0)
 
             val preciseGuesses = getWaypointsOfType("guess")
             val arrowGuesses = getWaypointsOfType("arrow")
@@ -146,7 +146,6 @@ object WaypointManager {
                             waypoint.pos.y < 60 ||
                             (waypoint.pos.x == posP.x && waypoint.pos.z == posP.z)
                 }
-                .toList()
 
             val rareWp = getWaypointsOfType("rareMob")
             if (Diana.removeRareMobwaypoint) {
@@ -163,17 +162,17 @@ object WaypointManager {
             this.forEachWaypoint { waypoint ->
                 if (waypoint.ttl > 0 && waypoint.creation + waypoint.ttl * 1000 < System.currentTimeMillis()) {
                     removeWaypoint(waypoint)
+                    return@forEachWaypoint
                 }
 
-                if (waypoint.type == "burrow") {
-                    waypoint.line = closestBurrow.first == waypoint && Diana.burrowLine && closestBurrow.second <= 60 && rareWp.isEmpty()
-                }
-
-                waypoint.format(rareWp, closestBurrow.second, waypoint == bestGuessWp)
+                waypoint.isClosest = waypoint == bestGuessWp
+                waypoint.format(rareWp, closestBurrow.second)
             }
 
             val shouldLegacyHaveLine = bestGuessWp != null && bestGuessWp.type == "guess" && !bestGuessWp.hidden
-            guessWp?.format(rareWp, closestBurrow.second, shouldLegacyHaveLine)
+
+            guessWp?.isClosest = shouldLegacyHaveLine
+            guessWp?.format(rareWp, closestBurrow.second)
         }
 
         WorldRenderEvents.BEFORE_TRANSLUCENT.register(WaypointRenderer)
@@ -349,10 +348,12 @@ object WaypointManager {
 
     fun getBestGuess(): Waypoint? {
         return (
-            getWaypointsOfType("burrow") +
-            getWaypointsOfType("arrow") +
-            getWaypointsOfType("guess").filter { !it.hidden }
-        ).minByOrNull { it.distanceToPlayer() }
+                getWaypointsOfType("burrow") +
+                getWaypointsOfType("arrow") +
+                getWaypointsOfType("guess")
+            )
+            .filter { !it.hidden }
+            .minByOrNull { it.distanceToPlayer() }
     }
 
     /**
@@ -362,13 +363,20 @@ object WaypointManager {
      * @return The closest waypoint of the specified type, or null if none are found.
      */
     fun getClosestWaypoint(pos: SboVec, type: String): Pair<Waypoint, Double>? {
-        val waypointsOfType = getWaypointsOfType(type)
-        if (waypointsOfType.isEmpty()) return null
+        return getClosestWaypointFrom(pos, getWaypointsOfType(type))
+    }
+
+    private fun getClosestWaypointFrom(pos: SboVec): Pair<Waypoint, Double>? {
+        return getClosestWaypointFrom(pos, getWaypointsOfType("burrow") + getWaypointsOfType("arrow") + getWaypointsOfType("guess"))
+    }
+
+    private fun getClosestWaypointFrom(pos: SboVec, waypoints: List<Waypoint>): Pair<Waypoint, Double>? {
+        if (waypoints.isEmpty()) return null
 
         var closestWaypoint: Waypoint? = null
         var closestDistance = Double.MAX_VALUE
 
-        for (waypoint in waypointsOfType) {
+        for (waypoint in waypoints) {
             val distance = pos.distanceTo(waypoint.pos)
             if (distance < closestDistance) {
                 closestDistance = distance


### PR DESCRIPTION
- Made it so waypoint's color is purple by default if it's the closest guess. Will not change the color if it's an already known burrow - e.g orange/red for treasure and mob burrows you already discovered will stay instead of becoming purple.

- Improved closest guess selection:
 - Before, it would always prioritize "precise" guesses, e.g those resulting from using shovel ability, even if there was way closer arrow or already known treasure/mob guesses. This resulted in making your rates worse whenever you used the shovel ability.
 - Before, it would never show an already known treasure/mob burrow as the closest, which would potentially warp or direct you to a further burrow with the line to closest burrow feature.

 Now it picks the actual closest guess out of all 3 types (burrow for already known, arrow for arrow guess, and guess for manual shovel guesses a.k.a the precise guesses only if it's not hidden)

- I've also made rare mob waypoints get removed when 8 blocks nearby instead of 3 as 3 seems little to low. Most starters seem to be confused why the rare mob waypoint goes away too late. This might be fixed by removing it on kill when the rare mob dies, but i figured removing when close is easier since it's just changing the 3 to 8. The "Remove Rare Mob Beam Distance" option is already set to 8 blocks by default but; that one just hides it when you are 8 blocks nearby instead of actually removing it, so it reappears when you get further, which is not optimal. The remove when near options will likely need to be refactored in future so that they are the actual source of truth for removing when close and they remove instead of hiding.

- I've also made it so instead of hiding the manual shovel waypoint, we now remove it when you are near it. The config option was changed with the "little default config tweaks" pr to be enabled by default and set to 8 blocks to remove any buggy precise guess waypoints; but i realzied it does not actually remove, just hides, which reappears when you get far again - is confusing, so i changed it.

- The guessWp?.apply block was also cleaned up to move the this.pos = pos assignment before the waypointExists check as it would use the previous guess location before.

Fixes #158