### PR TITLE
Add title on warp

### DIFF
--- a/src/main/kotlin/net/sbo/mod/settings/categories/Diana.kt
+++ b/src/main/kotlin/net/sbo/mod/settings/categories/Diana.kt
@@ -107,7 +107,7 @@ object Diana : CategoryKt("Diana") {
         this.description = Literal("Select the warps you want to be able to warp to with the guess and inquisitor warp keys.")
     }
 
-    var showTitleWhenWarpAvailable by boolean(true) {
+    var showTitleWhenWarpAvailable by boolean(false) {
         this.name = Literal("Show Title When Warp Is Available")
         this.description = Literal("If enabled, will show a title when warp is available.")
     }

--- a/src/main/kotlin/net/sbo/mod/settings/categories/Diana.kt
+++ b/src/main/kotlin/net/sbo/mod/settings/categories/Diana.kt
@@ -107,6 +107,11 @@ object Diana : CategoryKt("Diana") {
         this.description = Literal("Select the warps you want to be able to warp to with the guess and inquisitor warp keys.")
     }
 
+    var showTitleWhenWarpAvailable by boolean(true) {
+        this.name = Literal("Show Title When Warp Is Available")
+        this.description = Literal("If enabled, will show a title when warp is available.")
+    }
+
     var dontWarpIfBurrowClose by boolean(true) {
         this.name = Literal("Don't Warp If a Burrow is nearby")
         this.description = Literal("If enabled, the warp key will not warp you if you are within 60 blocks of a burrow")

--- a/src/main/kotlin/net/sbo/mod/utils/waypoint/Waypoint.kt
+++ b/src/main/kotlin/net/sbo/mod/utils/waypoint/Waypoint.kt
@@ -3,6 +3,7 @@ package net.sbo.mod.utils.waypoint
 import net.sbo.mod.settings.categories.Customization
 import net.sbo.mod.settings.categories.Diana
 import net.sbo.mod.utils.Player
+import net.sbo.mod.utils.Helper
 import net.sbo.mod.utils.math.SboVec
 import net.sbo.mod.utils.render.RenderUtils3D
 import kotlin.math.pow
@@ -59,9 +60,17 @@ class Waypoint(
 
     private fun setWarpText() {
         if (isClosest) {
-            this.formattedText = WaypointManager.getClosestWarp(this.pos)?.let {
+            val closest = WaypointManager.getClosestWarp(this.pos)
+
+            this.formattedText = closest?.let {
                 "$text§7 (warp $it)${this.distanceText}"
             } ?: "${this.text}${this.distanceText}"
+
+            val title = Diana.showTitleWhenWarpAvailable
+            if (title && closest != null) {
+                 val warpName = closest.replaceFirstChar(Char::titlecase)
+                 Helper.showTitle("§bWarp §e$warpName$distanceText", "", 0, 1, 0) // 1 ticks because next tick this will be called again
+            }
         } else {
             this.formattedText = "${this.text}${this.distanceText}"
         }


### PR DESCRIPTION
The setWarpText is called each tick, and we show a title that lasts for 1 tick. This does not cause flickering and updates the text on screen as soon as possible, and makes it disappear as soon as possible with 1 tick delay when I tested, so I think it's good.