### PR TITLE
Ignore Y Level and Prioritize Castle

### DIFF
--- a/src/main/kotlin/net/sbo/mod/utils/math/SboVec.kt
+++ b/src/main/kotlin/net/sbo/mod/utils/math/SboVec.kt
@@ -20,6 +20,12 @@ data class SboVec(var x: Double, var y: Double, var z: Double) {
         return sqrt((other.x - this.x).pow(2) + (other.y - this.y).pow(2) + (other.z - this.z).pow(2))
     }
 
+    fun distanceToIgnoringY(other: SboVec): Double {
+        val dx = x - other.x
+        val dz = z - other.z
+        return sqrt(dx * dx + dz * dz)
+    }
+
     fun distanceTo(x: Double, y: Double, z: Double): Double {
         return sqrt((x - this.x).pow(2) + (y - this.y).pow(2) + (z - this.z).pow(2))
     }

--- a/src/main/kotlin/net/sbo/mod/utils/waypoint/WarpPoint.kt
+++ b/src/main/kotlin/net/sbo/mod/utils/waypoint/WarpPoint.kt
@@ -2,6 +2,8 @@ package net.sbo.mod.utils.waypoint
 
 import net.sbo.mod.utils.math.SboVec
 
+const val COMPETITIVE_WARP_DISTANCE_THRESHOLD = 15.0
+
 /**
  * Represents a single warp point with coordinates and optional data.
  * @property pos The position of the warp point in the game world.
@@ -11,7 +13,10 @@ import net.sbo.mod.utils.math.SboVec
 data class WarpPoint(
     val pos: SboVec = SboVec(0.0, 0.0, 0.0),
     val unlocked: Boolean,
-    val setting: String? = null // Nullable, since not all warps have a setting
+    val setting: String? = null, // Nullable, since not all warps have a setting
+    val warpType: AdditionalHubWarps? = null, // null for hub, set for all others
+    val ignoreYLevel: Boolean = false,
+    val preferWarpAgainstCompetitive: AdditionalHubWarps? = null
 )
 
 val hubWarps: Map<String, WarpPoint> = mapOf(
@@ -19,13 +24,13 @@ val hubWarps: Map<String, WarpPoint> = mapOf(
 )
 
 val additionalHubWarps: Map<String, WarpPoint> = mapOf(
-    "castle" to WarpPoint(SboVec(-250.00, 130.00, 45.00), true, "castleWarp"),
-    "wizard" to WarpPoint(SboVec(44.50, 119.00, 93.50), true, "wizardWarp"),
-    "crypt" to WarpPoint(SboVec(-160.50, 62.00, -106.50), true, "cryptWarp"),
-    "stonks" to WarpPoint(SboVec(-36.50, 70.00, -81.50), true, "stonksWarp"),
-    "da" to WarpPoint(SboVec(91.50, 75.00, 173.50), true, "darkAuctionWarp"),
-    "taylor" to WarpPoint(SboVec(29.50, 73.00, -41.50), true, "taylorWarp"),
-    "museum" to WarpPoint(SboVec(29.50, 72.00, 1.50), true, "museumWarp")
+    "castle" to WarpPoint(SboVec(-250.00, 130.00, 45.00), true, "castleWarp", AdditionalHubWarps.CASTLE, true, AdditionalHubWarps.CRYPT),
+    "wizard" to WarpPoint(SboVec(44.50, 119.00, 93.50), true, "wizardWarp", AdditionalHubWarps.WIZARD, true),
+    "crypt" to WarpPoint(SboVec(-160.50, 62.00, -106.50), true, "cryptWarp", AdditionalHubWarps.CRYPT),
+    "stonks" to WarpPoint(SboVec(-36.50, 70.00, -81.50), true, "stonksWarp", AdditionalHubWarps.STONKS),
+    "da" to WarpPoint(SboVec(91.50, 75.00, 173.50), true, "darkAuctionWarp", AdditionalHubWarps.DA),
+    "taylor" to WarpPoint(SboVec(29.50, 73.00, -41.50), true, "taylorWarp", AdditionalHubWarps.TAYLOR),
+    "museum" to WarpPoint(SboVec(29.50, 72.00, 1.50), true, "museumWarp", AdditionalHubWarps.MUSEUM)
 )
 
 enum class AdditionalHubWarps {

--- a/src/main/kotlin/net/sbo/mod/utils/waypoint/WaypointManager.kt
+++ b/src/main/kotlin/net/sbo/mod/utils/waypoint/WaypointManager.kt
@@ -396,16 +396,41 @@ object WaypointManager {
             }
         }
 
+        var playerDistance = pos.distanceTo(Player.getLastPosition())
+
         var closestWarp: String? = null
+        var closestWarpPoint: WarpPoint? = null
         var closestDistance = Double.MAX_VALUE
-        val playerDistance = pos.distanceTo(Player.getLastPosition())
+
+        var secondClosestWarp: String? = null
+        var secondClosestWarpPoint: WarpPoint? = null
+        var secondClosestDistance = Double.MAX_VALUE
+
         for ((name, warp) in warps) {
-            val distance = pos.distanceTo(warp.pos)
+            val distance = if (warp.ignoreYLevel) pos.distanceToIgnoringY(warp.pos) else pos.distanceTo(warp.pos)
+
             if (distance < closestDistance) {
-                closestDistance = distance
+                secondClosestWarp = closestWarp
+                secondClosestWarpPoint = closestWarpPoint
+                secondClosestDistance = closestDistance
+
                 closestWarp = name
+                closestWarpPoint = warp
+                closestDistance = distance
+            } else if (distance < secondClosestDistance) {
+                secondClosestWarp = name
+                secondClosestWarpPoint = warp
+                secondClosestDistance = distance
             }
         }
+
+        if (secondClosestWarpPoint?.preferWarpAgainstCompetitive == closestWarpPoint?.warpType && secondClosestDistance - closestDistance < COMPETITIVE_WARP_DISTANCE_THRESHOLD) {
+            closestWarp = secondClosestWarp
+            closestWarpPoint = secondClosestWarpPoint
+            closestDistance = secondClosestDistance
+        }
+
+        if (closestWarpPoint?.ignoreYLevel == true) playerDistance = pos.distanceToIgnoringY(Player.getLastPosition())
 
         val condition1 = playerDistance > (closestDistance + Diana.warpDiff)
         val condition2 = condition1 && (closestWaypoint.second > 60 || getWaypointsOfType("rareMob").isNotEmpty())


### PR DESCRIPTION
Per user recommendation, for Castle and Wizard warps only uses X and Z distance, ignoring Y, and makes it so Castle takes priority over Crypt warp if Crypt is the closest but Castle is only 15 blocks short of becoming closest and is the second closest warp.

Draft because i need to add config options later as users said 15 blocks is too low so I need to bump default to like 50 but also make it configurable. Also need config options to make the new behaviour of ignoring Y and prioritizing Castle itself toggleable (and possibly false by default since it's potentially not the "closest" anymore).