### PR TITLE
Refactor message sending

### DIFF
--- a/src/main/java/net/sbo/mod/mixin/ClientPacketListenerMixin.java
+++ b/src/main/java/net/sbo/mod/mixin/ClientPacketListenerMixin.java
@@ -1,0 +1,23 @@
+package net.sbo.mod.mixin;
+
+import net.minecraft.client.multiplayer.ClientPacketListener;
+import net.sbo.mod.utils.events.SBOEvent;
+import net.sbo.mod.utils.events.impl.game.SentMessageEvent;
+import net.sbo.mod.utils.events.impl.game.SentCommandEvent;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(ClientPacketListener.class)
+public class ClientPacketListenerMixin {
+    @Inject(method = "sendChat", at = @At("HEAD"))
+    private void sbo$onSendMessage(String content, CallbackInfo ci) {
+        SBOEvent.INSTANCE.emit(new SentMessageEvent(content));
+    }
+
+    @Inject(method = "sendCommand", at = @At("HEAD"))
+    private void sbo$onSendCommand(String command, CallbackInfo ci) {
+        SBOEvent.INSTANCE.emit(new SentCommandEvent(command));
+    }
+}

--- a/src/main/kotlin/net/sbo/mod/diana/DianaStats.kt
+++ b/src/main/kotlin/net/sbo/mod/diana/DianaStats.kt
@@ -98,7 +98,7 @@ object DianaStats {
             append("Relics: ${stats.relicsDropped} (${stats.relicDropRate})")
         }
 
