### PR TITLE
Use public methods for position and chat width

### DIFF
--- a/src/main/kotlin/net/sbo/mod/guis/partyfinder/PartyFinderGUI.kt
+++ b/src/main/kotlin/net/sbo/mod/guis/partyfinder/PartyFinderGUI.kt
@@ -420,7 +420,7 @@ class PartyFinderGUI : WindowScreen(ElementaVersion.V10) {
             selectedPage = pageTitle
             contentBlock.clearChildren()
             partyListContainer.clearChildren()
-            if (selectedPage != "Home" && selectedPage != "Help" && selectedPage != "Settimgs") {
+            if (selectedPage != "Home" && selectedPage != "Help" && selectedPage != "Settings") {
                 contentBlock.addChild(partyListContainer)
             }
             updatePageHighlight()

--- a/src/main/kotlin/net/sbo/mod/utils/chat/Chat.kt
+++ b/src/main/kotlin/net/sbo/mod/utils/chat/Chat.kt
@@ -5,6 +5,7 @@ import net.minecraft.network.chat.Component
 import net.minecraft.network.chat.ClickEvent
 import net.minecraft.network.chat.HoverEvent
 import net.minecraft.network.chat.Style
+import net.minecraft.client.gui.components.ChatComponent
 import net.minecraft.ChatFormatting
 import net.sbo.mod.utils.events.ClickActionManager
 import net.sbo.mod.settings.categories.General
@@ -188,7 +189,7 @@ object Chat {
             return ""
         }
         val textRenderer = mc.font
-        val chatWidth = mc.gui.chat.width
+        val chatWidth = ChatComponent.getWidth(mc.options.chatWidth().get())
         val separatorWidth = textRenderer.width(separator)
 
         if (separatorWidth <= 0) {

--- a/src/main/kotlin/net/sbo/mod/utils/render/RenderUtils3D.kt
+++ b/src/main/kotlin/net/sbo/mod/utils/render/RenderUtils3D.kt
@@ -118,7 +118,7 @@ object RenderUtils3D {
         val height = 1.0
         val depth = 1.0
         context.pushPop {
-            val cameraPos = context.getCamera().position
+            val cameraPos = context.getCamera().position()
             translate(pos.x + 0.5 - cameraPos.x, pos.y - cameraPos.y, pos.z + 0.5 - cameraPos.z)
 
             val consumers = context.consumers()!!
@@ -164,7 +164,7 @@ object RenderUtils3D {
     ) {
         context.pushPop {
             val camera = context.getCamera()
-            val cameraPos = camera.position
+            val cameraPos = camera.position()
             val cameraYaw = camera.yRot
             val cameraPitch = camera.xRot
             val textRenderer = mc.font
@@ -221,7 +221,7 @@ object RenderUtils3D {
     ) {
         context.pushPop {
             val camera = context.getCamera()
-            val cameraPos = camera.position
+            val cameraPos = camera.position()
 
             translate(cameraPos.reverse())
 
@@ -282,7 +282,7 @@ object RenderUtils3D {
         val consumers = ctx.consumers()
         val wolrd = mc.level ?: return
         val partialTicks = mc.deltaTracker.getGameTimeDeltaPartialTick(true)
-        val cam = ctx.getCamera().position
+        val cam = ctx.getCamera().position()
         val beamColor = floatArrayOf(colorComponents[0], colorComponents[1], colorComponents[2], 1.0f)
 
         ctx.pushPop {

--- a/versions/1.21.11-fabric/src/main/resources/sbo-kotlin.classtweaker
+++ b/versions/1.21.11-fabric/src/main/resources/sbo-kotlin.classtweaker
@@ -1,4 +1,2 @@
 classTweaker v2 named
-accessible	method	net/minecraft/client/gui/components/ChatComponent getWidth ()I
-accessible	field	net/minecraft/client/Camera position Lnet/minecraft/world/phys/Vec3;
 accessible	method	net/minecraft/client/renderer/rendertype/RenderType create (Ljava/lang/String;Lnet/minecraft/client/renderer/rendertype/RenderSetup;)Lnet/minecraft/client/renderer/rendertype/RenderType;

--- a/versions/26.1.2-fabric/src/main/resources/sbo-kotlin.classtweaker
+++ b/versions/26.1.2-fabric/src/main/resources/sbo-kotlin.classtweaker
@@ -1,6 +1,4 @@
 classTweaker v2 official
-accessible	method	net/minecraft/client/gui/components/ChatComponent getWidth ()I
-accessible	field	net/minecraft/client/Camera position Lnet/minecraft/world/phys/Vec3;
 accessible	method	net/minecraft/client/renderer/rendertype/RenderType create (Ljava/lang/String;Lnet/minecraft/client/renderer/rendertype/RenderSetup;)Lnet/minecraft/client/renderer/rendertype/RenderType;
 accessible	method	net/minecraft/client/renderer/RenderPipelines register (Lcom/mojang/blaze3d/pipeline/RenderPipeline;)Lcom/mojang/blaze3d/pipeline/RenderPipeline;
 accessible	field	net/minecraft/client/renderer/RenderPipelines DEBUG_FILLED_SNIPPET Lcom/mojang/blaze3d/pipeline/RenderPipeline$Snippet;


### PR DESCRIPTION
Removed the classtweaker access-widening entries for Camera position and Chat width; use public methods for them instead.

Camera's position field was made private in 1.21.11, but .position() method exists in 1.21.10 onwards, so we can use it unconditionally, removing the need for classtweaker adjustment.

ChatComponent's getWidth method (which is called when you do .width in Kotlin since it acts as a property) also became private, however that method just delegates to the public static method with the mc.options.chatWidth().get() as the parameter, so we could just call the public static method ourselves with the same argument to remove the need for classtweaker.

The RenderType/Pipeline/Layer class tweaker entries are still needed for now as I was not able to find an alternative method to achieve the same behaviour. We could use vanilla's render layers/pipelines directly instead of registering our own (would also remove the need for explicit Iris compatibility class), but those might not support features like .setLineWidth on all versions we build for (1.21.10, 1.21.11, 26.1.2) so that is a future refactor.

Also fixed a typo in PartyFinderGUI.kt Settimgs --> Settings