### PR TITLE
Fix hover text not rendering

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -69,6 +69,7 @@ bloom {
         replacement("override fun render(", "override fun extractRenderState(")
         replacement("super.render(", "super.extractRenderState(")
         replacement("this.renderMenuBackground", "this.extractMenuBackground")
+        replacement("drawContext.renderTooltip(", "drawContext.tooltip(")
 
         // Render --> Extract (Hacky way to fix Mixins, too lazy for versioned Mixins)
         replacement("@Inject(method = \"render\", at = @At(\"HEAD\"))", "@Inject(method = \"extractRenderState\", at = @At(\"HEAD\"))")

--- a/src/main/kotlin/net/sbo/mod/overlays/DianaLoot.kt
+++ b/src/main/kotlin/net/sbo/mod/overlays/DianaLoot.kt
@@ -189,7 +189,7 @@ object DianaLoot : DirtyFlushableOverlay() {
                     drawContext,
                     "$YELLOW${Helper.toTitleCase(itemNameBase.replace("_", " ").lowercase())} LS Details:\n" +
                             lsText,
-                    mouseX, mouseY, textRenderer, overlay.scale
+                    mouseX, mouseY, textRenderer
                 )
             }
         if (SBOConfigBundle.sboData.hideTrackerLines.contains(itemNameBase)) {
@@ -303,7 +303,7 @@ object DianaLoot : DirtyFlushableOverlay() {
                             "${GOLD}Treasure: $AQUA${Helper.formatNumber(tracker.items.COINS - tracker.items.FISH_COINS - tracker.items.SCAVENGER_COINS)}\n" +
                             "${GOLD}Four-Eyed Fish: $AQUA${Helper.formatNumber(tracker.items.FISH_COINS)}\n" +
                             "${GOLD}Scavenger: $AQUA${Helper.formatNumber(tracker.items.SCAVENGER_COINS)}",
-                    mouseX, mouseY, textRenderer, overlay.scale)
+                    mouseX, mouseY, textRenderer)
             }
     }
 
@@ -317,7 +317,7 @@ object DianaLoot : DirtyFlushableOverlay() {
                 RenderUtils2D.drawHoveringString(drawContext,
                     "$GOLD$profitPerHr coins/hr\n" +
                             "$GOLD$profitPerBurrow coins/burrow",
-                    mouseX, mouseY, textRenderer, overlay.scale)
+                    mouseX, mouseY, textRenderer)
             }
     }
 

