### PR TITLE
Add Exclude Coins from Profit option

### DIFF
--- a/src/main/kotlin/net/sbo/mod/overlays/DianaLoot.kt
+++ b/src/main/kotlin/net/sbo/mod/overlays/DianaLoot.kt
@@ -293,7 +293,7 @@ object DianaLoot : DirtyFlushableOverlay() {
     }
 
     private fun createCoinLine(tracker: DianaTracker): OverlayTextLine {
-        return OverlayTextLine("${GOLD}Total Coins: $AQUA${Helper.formatNumber(tracker.items.COINS)}")
+        return OverlayTextLine("${GOLD}Total Coins: $AQUA${Helper.formatNumber(tracker.items.COINS)}" + if (Diana.excludeCoinsFromProfit) "$GRAY[$RED EXCLUDED$GRAY]" else "")
             .onHover { drawContext, textRenderer ->
                 val scaleFactor = mc.window.guiScale
                 val mouseX = mc.mouseHandler.xpos() / scaleFactor
@@ -335,7 +335,7 @@ object DianaLoot : DirtyFlushableOverlay() {
                 totalProfit += itemPrice * itemValue
             }
         }
-        return totalProfit + tracker.items.COINS
+        return if (Diana.excludeCoinsFromProfit) totalProfit else totalProfit + tracker.items.COINS
     }
 
     fun updateTimerText() {

--- a/src/main/kotlin/net/sbo/mod/settings/categories/Diana.kt
+++ b/src/main/kotlin/net/sbo/mod/settings/categories/Diana.kt
@@ -191,6 +191,11 @@ object Diana : CategoryKt("Diana") {
         this.description = Literal("Always prefers NPC prices for select items; such as the Pet Item drops like Cretan Urn, Dwarf Turtle Shelmet, Antique Remedies, Washed Up Souvenir and Crochet Tiger Plushie, along with Hilt of Revelations, useful if NPC selling them.")
     }
 
+    var excludeCoinsFromProfit by boolean(false) {
+        this.name = Literal("Exclude Coins from Profit")
+        this.description = Literal("Excludes coins from the loot tracker's profit calculation when enabled, useful if using a non-1B crown since coins are consumed.")
+    }
+
     var hideUnobtainedItems by ObservableEntry(
         boolean(true) {
             this.name = Literal("Hide Unobtained Items")


### PR DESCRIPTION
Added Exclude Coins from Profit option, for people that want accurate tracker when using a non-1B crown.

Could automatically do this detecting the helmet player uses, but would be more work to avoid false positive when switching to the 1B one for magic find, and users could ask "Why did my Profit/hr value went down after upgrading to the new version" - so better we make this opt-in as an option I figured, but let me know otherwise.