### PR TITLE
Add Wool and Food Highest MF

### DIFF
--- a/src/main/kotlin/net/sbo/mod/diana/DianaTracker.kt
+++ b/src/main/kotlin/net/sbo/mod/diana/DianaTracker.kt
@@ -711,9 +711,9 @@ object DianaTracker {
             when (itemId) {
                 "DAEDALUS_STICK" -> if (magicFind > sboData.highestStickMagicFind) sboData.highestStickMagicFind = magicFind
                 "CHIMERA" -> if (magicFind > sboData.highestChimMagicFind) sboData.highestChimMagicFind = magicFind
-                "MATI_CORE" -> if (magicFind > sboData.highestCoreMagicFind) sboData.highestCoreMagicFind = magicFind
+                "MANTI_CORE" -> if (magicFind > sboData.highestCoreMagicFind) sboData.highestCoreMagicFind = magicFind
                 "SHIMMERING_WOOL" -> if (magicFind > sboData.highestWoolMagicFind) sboData.highestWoolMagicFind = magicFind
-                "FABLED_STINGER" -> if (magicFind > sboData.highestStingerMagicFind) sboData.highestStingerMagicFind = magicFind
+                "FATEFUL_STINGER" -> if (magicFind > sboData.highestStingerMagicFind) sboData.highestStingerMagicFind = magicFind
                 "BRAIN_FOOD" -> if (magicFind > sboData.highestFoodMagicFind) sboData.highestFoodMagicFind = magicFind
             }
 

--- a/src/main/kotlin/net/sbo/mod/general/PartyCommands.kt
+++ b/src/main/kotlin/net/sbo/mod/general/PartyCommands.kt
@@ -6,7 +6,6 @@ import net.sbo.mod.settings.categories.PartyCommands
 import net.sbo.mod.utils.chat.Chat
 import net.sbo.mod.utils.data.SboDataObject.sboData
 import net.sbo.mod.utils.data.SboDataObject.dianaTrackerMayor
-import net.sbo.mod.utils.Helper.sleep
 import net.sbo.mod.utils.Helper.getPlayerName
 import net.sbo.mod.utils.Helper.calcPercentOne
 import net.sbo.mod.utils.Helper.formatNumber
@@ -169,7 +168,7 @@ object PartyCommands {
             "Mobs: $totalMobs ($perHr/h)"
         },
         PartyCommand(listOf("!mf", "!magicfind"), { settings.dianaPartyCommands }) {
-            "Chims (${sboData.highestChimMagicFind}% ✯) Sticks (${sboData.highestStickMagicFind}% ✯)"
+            "Wools (${sboData.highestWoolMagicFind}% ✯) Chims (${sboData.highestChimMagicFind}% ✯) Foods (${sboData.highestFoodMagicFind}% ✯) Sticks (${sboData.highestStickMagicFind}% ✯)"
         },
         PartyCommand(listOf("!playtime"), { settings.dianaPartyCommands }) {
             "Playtime: ${formatTime(dianaTrackerMayor.items.TIME)}"

--- a/src/main/kotlin/net/sbo/mod/overlays/MagicFind.kt
+++ b/src/main/kotlin/net/sbo/mod/overlays/MagicFind.kt
@@ -19,7 +19,9 @@ object MagicFind : DirtyFlushableOverlay() {
     override fun generateLines(): List<OverlayTextLine> {
         return listOf(
             OverlayTextLine("$YELLOW${BOLD}Diana MagicFind"),
+            OverlayTextLine("$GRAY - ${RED}Wools: $AQUA${sboData.highestWoolMagicFind}%"),
             OverlayTextLine("$GRAY - ${LIGHT_PURPLE}Chimera: $AQUA${sboData.highestChimMagicFind}%"),
+            OverlayTextLine("$GRAY - ${DARK_PURPLE}Foods: $AQUA${sboData.highestFoodMagicFind}%"),
             OverlayTextLine("$GRAY - ${GOLD}Sticks: $AQUA${sboData.highestStickMagicFind}%")
         )
     }


### PR DESCRIPTION
Adds Shimmering Wool and Brain Food Highest Magic Find to Magic Find overlay GUI and the !mf party command.

These were already tracked correctly before.

Also fixed typos to make tracking highest magic find for manti core and fateful stinger drops work:
 - MATI_CORE --> MANTI_CORE
 - FABLED_STINGER --> FATEFUL_STINGER

This PR intentionally does not add Manti Core and Fateful Stinger to the overlay and the command yet because the user will most likely have 0 magic find on them due to the typos in previous versions - ship a fixed version first so that users get their highest magic find tracked, then we can later add these as well.