### PR TITLE
Make timer inactivity pause time configurable and reduce default

### DIFF
--- a/src/main/kotlin/net/sbo/mod/settings/categories/Diana.kt
+++ b/src/main/kotlin/net/sbo/mod/settings/categories/Diana.kt
@@ -201,6 +201,13 @@ object Diana : CategoryKt("Diana") {
         }
     }
 
+    var afkTimeout by int(60) {
+        this.name = Literal("AFK Timeout")
+        this.description = Literal("Pause the trackers if it is not modified for this amount of seconds. Minimum 15, maximum 900 seconds is allowed.")
+        this.range = 15..900
+        this.slider = true
+    }
+
     var statsTracker by boolean(false) {
         this.name = Literal("Diana Stats Tracker")
         this.description = Literal("Shows stats like Mobs since Inquisitor, Inquisitors since Chimera, /sboguis to move the overlay")

--- a/src/main/kotlin/net/sbo/mod/utils/SboTimerManager.kt
+++ b/src/main/kotlin/net/sbo/mod/utils/SboTimerManager.kt
@@ -8,22 +8,20 @@ import net.sbo.mod.utils.events.annotations.SboEvent
 import net.sbo.mod.utils.events.impl.game.DisconnectEvent
 import java.lang.reflect.Field
 import java.util.Locale
+import net.sbo.mod.settings.categories.Diana
 
 object SboTimerManager {
     internal val activeTimers = mutableSetOf<SBOTimer>()
     val timerMayor = SBOTimer(
         name = "Mayor",
-        inactiveTimeLimit = 1.5f,
         tracker = SboDataObject.dianaTrackerMayor
     )
     val timerTotal = SBOTimer(
         name = "Total",
-        inactiveTimeLimit = 1.5f,
         tracker = SboDataObject.dianaTrackerTotal
     )
     val timerSession = SBOTimer(
         name = "Session",
-        inactiveTimeLimit = 1.5f,
         tracker = SboDataObject.dianaTrackerSession
     )
 
@@ -62,7 +60,6 @@ object SboTimerManager {
 
     class SBOTimer(
         val name: String,
-        inactiveTimeLimit: Float,
         private val tracker: DianaTracker
     ) {
         companion object {
@@ -73,8 +70,11 @@ object SboTimerManager {
         var elapsedTime: Long = 0
         private var state: TimerState = TimerState.Idle
         private var lastActivityTime: Long = System.currentTimeMillis()
-        private val INACTIVITY_LIMIT_MS: Long = (inactiveTimeLimit * 60 * 1000).toLong()
         private var inactivityFlag: Boolean = false
+
+        private fun getInactivityLimitMs(): Long {
+            return Diana.afkTimeout.toLong().coerceAtLeast(15L) * 1000L
+        }
 
         init {
             timerList.add(this)
@@ -101,10 +101,10 @@ object SboTimerManager {
             if (state != TimerState.Running) return
             val now = System.currentTimeMillis()
             updateElapsedTime(now)
-            if (now - lastActivityTime > INACTIVITY_LIMIT_MS) {
+            if (now - lastActivityTime > getInactivityLimitMs()) {
                 pause()
                 if (!inactivityFlag) {
-                    tracker.items.TIME = tracker.items.TIME - INACTIVITY_LIMIT_MS
+                    tracker.items.TIME = tracker.items.TIME - getInactivityLimitMs()
                     inactivityFlag = true
                 }
             }
@@ -127,7 +127,7 @@ object SboTimerManager {
         fun continueTimer() {
             if (state == TimerState.Running) return
             if (inactivityFlag) {
-                elapsedTime -= INACTIVITY_LIMIT_MS
+                elapsedTime -= getInactivityLimitMs()
             }
             startTime = System.currentTimeMillis()
             state = TimerState.Running


### PR DESCRIPTION
Remove inactiveTimeLimit constructor parameter and the INACTIVITY_LIMIT_MS fields since it's now calculated on the fly based on config value.

Add config value for it, defaulting to 60 seconds instead of 1.5 minutes that it was previously. Minimum allowed value is 15 and maximum allowed value is 900.

These default/min/max values match what SkyHanni has. (see https://github.com/hannibal002/SkyHanni/blob/940bb35948f207569e864eb0a57725c5bd0f5109/src/main/java/at/hannibal2/skyhanni/config/features/misc/tracker/TrackerGenericConfig.kt#L33-L40)