### PR TITLE
Don't use consumeClick for keybinds

### DIFF
--- a/src/main/kotlin/net/sbo/mod/utils/SboKeyBinds.kt
+++ b/src/main/kotlin/net/sbo/mod/utils/SboKeyBinds.kt
@@ -11,9 +11,8 @@ import org.lwjgl.glfw.GLFW
 import net.minecraft.resources.ResourceLocation
 
 object SboKeyBinds {
-
     private data class KeyPressState(var isHeldDown: Boolean = false, var lastActivation: Long = 0)
-    private val keyStates = mutableMapOf<KeyMapping, KeyPressState>()
+    private val keyStates = mutableMapOf<String, KeyPressState>()
     private val SBO_CATEGORY = KeyMapping.Category(ResourceLocation.fromNamespaceAndPath("sbo-kotlin", "keybinds"))
 
     fun init() {
@@ -61,9 +60,9 @@ object SboKeyBinds {
     }
 
     private fun handlePressAction(keyBinding: KeyMapping, cooldownMillis: Long, action: () -> Unit) {
-        val state = keyStates.getOrPut(keyBinding) { KeyPressState() }
+        val state = keyStates.getOrPut(keyBinding.name) { KeyPressState() }
 
-        if (keyBinding.consumeClick()) {
+        if (keyBinding.isDown) {
             val currentTime = System.currentTimeMillis()
             if (!state.isHeldDown && currentTime - state.lastActivation > cooldownMillis) {
                 action()


### PR DESCRIPTION
This should make it work even if a conflicting keybind was set. Some users were reporting warp key not working even with Always Diana active. I figured the only way would be if keybind handling itself and not the warpToGuess method was broken; and found consumeClick was used here, which was suspicious. Replacing it with isDown seems to fix the issue - tested having 2 keybinds, one SBO and one vanilla keybind to the same key, and both keys now work fine.

Also replaces KeyMapping key with the name of the key inside keyStates map, so that we depend on String#hashCode instead of KeyMapping#hashCode.