### PR TITLE
Improve parity with SH

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -62,7 +62,7 @@ fabriclanguagekotlin.version=1.13.11+kotlin.2.3.21
 # Fabric API
 fabricapi.version.1.21.10=0.138.4+1.21.10
 fabricapi.version.1.21.11=0.141.4+1.21.11
-fabricapi.version.26.1.2=0.150.0+26.1.2
+fabricapi.version.26.1.2=0.149.1+26.1.2
 
 # UniversalCraft
 universalcraft.version=494

--- a/gradle.properties
+++ b/gradle.properties
@@ -62,7 +62,7 @@ fabriclanguagekotlin.version=1.13.11+kotlin.2.3.21
 # Fabric API
 fabricapi.version.1.21.10=0.138.4+1.21.10
 fabricapi.version.1.21.11=0.141.4+1.21.11
-fabricapi.version.26.1.2=0.149.1+26.1.2
+fabricapi.version.26.1.2=0.150.0+26.1.2
 
 # UniversalCraft
 universalcraft.version=494

--- a/src/main/kotlin/net/sbo/mod/diana/burrows/BurrowDetector.kt
+++ b/src/main/kotlin/net/sbo/mod/diana/burrows/BurrowDetector.kt
@@ -92,7 +92,7 @@ object BurrowDetector {
 
     private fun burrowDetect(packet: ClientboundLevelParticlesPacket) {
         val particleType = ParticleTypes.getParticleType(packet) ?: return
-        val pos = SboVec(packet.x, packet.y - 1.0, packet.z).roundLocationToBlock()
+        val pos = SboVec(packet.x, packet.y, packet.z).roundLocationToBlock().down()
         val posString = "${pos.x.toInt()} ${pos.y.toInt()} ${pos.z.toInt()}"
 
         if (burrowsHistory.contains(posString)) return

--- a/src/main/kotlin/net/sbo/mod/diana/burrows/ParticleTypes.kt
+++ b/src/main/kotlin/net/sbo/mod/diana/burrows/ParticleTypes.kt
@@ -2,6 +2,7 @@ package net.sbo.mod.diana.burrows
 
 import net.minecraft.network.protocol.game.ClientboundLevelParticlesPacket
 import net.minecraft.core.particles.ParticleTypes as MCParticleTypes
+import net.sbo.mod.utils.NumberUtil.roundTo
 
 internal object ParticleTypes {
     internal val PARTICLE_CHECKS = mutableMapOf(
@@ -9,41 +10,41 @@ internal object ParticleTypes {
             packet.particle.type == MCParticleTypes.ENCHANT &&
                     packet.count == 5 &&
                     packet.maxSpeed == 0.05f &&
-                    packet.xDist == 0.5f &&
-                    packet.yDist == 0.4f &&
-                    packet.zDist == 0.5f
+                    packet.xDist.roundTo(2) == 0.5f &&
+                    packet.yDist.roundTo(2) == 0.4f &&
+                    packet.zDist.roundTo(2) == 0.5f
         },
         "EMPTY" to ParticleCheck { packet ->
             packet.particle.type == MCParticleTypes.ENCHANTED_HIT &&
                     packet.count == 4 &&
                     packet.maxSpeed == 0.01f &&
-                    packet.xDist == 0.5f &&
-                    packet.yDist == 0.1f &&
-                    packet.zDist == 0.5f
+                    packet.xDist.roundTo(2) == 0.5f &&
+                    packet.yDist.roundTo(2) == 0.1f &&
+                    packet.zDist.roundTo(2) == 0.5f
         },
         "MOB" to ParticleCheck { packet ->
             packet.particle.type == MCParticleTypes.CRIT &&
                     packet.count == 3 &&
                     packet.maxSpeed == 0.01f &&
-                    packet.xDist == 0.5f &&
-                    packet.yDist == 0.1f &&
-                    packet.zDist == 0.5f
+                    packet.xDist.roundTo(2) == 0.5f &&
+                    packet.yDist.roundTo(2) == 0.1f &&
+                    packet.zDist.roundTo(2) == 0.5f
         },
         "TREASURE" to ParticleCheck { packet ->
             packet.particle.type == MCParticleTypes.DRIPPING_LAVA &&
                     packet.count == 2 &&
                     packet.maxSpeed == 0.01f &&
-                    packet.xDist == 0.35f &&
-                    packet.yDist == 0.1f &&
-                    packet.zDist == 0.35f
+                    packet.xDist.roundTo(2) == 0.35f &&
+                    packet.yDist.roundTo(2) == 0.1f &&
+                    packet.zDist.roundTo(2) == 0.35f
         },
         "FOOTSTEP" to ParticleCheck { packet ->
             packet.particle.type == MCParticleTypes.CRIT &&
                     packet.count == 1 &&
                     packet.maxSpeed == 0.0f &&
-                    packet.xDist == 0.05f &&
-                    packet.yDist == 0.0f &&
-                    packet.zDist == 0.05f
+                    packet.xDist.roundTo(2) == 0.05f &&
+                    packet.yDist.roundTo(2) == 0.0f &&
+                    packet.zDist.roundTo(2) == 0.05f
         }
     )
 

--- a/src/main/kotlin/net/sbo/mod/diana/guesses/ArrowGuessBurrow.kt
+++ b/src/main/kotlin/net/sbo/mod/diana/guesses/ArrowGuessBurrow.kt
@@ -8,7 +8,7 @@ import net.minecraft.core.particles.ParticleTypes
 import net.sbo.mod.SBOKotlin
 import net.sbo.mod.diana.burrows.BurrowDetector
 import net.sbo.mod.settings.categories.Diana
-import net.sbo.mod.utils.Helper
+import net.sbo.mod.utils.NumberUtil.roundTo
 import net.sbo.mod.utils.math.RaycastUtils
 import net.sbo.mod.utils.collection.TimeLimitedSet
 import net.sbo.mod.utils.events.annotations.SboEvent
@@ -24,10 +24,8 @@ import java.util.Collections
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.CopyOnWriteArrayList
 import kotlin.math.abs
-import kotlin.math.pow
 import kotlin.math.sign
 import kotlin.math.sqrt
-import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.seconds
 
 //todo: when not precise and normal guess was used remove latest arrow guess waypoint
@@ -245,7 +243,7 @@ object ArrowGuessBurrow {
 
             val distanceFromOrigin = candidatePoint.distance(ray.origin)
 
-            val scaledDistance = (distanceToRay * 500000 / distanceFromOrigin).roundTo(5)
+            val scaledDistance = (distanceToRay * 500000 / distanceFromOrigin)
 
             candidates[candidateBlock] = Pair(scaledDistance.roundTo(2), distanceFromOrigin)
         }
@@ -322,11 +320,6 @@ object ArrowGuessBurrow {
         val dy = this.y - player.y
         val dz = this.z - player.z
         return sqrt(dx * dx + dy * dy + dz * dz)
-    }
-
-    private fun Double.roundTo(decimals: Int): Double {
-        val factor = 10.0.pow(decimals)
-        return kotlin.math.round(this * factor) / factor
     }
 
     private fun AABB.isInside(vec: SboVec): Boolean {

--- a/src/main/kotlin/net/sbo/mod/diana/guesses/ArrowGuessBurrow.kt
+++ b/src/main/kotlin/net/sbo/mod/diana/guesses/ArrowGuessBurrow.kt
@@ -79,14 +79,12 @@ object ArrowGuessBurrow {
         add(Blocks.OXEYE_DAISY)
     }
 
-    private val recentArrowParticles = TimeLimitedSet<SboVec>(1.minutes)
+    private val recentFoundArrows = TimeLimitedSet<RaycastUtils.Ray>(18.seconds)
     private val locations: MutableSet<SboVec> = Collections.newSetFromMap(ConcurrentHashMap())
 
     private var lastBlockClicked: SboVec? = null
 
     private val allGuesses = CopyOnWriteArrayList<GuessEntry>()
-
-    private var newArrow = true
 
     @SboEvent
     fun onReceiveParticle(event: PacketReceiveEvent) {
@@ -96,9 +94,8 @@ object ArrowGuessBurrow {
 
         val location = SboVec(packet.x, packet.y, packet.z)
         if (!location.isCloseToLastBurrow()) return
-        if(!recentArrowParticles.add(location)) return
 
-        val range = getArrowRange(packet.xDist, packet.yDist) ?: return
+        val range = getArrowRange(packet.xDist, packet.yDist, packet.zDist) ?: return
         locations.add(location)
         range.processArrowDetection()
     }
@@ -121,7 +118,6 @@ object ArrowGuessBurrow {
         val maxChain = event.maxBurrow
         if (currentChain != maxChain) {
             locations.clear()
-            newArrow = true
         }
         if (currentChain == 1) return
 
@@ -251,7 +247,7 @@ object ArrowGuessBurrow {
 
             val scaledDistance = (distanceToRay * 500000 / distanceFromOrigin).roundTo(5)
 
-            candidates[candidateBlock] = Pair(scaledDistance.roundTo(5), distanceFromOrigin)
+            candidates[candidateBlock] = Pair(scaledDistance.roundTo(2), distanceFromOrigin)
         }
         if (candidates.isEmpty()) return null
 
@@ -283,7 +279,6 @@ object ArrowGuessBurrow {
         val playerPos = player.position().toSboVec()
 
         for (guess in allGuesses) {
-            if (guess == null) continue
             val current = guess.getCurrent()
             if (!isBlockValid(current)) {
                 guess.moveToNext()
@@ -300,10 +295,10 @@ object ArrowGuessBurrow {
         }
     }
 
-    private fun getArrowRange(offsetX: Float, offsetY: Float): IntRange? {
-        if (offsetY == 128.0f) return 0..117 //Green Close
-        if (offsetY == 255.0f && offsetX == 255.0f) return 112..282 //Red Medium
-        if (offsetX == 255.0f) return 281..600 //Black Far
+    private fun getArrowRange(offsetX: Float, offsetY: Float, offsetZ: Float): IntRange? {
+        if (offsetX == 0f && offsetY == 128f && offsetZ == 0f) return 0..117 //Yellow Close
+        if (offsetX == 255f && offsetY == 255f && offsetZ == 0f) return 112..282 //Red Medium
+        if (offsetX == 255f && offsetY == 0f && offsetZ == 0f) return 281..600 //Black Far
         return null
     }
 
@@ -348,15 +343,17 @@ object ArrowGuessBurrow {
         return parameters is DustParticleOptions
     }
 
-    private fun SboVec.isCloseToLastBurrow(): Boolean = lastBlockClicked?.let { this.distanceTo(it) < 5 } ?: false
+    private fun SboVec.isCloseToLastBurrow(): Boolean = lastBlockClicked?.let { this.distanceTo(it) <= 6 } ?: false
 
     private fun IntRange.processArrowDetection(): IntRange {
         val arrow = detectArrow() ?: return this
+        if(!recentFoundArrows.add(arrow)) return this
+
         locations.clear()
         findClosestValidBlockToRayNew(arrow, this)?.let {
             WaypointManager.addArrowGuess(it)
-            newArrow = false
         }
+
         return this
     }
 }

--- a/src/main/kotlin/net/sbo/mod/diana/guesses/ArrowGuessBurrow.kt
+++ b/src/main/kotlin/net/sbo/mod/diana/guesses/ArrowGuessBurrow.kt
@@ -91,7 +91,7 @@ object ArrowGuessBurrow {
         if (!packet.isRelevant()) return
 
         val location = SboVec(packet.x, packet.y, packet.z)
-        if (!location.isCloseToLastBurrow()) return
+        if (!location.isCloseToLastBurrow() || packet.distanceToPlayer() > 6) return
 
         val range = getArrowRange(packet.xDist, packet.yDist, packet.zDist) ?: return
         locations.add(location)

--- a/src/main/kotlin/net/sbo/mod/diana/guesses/PreciseGuessBurrow.kt
+++ b/src/main/kotlin/net/sbo/mod/diana/guesses/PreciseGuessBurrow.kt
@@ -45,7 +45,7 @@ object PreciseGuessBurrow {
         if (packet.particle.type != ParticleTypes.DRIPPING_LAVA || packet.count != 2 || packet.maxSpeed != -0.5f) return
         val currLoc = SboVec(packet.x, packet.y, packet.z)
         this.lastLavaParticle = System.currentTimeMillis()
-        if (System.currentTimeMillis() - lastGuessTime > 1000) return
+        if (System.currentTimeMillis() - lastGuessTime > 3000) return
 
         if (this.particleLocations.isEmpty()) {
             this.particleLocations.add(currLoc)

--- a/src/main/kotlin/net/sbo/mod/utils/NumberUtil.kt
+++ b/src/main/kotlin/net/sbo/mod/utils/NumberUtil.kt
@@ -1,0 +1,18 @@
+package net.sbo.mod.utils
+
+import kotlin.math.pow
+import kotlin.math.round
+
+object NumberUtil {
+    /**
+     * This code was unmodified and taken under CC BY-SA 3.0 license
+     * @link https://stackoverflow.com/a/22186845
+     * @author jpdymond
+     */
+    fun Double.roundTo(precision: Int): Double {
+        val scale = 10.0.pow(precision)
+        return round(this * scale) / scale
+    }
+
+    fun Float.roundTo(precision: Int): Float = toDouble().roundTo(precision).toFloat()
+}


### PR DESCRIPTION
- Use .down() after instead of manual y - 1 like SH
- Add NumberUtil class so that we can call .roundTo on Float and Double
- Add missing .roundTo(2) calls to particle checks as it's done in SH It does have a todo comment to remove them in SH and that its only for workaround; but workaround (usually) means it would bug without the roundTo, so we should keep it for now
- Rename recentArrowParticles --> recentFoundArrows, change stored set entry from SboVec to RaycastUtils.Ray, make time 18 seconds instead of 1 minutes to match SH The add and duplicate check was moved to inside processArrowDetection.
- Removed unused newArrow property
- Replaced a .roundTo(5) with .roundTo(2) to match SH.
- Removed unnecessary guess == null check; the NPE there was caused by a concurrent remove whilst iterating rather than an actual null addition to the set. The set's type is non-nullable.
- Strengthened getArrowRange checks to check all three offsets; SH uses a LorenzVec .equals() here via the kotlin == operator, since we pass the three floats manually we have to compare each.
- Replaced isCloseToLastBurrow's 4 block or less check (< 5) with 6 block or less check to match the SH value SH checks players location instead of burrow's here, so might be a bit different of a case, but I think it is best to keep magic constants identical in any case.
- Replaced a 1000ms constant in PreciseGuessBurrow lastGuessTime check to 3000ms to match the SH value.

Also updated Fabric API to 0.15.0 while building for 26.1.2.

Still need to test whether or not if it changes anything (likely not much, but better if code looks closer to SH, as users report it's implementation performs better) or if it breaks anything. Will mark as draft till testing is done.