### PR TITLE
Fix SBO pause menu button location

### DIFF
--- a/src/main/java/net/sbo/mod/mixin/PauseScreenMixin.java
+++ b/src/main/java/net/sbo/mod/mixin/PauseScreenMixin.java
@@ -1,36 +1,53 @@
 package net.sbo.mod.mixin;
 
 import gg.essential.universal.UScreen;
-import net.minecraft.client.gui.screens.PauseScreen;
-import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.client.gui.components.Button;
+import net.minecraft.client.gui.layouts.GridLayout.RowHelper;
+import net.minecraft.client.gui.layouts.LayoutElement;
+import net.minecraft.client.gui.screens.PauseScreen;
 import net.minecraft.network.chat.Component;
 import net.sbo.mod.SBOKotlin;
 import net.sbo.mod.guis.AchievementsGUI;
 import net.sbo.mod.guis.Guis;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(PauseScreen.class)
-public abstract class PauseScreenMixin extends Screen {
+public abstract class PauseScreenMixin {
+    @Unique
+    int addedButtons;
+    @Unique
+    boolean injected = false;
 
-    protected PauseScreenMixin() {
-        super(null);
+    @Inject(method = "createPauseMenu", at = @At(value = "HEAD"))
+    void sbo$createPauseMenuHead(CallbackInfo ci) {
+        addedButtons = 0;
+        injected = false;
     }
 
-    @Inject(method = "init", at = @At("TAIL"))
-    private void onInit(CallbackInfo ci) {
-        PauseScreen self = (PauseScreen)(Object)this;
+    @Redirect(method = "createPauseMenu", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/layouts/GridLayout$RowHelper;addChild(Lnet/minecraft/client/gui/layouts/LayoutElement;)Lnet/minecraft/client/gui/layouts/LayoutElement;"))
+    LayoutElement sbo$onAddChild(RowHelper helper, LayoutElement original) {
+        if (addedButtons == 0 && !injected) {
+            injected = true;
 
-        Button button = Button.builder(Component.literal("SBO"), b -> SBOKotlin.mc.schedule(() -> {
-            if (Guis.INSTANCE.getAchievementsGui() == null) {
-                Guis.INSTANCE.setAchievementsGui(new AchievementsGUI());
-            }
-            UScreen.displayScreen(Guis.INSTANCE.getAchievementsGui());
-        })).bounds(self.width / 2 + 104, self.height / 4 + 32, 30, 20).build();
+            Button custom = Button.builder(
+                    Component.literal("SBO Achievements"),
+                    b -> SBOKotlin.mc.schedule(() -> {
+                        if (Guis.INSTANCE.getAchievementsGui() == null) {
+                            Guis.INSTANCE.setAchievementsGui(new AchievementsGUI());
+                        }
+                        UScreen.displayScreen(Guis.INSTANCE.getAchievementsGui());
+                    })
+            ).width(204).build();
 
-        this.addRenderableWidget(button);
+            helper.addChild(custom, 2);
+        }
+
+        addedButtons++;
+        return helper.addChild(original);
     }
 }


### PR DESCRIPTION
Instead of being out of place on the right side next to all other vanilla buttons, it injects cleanly now, taking a full row under Back to Game (before vanilla Advancements button) and keeps the place of other buttons including the "Mods" icon added by Mod Menu.

Some users were having an issue where the SBO button was inside another button and so wouldn't be clickable. This should both fix that and make the button look overall better.

Image:
<img width="757" height="537" alt="image" src="https://github.com/user-attachments/assets/06c19b47-2bb4-465d-a10d-a24d10095952" />

Since this is a Mixin and Mixins are not validated until runtime, i'll mark this PR as draft till I'm able to test and confirm that it works on all our supported versions at the moment (Works in 26.1.2; needs testing for 1.21.11 and 1.21.10 if that's still supported by Hypixel when I test it)