### PR TITLE
Further reduce reliancy on changing MC imports

### DIFF
--- a/src/main/kotlin/net/sbo/mod/SBOKotlin.kt
+++ b/src/main/kotlin/net/sbo/mod/SBOKotlin.kt
@@ -70,6 +70,15 @@ object SBOKotlin : ClientModInitializer {
 
 	fun id(path: String, owner: String = MOD_ID): ResourceLocation = ResourceLocation.fromNamespaceAndPath(owner, path)
 
+    fun userSuppliedId(path: String, owner: String = MOD_ID, onInvalid: (IdentifierException) -> Unit): ResourceLocation? {
+        return try {
+            id(path = path, owner = owner)
+        } catch (invalidIdentifierException: IdentifierException) {
+            onInvalid(invalidIdentifierException)
+            null
+        }
+    }
+
     fun toast(title: Component, message: Component) {
         mc.toastManager.addToast(
             SystemToast.multiline(mc, SystemToast.SystemToastId.PERIODIC_NOTIFICATION, title, message)

--- a/src/main/kotlin/net/sbo/mod/SBOKotlin.kt
+++ b/src/main/kotlin/net/sbo/mod/SBOKotlin.kt
@@ -73,7 +73,7 @@ object SBOKotlin : ClientModInitializer {
     fun userSuppliedId(path: String, owner: String = MOD_ID, onInvalid: (IdentifierException) -> Unit): ResourceLocation? {
         return try {
             id(path = path, owner = owner)
-        } catch (invalidIdentifierException: IdentifierException) {
+        } catch (invalidIdentifierException: ResourceLocationException) {
             onInvalid(invalidIdentifierException)
             null
         }

--- a/src/main/kotlin/net/sbo/mod/SBOKotlin.kt
+++ b/src/main/kotlin/net/sbo/mod/SBOKotlin.kt
@@ -7,6 +7,7 @@ import net.minecraft.Util
 import net.minecraft.client.Minecraft
 import net.minecraft.client.gui.components.toasts.SystemToast
 import net.minecraft.resources.ResourceLocation
+import net.minecraft.ResourceLocationException
 import net.minecraft.network.chat.Component
 import net.sbo.mod.compat.IrisCompatibility
 import net.sbo.mod.diana.DianaTracker
@@ -70,7 +71,7 @@ object SBOKotlin : ClientModInitializer {
 
 	fun id(path: String, owner: String = MOD_ID): ResourceLocation = ResourceLocation.fromNamespaceAndPath(owner, path)
 
-    fun userSuppliedId(path: String, owner: String = MOD_ID, onInvalid: (IdentifierException) -> Unit): ResourceLocation? {
+    fun userSuppliedId(path: String, owner: String = MOD_ID, onInvalid: (ResourceLocationException) -> Unit): ResourceLocation? {
         return try {
             id(path = path, owner = owner)
         } catch (invalidIdentifierException: ResourceLocationException) {

--- a/src/main/kotlin/net/sbo/mod/utils/SoundHandler.kt
+++ b/src/main/kotlin/net/sbo/mod/utils/SoundHandler.kt
@@ -7,7 +7,6 @@ import net.minecraft.SharedConstants
 import net.minecraft.client.resources.sounds.SimpleSoundInstance
 import net.minecraft.server.packs.PackType
 import net.minecraft.sounds.SoundEvent
-import net.minecraft.ResourceLocationException
 import net.sbo.mod.SBOKotlin
 import net.sbo.mod.SBOKotlin.MOD_ID
 import net.sbo.mod.SBOKotlin.mc
@@ -140,11 +139,14 @@ object SoundHandler {
             return
         }
 
-        val id = try {
-            SBOKotlin.id(safeSound)
-        } catch (invalidIdentifierError: ResourceLocationException) {
-            Chat.chat("§6[SBO] §cInvalid sound name. Use letters, numbers, _ or -")
-            logger.error("Invalid sound ID: $sound", invalidIdentifierError)
+        val id = SBOKotlin.userSuppliedId(safeSound) { invalidIdentifierException ->
+            Chat.chat("§6[SBO] §cInvalid sound name \"$sound\". Use letters, numbers, _ or -")
+            logger.error("Invalid sound ID: $sound", invalidIdentifierException)
+        }
+
+        if (id == null) {
+            Chat.chat("§6[SBO] §cUnknown error when creating Identifier for sound ID: $sound")
+            logger.error("Unknown error when creating Identifier for sound ID: $sound")
             return
         }
 

--- a/src/main/kotlin/net/sbo/mod/utils/SoundHandler.kt
+++ b/src/main/kotlin/net/sbo/mod/utils/SoundHandler.kt
@@ -7,6 +7,7 @@ import net.minecraft.SharedConstants
 import net.minecraft.client.resources.sounds.SimpleSoundInstance
 import net.minecraft.server.packs.PackType
 import net.minecraft.sounds.SoundEvent
+import net.minecraft.ResourceLocationException
 import net.sbo.mod.SBOKotlin
 import net.sbo.mod.SBOKotlin.MOD_ID
 import net.sbo.mod.SBOKotlin.mc

--- a/src/main/kotlin/net/sbo/mod/utils/game/ServerStats.kt
+++ b/src/main/kotlin/net/sbo/mod/utils/game/ServerStats.kt
@@ -4,7 +4,6 @@ import net.sbo.mod.utils.events.annotations.SboEvent
 import net.sbo.mod.utils.events.impl.packets.PacketReceiveEvent
 import net.minecraft.network.protocol.game.ClientboundLoginPacket
 import net.minecraft.network.protocol.game.ClientboundSetTimePacket
-import net.minecraft.Util
 import kotlin.math.max
 
 object ServerStats {
@@ -20,7 +19,7 @@ object ServerStats {
     fun onPacketReceive(event: PacketReceiveEvent) {
         when (event.packet) {
             is ClientboundSetTimePacket -> {
-                val currentTime = Util.getMillis()
+                val currentTime = System.currentTimeMillis()
                 if (prevTime != 0L) {
                     val deltaTime = currentTime - prevTime
                     averageTps = (20000f / max(1, deltaTime)).coerceIn(0f, 20f)


### PR DESCRIPTION
- Add userSuppliedId that catches the exception to avoid importing the exception type from outside of main class
 The exception type's name also changes between MC versions occassionally.

- Use System.currentTimeMillis() directly to avoid importing MC's Util class, which changes between MC versions.