--- a/src/main/kotlin/net/sbo/mod/utils/overlay/Overlay.kt
+++ b/src/main/kotlin/net/sbo/mod/utils/overlay/Overlay.kt
@@ -164,9 +164,9 @@ class Overlay(
     }
 
     private class LineRenderState(
-        private val line: OverlayTextLine,
-        private val x: Int,
-        private val y: Int
+        val line: OverlayTextLine,
+        val x: Int,
+        val y: Int
     )
 
     fun render(drawContext: GuiGraphics, mouseX: Double, mouseY: Double) {

--- a/src/main/kotlin/net/sbo/mod/utils/overlay/Overlay.kt
+++ b/src/main/kotlin/net/sbo/mod/utils/overlay/Overlay.kt
@@ -163,6 +163,12 @@ class Overlay(
         return mouseX >= x && mouseX <= x + totalWidth && mouseY >= y && mouseY <= y + totalHeight
     }
 
+    private class LineRenderState(
+        val line: OverlayTextLine,
+        val x: Int,
+        val y: Int
+    )
+
     fun render(drawContext: GuiGraphics, mouseX: Double, mouseY: Double) {
         if (!condition()) return
         val textRenderer = mc.font
@@ -188,17 +194,32 @@ class Overlay(
             drawContext.fill(currentX.toInt(), currentY.toInt(), (currentX + totalWidth).toInt(), (currentY + totalHeight).toInt(), Color(0, 0, 0, 100).rgb)
         }
 
-        val shouldRender by lazy(LazyThreadSafetyMode.NONE) { allowedScreens.any { it(mc.screen) } }
+        val lines = getLines()
+        val lineStates = mutableListOf<LineRenderState>()
 
-        for (line in getLines()) {
+        for (line in lines) {
             if (!line.checkCondition()) continue
-            if (shouldRender) line.updateMouseInteraction(mouseX, mouseY, currentX * scale, currentY * scale, textRenderer, scale, drawContext)
-            line.draw(drawContext, currentX.toInt(), currentY.toInt(), textRenderer)
+
+            val lineX = currentX.toInt()
+            val lineY = currentY.toInt()
+
+            lineStates += LineRenderState(line, lineX, lineY)
+            line.draw(drawContext, lineX, lineY, textRenderer)
+
             if (line.linebreak) {
                 currentY += textRenderer.lineHeight + 1
                 currentX = (x / scale)
             } else {
                 currentX += line.width
+            }
+        }
+
+        val shouldRender by lazy(LazyThreadSafetyMode.NONE) { allowedScreens.any { it(mc.screen) } }
+
+        for (state in lineStates) {
+            if (shouldRender) {
+                // renders the hover text after all main text, so that hover text renders on top of them instead of below
+                state.line.updateMouseInteraction(mouseX, mouseY, state.x * scale, state.y * scale, textRenderer, scale, drawContext)
             }
         }
 

--- a/src/main/kotlin/net/sbo/mod/utils/overlay/Overlay.kt
+++ b/src/main/kotlin/net/sbo/mod/utils/overlay/Overlay.kt
@@ -164,9 +164,9 @@ class Overlay(
     }
 
     private class LineRenderState(
-        val line: OverlayTextLine,
-        val x: Int,
-        val y: Int
+        private val line: OverlayTextLine,
+        private val x: Int,
+        private val y: Int
     )
 
     fun render(drawContext: GuiGraphics, mouseX: Double, mouseY: Double) {

--- a/src/main/kotlin/net/sbo/mod/utils/render/RenderUtils2D.kt
+++ b/src/main/kotlin/net/sbo/mod/utils/render/RenderUtils2D.kt
@@ -2,6 +2,8 @@ package net.sbo.mod.utils.render
 
 import net.minecraft.client.gui.Font
 import net.minecraft.client.gui.GuiGraphics
+import net.minecraft.client.gui.screens.inventory.tooltip.ClientTooltipComponent
+import net.minecraft.client.gui.screens.inventory.tooltip.DefaultTooltipPositioner
 import net.minecraft.network.chat.Component
 
 object RenderUtils2D {
@@ -11,17 +13,10 @@ object RenderUtils2D {
         x: Double,
         y: Double,
         textRenderer: Font,
-        scale: Float = 1.0f,
-        padding: Int = 2
     ) {
         if (text.isEmpty()) return
 
         val textLines = text.split("\n").map { Component.nullToEmpty(it) }
-
-        drawContext.pose().pushMatrix()
-
-        drawContext.setComponentTooltipForNextFrame(textRenderer, textLines, x.toInt(), y.toInt())
-
-        drawContext.pose().popMatrix()
+        drawContext.renderTooltip(textRenderer, textLines.map { it.visualOrderText }.map { ClientTooltipComponent.create(it) }, x.toInt(), y.toInt(), DefaultTooltipPositioner.INSTANCE, null)
     }
 }


### PR DESCRIPTION
I think this was broken ever since 1.21.8 and only worked on 1.21.5.

This fixes it fully. Tested and works in 26.1.2; should work on others as well. Restores the functionality of being able to see LS details on combined loot tracker, coins from four-eyed fish etc., by hovering over the relevant lines.

---

I think the issue was happening because setComponentTooltipForNextFrame was used instead of renderTooltip. This code path is called every render frame, so it keeps delaying render to next frame each time and in the end nothing is rendered. By calling the correct method, the issue is fixed. However, now the overlays would render below the regular HUD lines, making them hard to read; so I had to modify the overlay rendering loop to do a second pass with the same X and Y line states saved to render the hover text after all normal lines, which fixed the issue. Also removed the unused scale and padding parameters, and the unused push/pop matrix calls (the vanilla renderTooltip already does push/pop for us)