### PR TITLE
Small cleanup

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,4 +1,3 @@
-import java.nio.charset.StandardCharsets
 import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
 import org.jetbrains.kotlin.buildtools.api.ExperimentalBuildToolsApi
 import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
@@ -20,7 +19,7 @@ private val mcProject: String = project.name
 private val mcVersion: String = mcProject.replace("-fabric", "")
 
 private fun versionedProperty(name: String): String {
-    return project.property("${name}.${mcVersion}")?.toString() ?: throw AssertionError("build.gradle.kts needs updating for ${mcProject}")
+    return project.property("${name}.${mcVersion}")?.toString() ?: throw AssertionError("build.gradle.kts needs updating for $mcProject")
 }
 
 private fun isUnobfuscatedMCVersion(): Boolean {
@@ -216,8 +215,8 @@ tasks.withType<KotlinJvmCompile> {
 }
 
 tasks.matching { it.name.contains("Test") || it.name.contains("test") }.configureEach {
-    // One of the tasks create problems since preprocessTestCode reads output of kspTestKotlin without depending on it
-    // We don't have any tests anyway; so this OK to disable to workaround the error.
+    // One of the tasks create problems since preprocessTestCode reads output of kspTestKotlin without depending on it,
+    // We don't have any tests anyway; so this OK to disable to work around the error.
     enabled = false
 }
 
@@ -317,7 +316,7 @@ dependencies {
     maybeModImplementation("net.fabricmc.fabric-api:fabric-api:${versionedProperty("fabricapi.version")}")
     implementation("net.fabricmc:fabric-language-kotlin:${property("fabriclanguagekotlin.version")}")
 
-    ksp(project(":event-processor"))
+    implementation(ksp(project(":event-processor"))!!)
     ksp("dev.zacsweers.autoservice:auto-service-ksp:${property("autoservice.version")}")
 
     implementation(include("gg.essential:elementa:${property("elementa.version")}")!!)
@@ -344,10 +343,9 @@ dependencies {
             maybeModImplementation(include("gg.essential:universalcraft-1.21.9-fabric:${property("universalcraft.version")}")!!)
             compileOnly("maven.modrinth:iris:${versionedProperty("iris.version")}+1.21.10-fabric")
         }
-        else -> throw AssertionError("build.gradle.kts needs updating for ${mcProject}")
+        else -> throw AssertionError("build.gradle.kts needs updating for $mcProject")
     }
 
-    implementation(project(":event-processor"))
     runtimeOnly("me.djtheredstoner:DevAuth-fabric:${property("devauth.version")}")
 }
 
