### PR TITLE
Add NPC Price overrides for Pet Items and Hilt of Revelations

### DIFF
--- a/src/main/kotlin/net/sbo/mod/settings/categories/Diana.kt
+++ b/src/main/kotlin/net/sbo/mod/settings/categories/Diana.kt
@@ -186,6 +186,11 @@ object Diana : CategoryKt("Diana") {
         }
     }
 
+    var npcPriceOverrides by boolean(false) {
+        this.name = Literal("NPC Price Overrides")
+        this.description = Literal("Always prefers NPC prices for select items; such as the Pet Item drops like Cretan Urn, Dwarf Turtle Shelmet, Antique Remedies, Washed Up Souvenir and Crochet Tiger Plushie, along with Hilt of Revelations, useful if NPC selling them.")
+    }
+
     var hideUnobtainedItems by ObservableEntry(
         boolean(true) {
             this.name = Literal("Hide Unobtained Items")

--- a/src/main/kotlin/net/sbo/mod/utils/Helper.kt
+++ b/src/main/kotlin/net/sbo/mod/utils/Helper.kt
@@ -588,7 +588,8 @@ object Helper {
         val ahPrice = priceDataAh[id]?.toDouble() ?: 0.0
         val npcPrice = npcSellValueMap[id]?.toDouble() ?: 0.0
 
-        val bestUnitPrice = if (npcPrice > ahPrice) npcPrice else ahPrice
+        val preferNpc = Diana.npcPriceOverrides && (sbId == "CRETAN_URN" || sbId == "DWARF_TURTLE_SHELMET" || sbId == "ANTIQUE_REMEDIES" || sbId == "WASHED_UP_SOUVENIR" || sbId == "CROCHET_TIGER_PLUSHIE" || sbId == "HILT_OF_REVELATIONS")
+        val bestUnitPrice = if (npcPrice > ahPrice || preferNpc) npcPrice else ahPrice
 
         return (bestUnitPrice * amount).roundToLong()
     }


### PR DESCRIPTION
Adds NPC Price overrides option for Pet Items and Hilt of Revelations; was requested by users.

Many people are too lazy to sell these items one-by-one on AH (since there's no insta sell or put multiple items to order at same time there), so they end up NPC selling them for 250k/150k each. This makes the profit tracker and money per hour inaccurate for them as in realtiy they have made less money.

Hardcoded multiple comparision against the sbId, could refactor later, minimal git diff that works for now.

Tested turning option ON and checking if all prices match expected with my TOTAL tracker; seems to work fine.