### PR TITLE
Make beacon beam toggleable

### DIFF
--- a/src/main/kotlin/net/sbo/mod/settings/categories/Diana.kt
+++ b/src/main/kotlin/net/sbo/mod/settings/categories/Diana.kt
@@ -70,6 +70,11 @@ object Diana : CategoryKt("Diana") {
         )
     }
 
+    var showBeaconBeam by boolean(true) {
+        this.name = Literal("Show Beacon Beam")
+        this.description = Literal("Shows a beacon beam for waypoints going to the sky if enabled.")
+    }
+
     var showTitleWhenInaccurate by boolean(false) {
         this.name = Literal("Show Title When Inaccurate")
         this.description = Literal("Shows a title to guess normally when the arrow guess is inaccurate")
@@ -209,7 +214,6 @@ object Diana : CategoryKt("Diana") {
         this.name = Literal("AFK Timeout")
         this.description = Literal("Pause the trackers if it is not modified for this amount of seconds. Minimum 15, maximum 900 seconds is allowed.")
         this.range = 15..900
-        this.slider = true
     }
 
     var statsTracker by boolean(false) {

--- a/src/main/kotlin/net/sbo/mod/utils/waypoint/Waypoint.kt
+++ b/src/main/kotlin/net/sbo/mod/utils/waypoint/Waypoint.kt
@@ -25,7 +25,6 @@ import net.fabricmc.fabric.api.client.rendering.v1.world.WorldRenderContext
  * @param ttl The time to live for the waypoint in seconds (0 for infinite).
  * @param type The type of the waypoint for customization.
  * @param line Whether to draw a line to the waypoint.
- * @param beam Whether to draw a beam at the waypoint.
  * @param distance Whether to display the distance in meters (blocks) to the waypoint.
  */
 class Waypoint(
@@ -39,7 +38,6 @@ class Waypoint(
     val ttl: Int = 0,
     val type: String = "normal",
     var line: Boolean = false,
-    var beam: Boolean = true,
     var distance: Boolean = true
 ) {
     var pos: SboVec = SboVec(this.x, this.y, this.z)
@@ -133,7 +131,7 @@ class Waypoint(
             true,
             this.line,
             Diana.dianaLineWidth.toFloat(),
-            this.beam
+            Diana.showBeaconBeam
         )
     }
 }


### PR DESCRIPTION
Adds an option to disable beacon beam going to the sky effect toggleable on waypoints.

The code internally already had a toggle for this but it wasn't exposed to the user via configuration, was a pretty simple change to make.

Also removed the slider option for AFK Timeout to allow entering a precise value.