### PR TITLE
Add use spade on chain end option

### DIFF
--- a/src/main/kotlin/net/sbo/mod/diana/burrows/BurrowDetector.kt
+++ b/src/main/kotlin/net/sbo/mod/diana/burrows/BurrowDetector.kt
@@ -42,7 +42,7 @@ object BurrowDetector {
             true
         }
 
-        Register.onChatMessage(Regex("""^§eYou finished the Griffin burrow chain!.*$""")) { message, matchResult -> {
+        Register.onChatMessage(Regex("""^§eYou finished the Griffin burrow chain!.*$""")) { message, matchResult ->
             if (Diana.showTitleWhenChainEnd) requestSpade()
         }
     }

--- a/src/main/kotlin/net/sbo/mod/diana/burrows/BurrowDetector.kt
+++ b/src/main/kotlin/net/sbo/mod/diana/burrows/BurrowDetector.kt
@@ -41,6 +41,14 @@ object BurrowDetector {
             refreshBurrows()
             true
         }
+
+        Register.onChatMessage(Regex("""^§eYou finished the Griffin burrow chain!.*$""")) { message, matchResult -> {
+            if (Diana.showTitleWhenChainEnd) requestSpade()
+        }
+    }
+
+    fun requestSpade() {
+        Helper.showTitle("§c Use Spade!", "", 0, 30, 0)
     }
 
     @SboEvent

--- a/src/main/kotlin/net/sbo/mod/diana/burrows/BurrowDetector.kt
+++ b/src/main/kotlin/net/sbo/mod/diana/burrows/BurrowDetector.kt
@@ -44,7 +44,8 @@ object BurrowDetector {
         }
 
         Register.onChatMessage(Regex("""^§eYou finished the Griffin burrow chain!.*$""")) { message, matchResult ->
-            if (Diana.showTitleWhenChainEnd) requestSpade()
+            val anyClose = WaypointManager.getAllGuessesAndBurrows().filter { it.distanceToPlayer() < 90 }
+            if (Diana.showTitleWhenChainEnd && anyClose.isEmpty()) requestSpade()
         }
     }
 

--- a/src/main/kotlin/net/sbo/mod/diana/burrows/BurrowDetector.kt
+++ b/src/main/kotlin/net/sbo/mod/diana/burrows/BurrowDetector.kt
@@ -20,6 +20,7 @@ import net.sbo.mod.utils.math.SboVec
 import net.sbo.mod.utils.game.World
 import java.util.concurrent.ConcurrentHashMap
 import java.util.regex.Pattern
+import net.sbo.mod.utils.Helper
 
 object BurrowDetector {
     internal val burrows = ConcurrentHashMap<String, Burrow>()

--- a/src/main/kotlin/net/sbo/mod/diana/guesses/ArrowGuessBurrow.kt
+++ b/src/main/kotlin/net/sbo/mod/diana/guesses/ArrowGuessBurrow.kt
@@ -251,7 +251,7 @@ object ArrowGuessBurrow {
 
         if (Diana.showTitleWhenInaccurate) {
             if (withinRange.size > 1) {
-                if (!spadeTitleShown) Helper.showTitle("§c Use Spade!", "", 0, 30, 0)
+                if (!spadeTitleShown) BurrowDetector.requestSpade()
                 spadeTitleShown = true
             } else {
                 spadeTitleShown = false

--- a/src/main/kotlin/net/sbo/mod/settings/categories/Diana.kt
+++ b/src/main/kotlin/net/sbo/mod/settings/categories/Diana.kt
@@ -76,6 +76,11 @@ object Diana : CategoryKt("Diana") {
         this.description = Literal("Shows a title to guess normally when the arrow guess is inaccurate")
     }
 
+    var showTitleWhenChainEnd by boolean(false) {
+        this.name = Literal("Show Title When Chain End")
+        this.description = Literal("Shows a title to guess normally when the burrow chain is complete")
+    }
+
     var dontClearArrowGuess by boolean(true) {
         this.name = Literal("Don't Clear Arrow Guess on World Change")
         this.description = Literal("If enabled, the arrow guess waypoints will not be cleared when changing worlds/lobby")

--- a/src/main/kotlin/net/sbo/mod/settings/categories/Diana.kt
+++ b/src/main/kotlin/net/sbo/mod/settings/categories/Diana.kt
@@ -78,7 +78,7 @@ object Diana : CategoryKt("Diana") {
 
     var showTitleWhenChainEnd by boolean(false) {
         this.name = Literal("Show Title When Chain End")
-        this.description = Literal("Shows a title to guess normally when the burrow chain is complete")
+        this.description = Literal("Shows a title to guess normally when the burrow chain is complete and there's no more guesses or burrows at least 90 blocks nearby")
     }
 
     var dontClearArrowGuess by boolean(true) {

--- a/src/main/kotlin/net/sbo/mod/utils/waypoint/WaypointManager.kt
+++ b/src/main/kotlin/net/sbo/mod/utils/waypoint/WaypointManager.kt
@@ -337,12 +337,12 @@ object WaypointManager {
         return waypoints[type.lowercase()] ?: emptyList()
     }
 
+    fun getAllGuessesAndBurrows(): List<Waypoint> {
+        return getWaypointsOfType("burrow") + getWaypointsOfType("arrow") + getWaypointsOfType("guess")
+    }
+
     fun getBestGuess(): Waypoint? {
-        return (
-                getWaypointsOfType("burrow") +
-                getWaypointsOfType("arrow") +
-                getWaypointsOfType("guess")
-            )
+        return getAllGuessesAndBurrows()
             .filter { !it.hidden }
             .minByOrNull { it.distanceToPlayer() }
     }
@@ -358,7 +358,7 @@ object WaypointManager {
     }
 
     private fun getClosestWaypointFrom(pos: SboVec): Pair<Waypoint, Double>? {
-        return getClosestWaypointFrom(pos, getWaypointsOfType("burrow") + getWaypointsOfType("arrow") + getWaypointsOfType("guess"))
+        return getClosestWaypointFrom(pos, getAllGuessesAndBurrows())
     }
 
     private fun getClosestWaypointFrom(pos: SboVec, waypoints: List<Waypoint>): Pair<Waypoint, Double>? {


### PR DESCRIPTION
Adds use spade on chain end option, this was in SkyHanni but did not exist in SBO. This is different from the show title when inaccurate option for Arrow Guess.

See https://github.com/hannibal002/SkyHanni/blob/940bb35948f207569e864eb0a57725c5bd0f5109/src/main/java/at/hannibal2/skyhanni/config/features/event/diana/DianaConfig.kt#L104-L110

Also centralizes the spade title to a single function named requestSpade to avoid code duplication since there's now 2 places that show a use spade title.

This title is disabled by default just like the show title when inaccurate one, but may be enabled later if testing proves it is helpful.