### PR TITLE
Add update toast

### DIFF
--- a/src/main/kotlin/net/sbo/mod/utils/version/UpdateChecker.kt
+++ b/src/main/kotlin/net/sbo/mod/utils/version/UpdateChecker.kt
@@ -1,6 +1,8 @@
 package net.sbo.mod.utils.version
 
-import net.minecraft.Util
+import net.minecraft.ChatFormatting
+import net.minecraft.network.chat.Component
+import net.minecraft.network.chat.Style
 import net.sbo.mod.SBOKotlin
 import net.sbo.mod.utils.chat.Chat
 import net.sbo.mod.utils.http.Http
@@ -44,6 +46,15 @@ object UpdateChecker {
         val breakLine = Chat.getChatBreak(" ", "§a§m")
 
         val versionUrl = "https://modrinth.com/mod/skyblock-overhaul/version/${latestId}"
+
+        SBOKotlin.toast(
+                Component.literal("SBO").setStyle(
+                    Style.EMPTY.withColor(ChatFormatting.GOLD)
+                ),
+                Component.literal("Outdated version, please update!").setStyle(
+                    Style.EMPTY.withColor(ChatFormatting.YELLOW)
+                )
+        )
 
         Chat.chat(breakLine)
         Chat.clickableChat(


### PR DESCRIPTION
Adds a toast message when user is using an outdated version. Suprisingly many people were still on 0.2.1-beta when we released 0.3.0-beta and was asking about bugs already fixed in 0.3.0-beta. We should make sure we give the right visibility and attention when an update is available; the chat can be clogged and scrolled up easily, a toast is much more visible and telling to the user that they should upgrade.