-        Chat.command("pc $statsMessage")
+        Chat.pc(statsMessage)
     }
 
     data class PlayerStats(

--- a/src/main/kotlin/net/sbo/mod/general/PartyCommands.kt
+++ b/src/main/kotlin/net/sbo/mod/general/PartyCommands.kt
@@ -217,20 +217,18 @@ object PartyCommands {
                 "!time" -> if (settings.timeCommand) sendResponse(SimpleDateFormat("HH:mm:ss").format(Date()))
                 "!tps" -> if (settings.tpsCommand) sendResponse("${"%.2f".format(ServerStats.getTps())} TPS")
                 "!stats", "!stat" -> if (settings.dianaPartyCommands && secondArg?.lowercase() == user.lowercase()) {
-                    sleep(200) { DianaStats.sendPlayerStats(false) }
+                    DianaStats.sendPlayerStats(false)
                 }
                 "!totalstats", "!totalstat" -> if (settings.dianaPartyCommands && secondArg?.lowercase() == user.lowercase()) {
-                    sleep(200) { DianaStats.sendPlayerStats(true) }
+                    DianaStats.sendPlayerStats(true)
                 }
                 "!sessionstats", "!sessionstat" -> if (settings.dianaPartyCommands && secondArg?.lowercase() == user.lowercase()) {
-                    sleep(200) { DianaStats.sendPlayerStats(null) }
+                    DianaStats.sendPlayerStats(null)
                 }
                 "!version" -> sendResponse("SBO version: ${SBOKotlin.version} | Minecraft version: ${SBOKotlin.mcVersion}")
                 "!help" -> if (settings.dianaPartyCommands) {
-                    sleep(200) {
-                        help()
-                        Chat.pc("Available diana party commands: ${helpCommands.joinToString(",")}")
-                    }
+                    help()
+                    sendResponse("Available diana party commands: ${helpCommands.joinToString(",")}")
                 }
                 "!since" -> handleSinceCommand(secondArg)
                 else -> commandMap[command]?.let { cmd ->
@@ -255,9 +253,9 @@ object PartyCommands {
             "woolls", "lswool" -> "Kings since lootshare wool: ${sboData.kingSinceLsWool}"
             else -> "Mobs since inq: ${sboData.mobsSinceInq}"
         }
-        sleep(200) { Chat.pc(response) }
+        sendResponse(response)
     }
 
-    private fun sendCommand(cmd: String) = sleep(200) { Chat.command(cmd) }
-    private fun sendResponse(msg: String) = sleep(200) { Chat.pc(msg) }
+    private fun sendCommand(cmd: String) = Chat.command(cmd)
+    private fun sendResponse(msg: String) = Chat.pc(msg)
 }

--- a/src/main/kotlin/net/sbo/mod/utils/chat/Chat.kt
+++ b/src/main/kotlin/net/sbo/mod/utils/chat/Chat.kt
@@ -8,6 +8,7 @@ import net.minecraft.network.chat.Style
 import net.minecraft.ChatFormatting
 import net.sbo.mod.utils.events.ClickActionManager
 import net.sbo.mod.settings.categories.General
+import net.sbo.mod.utils.chat.ChatMessageQueue
 
 object Chat {
 
@@ -38,9 +39,9 @@ object Chat {
      */
     fun command(command: String) {
         if (!command.startsWith("/")) {
-            mc.player?.connection?.sendChat("/$command")
+            say("/$command")
         } else {
-            mc.player?.connection?.sendChat(command)
+            say(command)
         }
     }
 
@@ -69,7 +70,7 @@ object Chat {
      * @param message The message to send.
      */
     fun say(message: String) {
-        mc.connection?.sendChat(message)
+        ChatMessageQueue.queue(message)
     }
 
     /**

--- a/src/main/kotlin/net/sbo/mod/utils/chat/ChatMessageQueue.kt
+++ b/src/main/kotlin/net/sbo/mod/utils/chat/ChatMessageQueue.kt
@@ -37,7 +37,6 @@ object ChatMessageQueue {
 
     fun flush() {
         val player = mc.player ?: return
-        val connection = player.connection ?: return
 
         if (queue.isEmpty) {
             return
@@ -49,8 +48,8 @@ object ChatMessageQueue {
 
         val message = queue.dequeue()
 
-        if (!message.isNullOrEmpty()) {
-            connection.sendChat(message)
+        if (!message.isEmpty()) {
+            player.connection.sendChat(message)
         }
     }
 }

--- a/src/main/kotlin/net/sbo/mod/utils/chat/ChatMessageQueue.kt
+++ b/src/main/kotlin/net/sbo/mod/utils/chat/ChatMessageQueue.kt
@@ -1,0 +1,56 @@
+package net.sbo.mod.utils.chat
+
+import it.unimi.dsi.fastutil.objects.ObjectArrayFIFOQueue
+import net.sbo.mod.utils.events.Register
+import net.sbo.mod.SBOKotlin.mc
+import net.sbo.mod.utils.events.annotations.SboEvent
+import net.sbo.mod.utils.events.impl.game.SentMessageEvent
+import net.sbo.mod.utils.events.impl.game.SentCommandEvent
+
+object ChatMessageQueue {
+    private const val delayNanos = 200_000_000L
+    private val queue = ObjectArrayFIFOQueue<String>(1)
+
+    private var lastSentAt = 0L
+
+    init {
+         Register.onTick(1) { flush() }
+    }
+
+    @SboEvent
+    fun onMessageSent(event: SentMessageEvent) {
+        onCommandOrMessageSent()
+    }
+
+    @SboEvent
+    fun onCommandSent(event: SentCommandEvent) {
+        onCommandOrMessageSent()
+    }
+
+    fun onCommandOrMessageSent() {
+        lastSentAt = System.nanoTime()
+    }
+
+    fun queue(message: String) {
+        queue.enqueue(message)
+    }
+
+    fun flush() {
+        val player = mc.player ?: return
+        val connection = player.connection ?: return
+
+        if (queue.isEmpty) {
+            return
+        }
+
+        if (0L != lastSentAt && System.nanoTime() - lastSentAt <= delayNanos) {
+            return
+        }
+
+        val message = queue.dequeue()
+
+        if (!message.isNullOrEmpty()) {
+            connection.sendChat(message)
+        }
+    }
+}

--- a/src/main/kotlin/net/sbo/mod/utils/events/impl/game/SentCommandEvent.kt
+++ b/src/main/kotlin/net/sbo/mod/utils/events/impl/game/SentCommandEvent.kt
@@ -1,0 +1,10 @@
+package net.sbo.mod.utils.events.impl.game
+
+/**
+ * Event fired when a chat command is sent by the player to the server.
+ * Includes commands sent automatically by any mod in behalf of the player.
+ *
+ * @param content The content of the command. Always begins with a slash ('/').
+ * For messages, use {@link SentMessageEvent}.
+ */
+class SentCommandEvent(val content: String)

--- a/src/main/kotlin/net/sbo/mod/utils/events/impl/game/SentMessageEvent.kt
+++ b/src/main/kotlin/net/sbo/mod/utils/events/impl/game/SentMessageEvent.kt
@@ -1,0 +1,11 @@
+package net.sbo.mod.utils.events.impl.game
+
+/**
+ * Event fired when a chat message is sent by the player to the server.
+ * Includes messages sent automatically by any mod in behalf of the player.
+ * Triggers in all channels (all, guild, party, officer, etc.,)
+ *
+ * @param content The content of the message. Never begins with a slash ('/').
+ * For commands, use {@link SentCommandEvent}.
+ */
+class SentMessageEvent(val content: String)


### PR DESCRIPTION
- Use a mixin to detect all messages and commands sent by player, either by a mod (not just SBO) in-behalf of the player, or player themselves. This is used to reset the message send cooldown. This should make the you are doing this too fast error never happen when the mod tries to send a message in behalf of the player.

- Added new SentCommandEvent and SentMessageEvent respectively, triggered by the mixin.

- Centralize calls to send a message in behalf of the player to the Chat.say method (Made Chat.command call the Chat.say method).

- Added new ChatMessageQueue utility class: ObjectArrayFIFOQueue<String> is used to hold queued messages. queue() adds to the queue. flush() polls from the queue every tick, checks cooldown and sends if it's not null or empty. The cooldown (delayNanos) is set to 200 ms just as before, but now uses nanosecond precision and System.nanoTime() comparision instead of arbitary sleep(200) which would call Thread.sleep on a virtual thread to make the delay happen. Per JavaDoc, Thread.sleep can sleep more than the requested time and is not very precise, so checking System.nanoTime() is an improvement.

 The new utility also makes it so if last message sent was already 200ms ago, it does not force a 200ms delay, making e.g., PartyCommand outputs feel more "instantenous" when another player sends the command. The delay is still there for other cases such as if the player uses party command themselves.

- Make DianaStats use the new Chat.pc method as well, missed this in other PR.

- Removed now-unnecessary sleep(200) calls before calling Chat.pc or DianaStats method that sends into party chat.