@@ -355,6 +353,6 @@ tasks.findByName("preprocessCode")?.apply {
     when (mcProject) {
         "26.1.2-fabric" -> dependsOn(":1.21.11-fabric:kspKotlin")
         "1.21.11-fabric" -> dependsOn(":1.21.10-fabric:kspKotlin")
-        else -> throw AssertionError("build.gradle.kts needs updating for ${mcProject}")
+        else -> throw AssertionError("build.gradle.kts needs updating for $mcProject")
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -54,7 +54,7 @@ java.version.1.21.11=21
 java.version.26.1.2=25
 
 # Fabric Loader
-fabricloader.version=0.19.2
+fabricloader.version=0.19.3
 
 # Fabric Language Kotlin
 fabriclanguagekotlin.version=1.13.11+kotlin.2.3.21

--- a/src/main/java/net/sbo/mod/mixin/PacketMixin.java
+++ b/src/main/java/net/sbo/mod/mixin/PacketMixin.java
@@ -15,13 +15,13 @@ import io.netty.channel.ChannelFutureListener;
 
 @Mixin(Connection.class)
 public class PacketMixin {
-    // recived S2C packets
+    // received S2C packets
     @Inject(method = "channelRead0(Lio/netty/channel/ChannelHandlerContext;Lnet/minecraft/network/protocol/Packet;)V", at = @At("HEAD"))
     private void onPacketReceive(ChannelHandlerContext context, Packet<?> packet, CallbackInfo ci) {
         SBOEvent.INSTANCE.emit(new PacketReceiveEvent(packet));
     }
 
-    // sended C2S packets
+    // sent C2S packets
     @Inject(method = "send(Lnet/minecraft/network/protocol/Packet;Lio/netty/channel/ChannelFutureListener;)V", at = @At("HEAD"))
     private void onPacketSend(Packet<?> packet, ChannelFutureListener channelFutureListener, CallbackInfo ci) {
         SBOEvent.INSTANCE.emit(new PacketSendEvent(packet));

--- a/src/main/kotlin/net/sbo/mod/compat/IrisCompatibility.kt
+++ b/src/main/kotlin/net/sbo/mod/compat/IrisCompatibility.kt
@@ -4,19 +4,17 @@ import net.irisshaders.iris.api.v0.IrisApi
 import net.irisshaders.iris.api.v0.IrisProgram
 import net.sbo.mod.utils.render.SboRenderPipelines
 
-private typealias Pipelines = SboRenderPipelines
-
 object IrisCompatibility {
 
     fun init() {
         IrisApi.getInstance().apply {
-            assignPipeline(Pipelines.FILLED_BOX_THROUGH_WALLS, IrisProgram.BASIC)
-            assignPipeline(Pipelines.LINES, IrisProgram.LINES)
-            assignPipeline(Pipelines.LINES_THROUGH_WALLS, IrisProgram.LINES)
-            assignPipeline(Pipelines.BEACON_BEAM_OPAQUE, IrisProgram.BEACON_BEAM)
-            assignPipeline(Pipelines.BEACON_BEAM_OPAQUE_THROUGH_WALLS, IrisProgram.BEACON_BEAM)
-            assignPipeline(Pipelines.BEACON_BEAM_TRANSLUCENT, IrisProgram.BEACON_BEAM)
-            assignPipeline(Pipelines.BEACON_BEAM_TRANSLUCENT_THROUGH_WALLS, IrisProgram.BEACON_BEAM)
+            assignPipeline(SboRenderPipelines.FILLED_BOX_THROUGH_WALLS, IrisProgram.BASIC)
+            assignPipeline(SboRenderPipelines.LINES, IrisProgram.LINES)
+            assignPipeline(SboRenderPipelines.LINES_THROUGH_WALLS, IrisProgram.LINES)
+            assignPipeline(SboRenderPipelines.BEACON_BEAM_OPAQUE, IrisProgram.BEACON_BEAM)
+            assignPipeline(SboRenderPipelines.BEACON_BEAM_OPAQUE_THROUGH_WALLS, IrisProgram.BEACON_BEAM)
+            assignPipeline(SboRenderPipelines.BEACON_BEAM_TRANSLUCENT, IrisProgram.BEACON_BEAM)
+            assignPipeline(SboRenderPipelines.BEACON_BEAM_TRANSLUCENT_THROUGH_WALLS, IrisProgram.BEACON_BEAM)
         }
     }
 

--- a/src/main/kotlin/net/sbo/mod/guis/partyfinder/PartyFinderGUI.kt
+++ b/src/main/kotlin/net/sbo/mod/guis/partyfinder/PartyFinderGUI.kt
@@ -882,6 +882,17 @@ class PartyFinderGUI : WindowScreen(ElementaVersion.V10) {
         }
     }
 
+    private fun stpBtn(btn: GuiHandler.Button) {
+        btn.textObject.setTextScale(getTextScale())
+        btn.uiObject.addChild(GuiHandler.UILine(
+            x = CenterConstraint(),
+            y = 100.percent(),
+            (btn.textObject.getWidth() + 10).pixels(),
+            10.percent(),
+            Color(0, 110, 250, 255)
+        ).get())
+    }
+
     private fun createGui() {
         filterBackground = UIBlock().constrain {
             width = 100.percent()
@@ -994,14 +1005,7 @@ class PartyFinderGUI : WindowScreen(ElementaVersion.V10) {
             .setTextOnClick {
                 Util.getPlatform().openUri("https://discord.gg/QvM6b9jsJD")
             }
-        discord.textObject.setTextScale(getTextScale())
-        discord.uiObject.addChild(GuiHandler.UILine(
-            x = CenterConstraint(),
-            y = 100.percent(),
-            (discord.textObject.getWidth() + 10).pixels(),
-            10.percent(),
-            Color(0, 110, 250, 255)
-        ).get())
+        stpBtn(discord)
 
         val githubBlock = UIBlock().constrain {
             width = 11.percent()
@@ -1023,14 +1027,7 @@ class PartyFinderGUI : WindowScreen(ElementaVersion.V10) {
             .setTextOnClick {
                 Util.getPlatform().openUri("https://github.com/SkyblockOverhaul/SBO-Kotlin")
             }
-        github.textObject.setTextScale(getTextScale())
-        github.uiObject.addChild(GuiHandler.UILine(
-            x = CenterConstraint(),
-            y = 100.percent(),
-            (github.textObject.getWidth() + 10).pixels(),
-            10.percent(),
-            Color(0, 110, 250, 255)
-        ).get())
+        stpBtn(github)
 
         val patreonBlock = UIBlock().constrain {
             width = 11.percent()

--- a/src/main/kotlin/net/sbo/mod/utils/SboTimerManager.kt
+++ b/src/main/kotlin/net/sbo/mod/utils/SboTimerManager.kt
@@ -5,7 +5,6 @@ import net.sbo.mod.utils.data.DianaTracker
 import net.sbo.mod.utils.events.Register
 import net.sbo.mod.utils.events.annotations.SboEvent
 import net.sbo.mod.utils.events.impl.game.DisconnectEvent
-import java.util.Locale
 import net.sbo.mod.settings.categories.Diana
 import java.util.concurrent.CopyOnWriteArraySet
 

--- a/src/main/kotlin/net/sbo/mod/utils/chat/Chat.kt
+++ b/src/main/kotlin/net/sbo/mod/utils/chat/Chat.kt
@@ -9,7 +9,6 @@ import net.minecraft.client.gui.components.ChatComponent
 import net.minecraft.ChatFormatting
 import net.sbo.mod.utils.events.ClickActionManager
 import net.sbo.mod.settings.categories.General
-import net.sbo.mod.utils.chat.ChatMessageQueue
 
 object Chat {
 

--- a/src/main/kotlin/net/sbo/mod/utils/collection/CacheMap.kt
+++ b/src/main/kotlin/net/sbo/mod/utils/collection/CacheMap.kt
@@ -88,7 +88,7 @@ abstract class CacheMap<K : Any, V : Any> : MutableMap<K, V> {
             }
         }
 
-        inline fun <K : Any, V : Any> buildCache(block: CacheBuilder<K, V>.() -> Unit): Cache<K, V> {
+        fun <K : Any, V : Any> buildCache(block: CacheBuilder<K, V>.() -> Unit): Cache<K, V> {
             @Suppress("UNCHECKED_CAST")
             return (CacheBuilder.newBuilder() as CacheBuilder<K, V>).apply(block).build()
         }

--- a/src/main/kotlin/net/sbo/mod/utils/data/SboDataObject.kt
+++ b/src/main/kotlin/net/sbo/mod/utils/data/SboDataObject.kt
@@ -514,8 +514,6 @@ object SboDataObject {
         }
     }
 
-    private val backupRegex = Regex("SBOBackup_\\d{8}_\\d{6}")
-
     private fun cleanupBrokenBackups(modName: String, backupDir: File) {
         val files = backupDir.listFiles() ?: return
 

--- a/src/main/kotlin/net/sbo/mod/utils/game/InventoryUtils.kt
+++ b/src/main/kotlin/net/sbo/mod/utils/game/InventoryUtils.kt
@@ -1,7 +1,6 @@
 package net.sbo.mod.utils.game
 
 import net.minecraft.client.Minecraft
-import net.minecraft.core.component.DataComponents
 import net.minecraft.world.item.ItemStack
 import net.minecraft.core.registries.BuiltInRegistries
 import net.sbo.mod.SBOKotlin

--- a/src/main/kotlin/net/sbo/mod/utils/game/Mayor.kt
+++ b/src/main/kotlin/net/sbo/mod/utils/game/Mayor.kt
@@ -8,7 +8,6 @@ import java.util.Calendar
 import java.util.Date
 import java.util.GregorianCalendar
 import kotlin.math.floor
-import kotlin.math.round
 
 object Mayor {
     private const val SKYBLOCK_EPOCH = 1560276000L

--- a/src/main/kotlin/net/sbo/mod/utils/render/RenderUtils3D.kt
+++ b/src/main/kotlin/net/sbo/mod/utils/render/RenderUtils3D.kt
@@ -87,9 +87,6 @@ object RenderUtils3D {
      * Draws a filled box at the specified world coordinates.
      * @param context The world render context.
      * @param pos The position in the world where the box should be drawn.
-     * @param width The width of the box.
-     * @param height The height of the box.
-     * @param depth The depth of the box.
      * @param colorComponents The RGB color components as a FloatArray (0.0 to 1.0).
      * @param alpha The alpha value for transparency (0.0 to 1.0).
      * @param throughWalls Whether the box should be drawn through walls.
@@ -264,12 +261,11 @@ object RenderUtils3D {
     }
     /**
      * Renders a beacon beam at the given location.
-     * @param context The world render context.
+     * @param ctx The world render context.
      * @param vec The position in the world where the beacon beam should be rendered.
      * @param colorComponents The RGB color components as a FloatArray (0.0 to
      * @param phase Whether the beam should render through walls.
      */
-    @JvmOverloads
     fun renderBeaconBeam(
         ctx: WorldRenderContext,
         vec: SboVec,
@@ -418,12 +414,12 @@ object RenderUtils3D {
         return gameRenderer().mainCamera
     }
 
-    private inline fun WorldRenderContext.pushPop(function: PoseStack.() -> Unit) {
+    private fun WorldRenderContext.pushPop(function: PoseStack.() -> Unit) {
         val matrix = matrices()
         matrix.pushPop(function)
     }
 
-    private inline fun PoseStack.withLineWidth(lineWidth: Float, function: PoseStack.() -> Unit) {
+    private fun PoseStack.withLineWidth(lineWidth: Float, function: PoseStack.() -> Unit) {
         //#if MC > 1.21.10
         //$$ function()
         //#else
@@ -434,7 +430,7 @@ object RenderUtils3D {
         //#endif
     }
 
-    private inline fun PoseStack.pushPop(function: PoseStack.() -> Unit) {
+    private fun PoseStack.pushPop(function: PoseStack.() -> Unit) {
         this.pushPose()
         function()
         this.popPose()


### PR DESCRIPTION
- Extracted stpBtn from duplicate code in PartyFinderGUI for github and discord buttons and use the method instead to reduce duplication
- Removed typealias only used in a single file for 1 purpose, replace with real name instead directly
- Fixed "recived" and "sended" typos in PacketMixin comments
- Bumped Fabric Loader to 0.19.3
- Removed unused imports and an unused regex property
- Removed unnecessary inline fun, Java is smart enough to do inlining decisions in runtime; we only need inline fun for reified types or crossinline lambda parameters, otherwise it is not justified, leave the decision to the HotSpot C2 compiler for inlining in runtime
- Removed unnecessary JvmOverloads, it is only needed when using default parameters from Java side or when stable API is required for libraries, also fixed context --> ctx javadoc reference and removed invalid javadoc references leftover from removed parameters (width, height, depth)
- Small cleanup in build.gradle.kts; removed unused import, change ${} to $ for mcVersion, add commas and spaces missing in comments, use implementation(ksp( directly instead of seperate for event-processor project dependency