### PR TITLE
More enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,15 +19,15 @@ This mod is heavily focused on the Diana event, providing numerous tools to help
 
 * **Diana Burrow Guessing**: Precise Diana Guess.
 * **Diana Burrow Detection**: Automatically detects and highlights Diana burrows.
-* **Diana Warp**: Allowy you to instantly warp to the location you guessed.
+* **Diana Warp**: Allows you to instantly warp to the location you guessed.
   * **Customizable Warp Locations**: (Crypt, DA, Wizard, Castle, Stonks)
   * **Don't Warp If Burrow Close**: Prevents accidental warps if you are within 60 blocks of a burrow.
   * **Warp Delay**: Configurable delay before you are able to warp mainly used to make the guess more precise.
 * **Diana Trackers**: Adds multiple on-screen overlays to keep track of your progress. You can move these overlays with the `/sboguis` command.
   * **Mob Tracker**: Tracks your Diana mob kills.
   * **Loot Tracker**: Tracks your Diana loot.
-  * **Inquis Loot**: Tracks your inquis loot.
-  * **Stats Tracker**: Tracks your Diana stats (Since inq, Since chim, etc).
+  * **Inquisitor Loot**: Tracks your inquisitor loot.
+  * **Stats Tracker**: Tracks your Diana stats (Since inq, Since chim, etc.,).
   * **Magic Find Tracker**: Tracks your highest magic find for sticks/chims.
 * **Loot Announcers**: Get notified about your rare drops.
   * **Chat Announcer**: Announces rare drops like relics in your chat.
@@ -58,7 +58,7 @@ The mod offers a wide range of options to personalize your experience.
   * **Diana Party Commands**: Use commands like `!chim` or `!inq` to share your stats with your party.
 * **Party Finder**:
   * **Auto-Invite**: Automatically invites players who meet your party requirements.
-  * **Auto-Requeue**: Automatically requeues your party after a member leaves.
+  * **Auto-Requeue**: Automatically re-queues your party after a member leaves.
 * **Message Hiders**: Reduce chat clutter by hiding messages from Diana events, AutoPet, Implosion, and Sacks.
 * **Phoenix Announcer**: Get an on-screen announcement when you drop a Phoenix pet.
 
@@ -72,7 +72,7 @@ Before you begin, you need to have a few things installed:
 
 * **Fabric API**: This is a dependency for most Fabric mods, including SkyblockOverhaul. [Download it from Modrinth](https://modrinth.com/mod/fabric-api)
 * **Fabric Language Kotlin**: This mod is written in Kotlin, so you need this library as well. [Download it from Modrinth](https://modrinth.com/mod/fabric-language-kotlin)
-* **Mod Menu**: needed so sbo settings show up in mod page ingame. [Download it from Modrinth](https://modrinth.com/mod/modmenu)
+* **Mod Menu**: needed so sbo settings show up in mod page in game. [Download it from Modrinth](https://modrinth.com/mod/modmenu)
 
 ### Step-by-Step Installation Guide
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -70,7 +70,7 @@ bloom {
         replacement("@Inject(method = \"render\", at = @At(\"HEAD\"))", "@Inject(method = \"extractRenderState\", at = @At(\"HEAD\"))")
         replacement("Lnet/minecraft/client/gui/Gui;render(", "Lnet/minecraft/client/gui/Gui;extractRenderState(")
         replacement("@Inject(method = \"render\", at = @At(value = \"INVOKE\", target = ", "@Inject(method = \"extractGui\", at = @At(value = \"INVOKE\", target = ")
-        replacement("private void afterHudRender(DeltaTracker tickCounter, boolean tick, ", "private void afterHudRender(DeltaTracker tickCounter, boolean tick, boolean resourcesLoaded, ")
+        replacement("private void afterHudRender(@NonNull DeltaTracker tickCounter, boolean tick, ", "private void afterHudRender(@NonNull DeltaTracker tickCounter, boolean tick, boolean resourcesLoaded, ")
 
         // drawString --> text
         replacement("drawContext.drawString(", "drawContext.text(")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -318,7 +318,7 @@ dependencies {
     maybeModImplementation("net.fabricmc.fabric-api:fabric-api:${versionedProperty("fabricapi.version")}")
     implementation("net.fabricmc:fabric-language-kotlin:${property("fabriclanguagekotlin.version")}")
 
-    implementation(ksp(project(":event-processor"))!!)
+    ksp(project(":event-processor"))
     ksp("dev.zacsweers.autoservice:auto-service-ksp:${property("autoservice.version")}")
 
     implementation(include("gg.essential:elementa:${property("elementa.version")}")!!)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -109,7 +109,7 @@ tasks.withType<KotlinJvmCompile>().configureEach {
 
         freeCompilerArgs = args
 
-        moduleName.set("sbo") // default is project name which becomes e.g 1.21.11-fabric or 26.1.2-fabric; we need unified name instead of MC version. The module name is used when generating the mangled name for internal visibility items and the .kotlin_module file in the META-INF directory.
+        moduleName.set("sbo-${mcVersion}") // default is project name which becomes e.g 1.21.11-fabric or 26.1.2-fabric without the sbo naming; The module name is used when generating the mangled name for internal visibility items and the .kotlin_module file in the META-INF directory.
     }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -60,7 +60,7 @@ fabriclanguagekotlin.version=1.13.12+kotlin.2.4.0
 
 # Fabric API
 fabricapi.version.1.21.11=0.141.4+1.21.11
-fabricapi.version.26.1.2=0.151.0+26.1.2
+fabricapi.version.26.1.2=0.152.1+26.1.2
 
 # UniversalCraft
 universalcraft.version=494

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@
 
 # Some references: https://openjdk.org/jeps/8359211 (lower Xms is faster JVM startup), https://www.evanjones.ca/java-bytebuffer-leak.html (prevents high native off heap memory), https://www.evanjones.ca/jvm-mmap-pause.html (prevents disk I/O for writing perf counters), https://openjdk.org/jeps/450 (compact object headers), https://openjdk.org/jeps/522 (ParallelGC is faster for pure throughput workloads)
 
-# C2 compiler threads often compete with gradle threads heavily for CPU-time
+# C2 compiler threads often compete with Gradle threads heavily for CPU-time
 # Gradle daemon is not a server application; while it does stay alive between builds and benefit from some optimization (C1-tier) it eventually shutdowns, no need to generate C2 compiled code, so we use TieredStopAtLevel=1
 
 # The JVM option -XX:+PrintFlagsFinal can be used to find out default values of each flag before changing it.
@@ -34,7 +34,7 @@ fabric.loom.dropNonIntermediateRootMethods=true
 # DGT
 dgt.minecraft.revision=5
 
-# We setup everything ourselves
+# We set up everything ourselves
 dgt.loom.minecraft.setup=false
 dgt.loom.mappings.use=false
 dgt.loom.loader.use=false

--- a/src/main/java/net/sbo/mod/mixin/ClientPacketListenerMixin.java
+++ b/src/main/java/net/sbo/mod/mixin/ClientPacketListenerMixin.java
@@ -2,8 +2,9 @@ package net.sbo.mod.mixin;
 
 import net.minecraft.client.multiplayer.ClientPacketListener;
 import net.sbo.mod.utils.events.SBOEvent;
-import net.sbo.mod.utils.events.impl.game.SentMessageEvent;
 import net.sbo.mod.utils.events.impl.game.SentCommandEvent;
+import net.sbo.mod.utils.events.impl.game.SentMessageEvent;
+import org.jspecify.annotations.NonNull;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
@@ -12,12 +13,12 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 @Mixin(ClientPacketListener.class)
 public class ClientPacketListenerMixin {
     @Inject(method = "sendChat", at = @At("HEAD"))
-    private void sbo$onSendMessage(String content, CallbackInfo ci) {
+    private void sbo$onSendMessage(@NonNull String content, @NonNull CallbackInfo ci) {
         SBOEvent.INSTANCE.emit(new SentMessageEvent(content));
     }
 
     @Inject(method = "sendCommand", at = @At("HEAD"))
-    private void sbo$onSendCommand(String command, CallbackInfo ci) {
+    private void sbo$onSendCommand(@NonNull String command, @NonNull CallbackInfo ci) {
         SBOEvent.INSTANCE.emit(new SentCommandEvent(command));
     }
 }

--- a/src/main/java/net/sbo/mod/mixin/ClientPacketListenerMixin.java
+++ b/src/main/java/net/sbo/mod/mixin/ClientPacketListenerMixin.java
@@ -1,14 +1,19 @@
 package net.sbo.mod.mixin;
 
 import net.minecraft.client.multiplayer.ClientPacketListener;
+import net.minecraft.network.PacketListener;
+import net.minecraft.network.protocol.Packet;
 import net.sbo.mod.utils.events.SBOEvent;
 import net.sbo.mod.utils.events.impl.game.SentCommandEvent;
 import net.sbo.mod.utils.events.impl.game.SentMessageEvent;
+import net.sbo.mod.utils.events.impl.packets.PacketReceiveEvent;
 import org.jspecify.annotations.NonNull;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 
 @Mixin(ClientPacketListener.class)
 public class ClientPacketListenerMixin {
@@ -20,5 +25,11 @@ public class ClientPacketListenerMixin {
     @Inject(method = "sendCommand", at = @At("HEAD"))
     private void sbo$onSendCommand(@NonNull String command, @NonNull CallbackInfo ci) {
         SBOEvent.INSTANCE.emit(new SentCommandEvent(command));
+    }
+
+    @WrapOperation(method = "handleBundlePacket", at = @At(value = "INVOKE", target = "Lnet/minecraft/network/protocol/Packet;handle(Lnet/minecraft/network/PacketListener;)V"))
+    private void wrapPacketHandle(@NonNull Packet<?> packet, @NonNull PacketListener listener, @NonNull Operation<Void> original) {
+        SBOEvent.INSTANCE.emit(new PacketReceiveEvent(packet));
+        original.call(packet, listener);
     }
 }

--- a/src/main/java/net/sbo/mod/mixin/EntityMixin.java
+++ b/src/main/java/net/sbo/mod/mixin/EntityMixin.java
@@ -2,6 +2,7 @@ package net.sbo.mod.mixin;
 
 import net.minecraft.world.entity.Entity;
 import net.sbo.mod.utils.accessors.EntityAccessor;
+import org.jspecify.annotations.NonNull;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
@@ -24,7 +25,7 @@ public class EntityMixin implements EntityAccessor {
             at = @At("HEAD"),
             cancellable = true
     )
-    public void getTeamColorValue(CallbackInfoReturnable<Integer> cir) {
+    public void getTeamColorValue(@NonNull CallbackInfoReturnable<Integer> cir) {
         if (sbo$hasCustomGlow()) {
             cir.setReturnValue(sbo$glowingColor);
             // We don't reset frame glow here to ensure it persists through the render cycle
@@ -36,7 +37,7 @@ public class EntityMixin implements EntityAccessor {
             at = @At("HEAD"),
             cancellable = true
     )
-    public void isGlowing(CallbackInfoReturnable<Boolean> cir) {
+    public void isGlowing(@NonNull CallbackInfoReturnable<Boolean> cir) {
         if (sbo$hasCustomGlow()) {
             cir.setReturnValue(true);
         }

--- a/src/main/java/net/sbo/mod/mixin/GameRenderMixin.java
+++ b/src/main/java/net/sbo/mod/mixin/GameRenderMixin.java
@@ -1,11 +1,12 @@
 package net.sbo.mod.mixin;
 
 import com.llamalad7.mixinextras.sugar.Local;
+import net.minecraft.client.DeltaTracker;
 import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.client.renderer.GameRenderer;
-import net.minecraft.client.DeltaTracker;
 import net.sbo.mod.utils.events.SBOEvent;
 import net.sbo.mod.utils.events.impl.render.RenderEvent;
+import org.jspecify.annotations.NonNull;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
@@ -14,7 +15,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 @Mixin(GameRenderer.class)
 public class GameRenderMixin {
     @Inject(method = "render", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/Gui;render(Lnet/minecraft/client/gui/GuiGraphics;Lnet/minecraft/client/DeltaTracker;)V", shift = At.Shift.AFTER))
-    private void afterHudRender(DeltaTracker tickCounter, boolean tick, CallbackInfo ci, @Local GuiGraphics context) {
+    private void afterHudRender(@NonNull DeltaTracker tickCounter, boolean tick, @NonNull CallbackInfo ci, @Local @NonNull GuiGraphics context) {
         SBOEvent.INSTANCE.emit(new RenderEvent(context));
     }
 }

--- a/src/main/java/net/sbo/mod/mixin/MinecraftMixin.java
+++ b/src/main/java/net/sbo/mod/mixin/MinecraftMixin.java
@@ -4,6 +4,8 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.screens.Screen;
 import net.sbo.mod.utils.events.SBOEvent;
 import net.sbo.mod.utils.events.impl.guis.GuiOpenEvent;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
@@ -12,7 +14,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 @Mixin(Minecraft.class)
 public abstract class MinecraftMixin {
     @Inject(method = "setScreen", at = @At("HEAD"))
-    public void onSetScreen(Screen screen, CallbackInfo ci) {
+    public void onSetScreen(@Nullable Screen screen, @NonNull CallbackInfo ci) {
         if (screen != null) {
             SBOEvent.INSTANCE.emit(new GuiOpenEvent(screen, ci));
         }

--- a/src/main/java/net/sbo/mod/mixin/PacketMixin.java
+++ b/src/main/java/net/sbo/mod/mixin/PacketMixin.java
@@ -1,29 +1,29 @@
 package net.sbo.mod.mixin;
 
+import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandlerContext;
 import net.minecraft.network.Connection;
 import net.minecraft.network.protocol.Packet;
 import net.sbo.mod.utils.events.SBOEvent;
 import net.sbo.mod.utils.events.impl.packets.PacketReceiveEvent;
 import net.sbo.mod.utils.events.impl.packets.PacketSendEvent;
+import org.jspecify.annotations.NonNull;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
-import io.netty.channel.ChannelFutureListener;
-
 @Mixin(Connection.class)
 public class PacketMixin {
     // received S2C packets
     @Inject(method = "channelRead0(Lio/netty/channel/ChannelHandlerContext;Lnet/minecraft/network/protocol/Packet;)V", at = @At("HEAD"))
-    private void onPacketReceive(ChannelHandlerContext context, Packet<?> packet, CallbackInfo ci) {
+    private void onPacketReceive(@NonNull ChannelHandlerContext context, @NonNull Packet<?> packet, @NonNull CallbackInfo ci) {
         SBOEvent.INSTANCE.emit(new PacketReceiveEvent(packet));
     }
 
     // sent C2S packets
     @Inject(method = "send(Lnet/minecraft/network/protocol/Packet;Lio/netty/channel/ChannelFutureListener;)V", at = @At("HEAD"))
-    private void onPacketSend(Packet<?> packet, ChannelFutureListener channelFutureListener, CallbackInfo ci) {
+    private void onPacketSend(@NonNull Packet<?> packet, @NonNull ChannelFutureListener channelFutureListener, @NonNull CallbackInfo ci) {
         SBOEvent.INSTANCE.emit(new PacketSendEvent(packet));
     }
 }

--- a/src/main/java/net/sbo/mod/mixin/PauseScreenMixin.java
+++ b/src/main/java/net/sbo/mod/mixin/PauseScreenMixin.java
@@ -9,6 +9,7 @@ import net.minecraft.network.chat.Component;
 import net.sbo.mod.SBOKotlin;
 import net.sbo.mod.guis.AchievementsGUI;
 import net.sbo.mod.guis.Guis;
+import org.jspecify.annotations.NonNull;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
@@ -24,13 +25,14 @@ public abstract class PauseScreenMixin {
     boolean injected = false;
 
     @Inject(method = "createPauseMenu", at = @At(value = "HEAD"))
-    void sbo$createPauseMenuHead(CallbackInfo ci) {
+    void sbo$createPauseMenuHead(@NonNull CallbackInfo ci) {
         addedButtons = 0;
         injected = false;
     }
 
     @Redirect(method = "createPauseMenu", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/layouts/GridLayout$RowHelper;addChild(Lnet/minecraft/client/gui/layouts/LayoutElement;)Lnet/minecraft/client/gui/layouts/LayoutElement;"))
-    LayoutElement sbo$onAddChild(RowHelper helper, LayoutElement original) {
+    @NonNull
+    LayoutElement sbo$onAddChild(@NonNull RowHelper helper, @NonNull LayoutElement original) {
         if (addedButtons == 0 && !injected) {
             injected = true;
 

--- a/src/main/java/net/sbo/mod/mixin/PlayerInteractMixin.java
+++ b/src/main/java/net/sbo/mod/mixin/PlayerInteractMixin.java
@@ -3,11 +3,12 @@ package net.sbo.mod.mixin;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.multiplayer.MultiPlayerGameMode;
 import net.minecraft.client.player.LocalPlayer;
-import net.minecraft.world.phys.BlockHitResult;
-import net.minecraft.world.InteractionResult;
 import net.minecraft.world.InteractionHand;
+import net.minecraft.world.InteractionResult;
+import net.minecraft.world.phys.BlockHitResult;
 import net.sbo.mod.utils.events.SBOEvent;
 import net.sbo.mod.utils.events.impl.game.PlayerInteractEvent;
+import org.jspecify.annotations.NonNull;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
@@ -18,10 +19,10 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 public class PlayerInteractMixin {
 
     @Unique
-    private final Minecraft client = Minecraft.getInstance();
+    private final @NonNull Minecraft client = Minecraft.getInstance();
 
     @Inject(method = "useItem", at = @At("HEAD"), cancellable = true)
-    private void onInteractItem(CallbackInfoReturnable<InteractionResult> cir) {
+    private void onInteractItem(@NonNull CallbackInfoReturnable<InteractionResult> cir) {
         if (client.player != null) {
             PlayerInteractEvent event = new PlayerInteractEvent(
                     "useItem", null, client.player, client.player.level(), false
@@ -36,7 +37,7 @@ public class PlayerInteractMixin {
     }
 
     @Inject(method = "useItemOn", at = @At("HEAD"), cancellable = true)
-    private void onInteractBlock(LocalPlayer player, InteractionHand hand, BlockHitResult hitResult, CallbackInfoReturnable<InteractionResult> cir) {
+    private void onInteractBlock(@NonNull LocalPlayer player, @NonNull InteractionHand hand, @NonNull BlockHitResult hitResult, @NonNull CallbackInfoReturnable<InteractionResult> cir) {
         if (hand == InteractionHand.MAIN_HAND) {
             PlayerInteractEvent event = new PlayerInteractEvent(
                     "useBlock", hitResult.getBlockPos(), player, player.level(), false

--- a/src/main/java/net/sbo/mod/mixin/ScreenHandlerSlotUpdateS2CPacketMixin.java
+++ b/src/main/java/net/sbo/mod/mixin/ScreenHandlerSlotUpdateS2CPacketMixin.java
@@ -4,6 +4,7 @@ import net.minecraft.client.multiplayer.ClientPacketListener;
 import net.minecraft.network.protocol.game.ClientboundContainerSetSlotPacket;
 import net.sbo.mod.utils.events.SBOEvent;
 import net.sbo.mod.utils.events.impl.game.InventorySlotUpdateEvent;
+import org.jspecify.annotations.NonNull;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
@@ -12,7 +13,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 @Mixin(ClientPacketListener.class)
 public class ScreenHandlerSlotUpdateS2CPacketMixin {
     @Inject(method = "handleContainerSetSlot", at = @At("TAIL"))
-    private void onSlotUpdate(ClientboundContainerSetSlotPacket packet, CallbackInfo ci) {
+    private void onSlotUpdate(@NonNull ClientboundContainerSetSlotPacket packet, @NonNull CallbackInfo ci) {
         SBOEvent.INSTANCE.emit(new InventorySlotUpdateEvent(packet));
     }
 }

--- a/src/main/java/net/sbo/mod/mixin/ScreenMixin.java
+++ b/src/main/java/net/sbo/mod/mixin/ScreenMixin.java
@@ -1,12 +1,13 @@
 package net.sbo.mod.mixin;
 
 import net.minecraft.client.Minecraft;
-import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.client.input.KeyEvent;
 import net.sbo.mod.utils.events.SBOEvent;
 import net.sbo.mod.utils.events.impl.guis.GuiKeyEvent;
 import net.sbo.mod.utils.events.impl.guis.GuiRenderEvent;
+import org.jspecify.annotations.NonNull;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
@@ -17,14 +18,14 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 public abstract class ScreenMixin {
 
     @Inject(method = "render", at = @At("HEAD"))
-    public void onRender(GuiGraphics context, int mouseX, int mouseY, float delta, CallbackInfo ci) {
+    public void onRender(@NonNull GuiGraphics context, int mouseX, int mouseY, float delta, @NonNull CallbackInfo ci) {
         Minecraft client = Minecraft.getInstance();
         Screen screen = (Screen)(Object)this;
         SBOEvent.INSTANCE.emit(new GuiRenderEvent(client, screen, context, mouseX, mouseY, delta));
     }
 
     @Inject(method = "keyPressed", at = @At("HEAD"), cancellable = true)
-    public void onKeyPressed(KeyEvent input, CallbackInfoReturnable<Boolean> cir) {
+    public void onKeyPressed(KeyEvent input, @NonNull CallbackInfoReturnable<Boolean> cir) {
         Minecraft client = Minecraft.getInstance();
         Screen screen = (Screen)(Object)this;
         int keyCode = input.key();

--- a/src/main/kotlin/net/sbo/mod/SBOKotlin.kt
+++ b/src/main/kotlin/net/sbo/mod/SBOKotlin.kt
@@ -2,57 +2,43 @@ package net.sbo.mod
 
 import com.teamresourceful.resourcefulconfig.api.client.ResourcefulConfigScreen
 import com.teamresourceful.resourcefulconfig.api.loader.Configurator
+import net.fabricmc.api.ClientModInitializer
 import net.fabricmc.loader.api.FabricLoader
-import net.minecraft.util.Util
+import net.minecraft.IdentifierException
 import net.minecraft.client.Minecraft
 import net.minecraft.client.gui.components.toasts.SystemToast
-import net.minecraft.resources.Identifier
-import net.minecraft.IdentifierException
 import net.minecraft.network.chat.Component
+import net.minecraft.resources.Identifier
+import net.minecraft.util.Util
 import net.sbo.mod.compat.IrisCompatibility
-import net.sbo.mod.diana.DianaTracker
-import net.sbo.mod.utils.waypoint.WaypointManager
-import org.slf4j.LoggerFactory
-import net.sbo.mod.settings.Settings
-import net.sbo.mod.utils.game.Mayor
-import net.sbo.mod.utils.events.Register
-import net.sbo.mod.general.PartyCommands
-import net.sbo.mod.general.Pickuplog
-import net.sbo.mod.utils.data.SboDataObject
-import net.sbo.mod.partyfinder.PartyFinderManager
-import net.sbo.mod.utils.SboKeyBinds
-import net.sbo.mod.guis.Guis
-import net.sbo.mod.partyfinder.PartyCheck
-import net.sbo.mod.partyfinder.PartyPlayer
-import net.sbo.mod.utils.events.ClickActionManager
-import net.sbo.mod.utils.HypixelModApi
-import net.sbo.mod.utils.game.World
-import net.sbo.mod.diana.burrows.BurrowDetector
 import net.sbo.mod.diana.DianaMobDetect
+import net.sbo.mod.diana.DianaTracker
 import net.sbo.mod.diana.RareMobHighlight
 import net.sbo.mod.diana.achievements.AchievementManager
 import net.sbo.mod.diana.achievements.AchievementManager.unlockAchievement
+import net.sbo.mod.diana.burrows.BurrowDetector
 import net.sbo.mod.diana.sphinx.SphinxSolver
 import net.sbo.mod.general.HelpCommand
-import net.sbo.mod.overlays.Bobber
-import net.sbo.mod.overlays.DianaLoot
-import net.sbo.mod.overlays.DianaMobs
-import net.sbo.mod.overlays.DianaStats
-import net.sbo.mod.overlays.Legion
-import net.sbo.mod.overlays.MagicFind
+import net.sbo.mod.general.PartyCommands
+import net.sbo.mod.general.Pickuplog
+import net.sbo.mod.guis.Guis
+import net.sbo.mod.overlays.*
+import net.sbo.mod.partyfinder.PartyCheck
+import net.sbo.mod.partyfinder.PartyFinderManager
+import net.sbo.mod.partyfinder.PartyPlayer
 import net.sbo.mod.qol.MessageHider
-import net.sbo.mod.utils.Helper
-import net.sbo.mod.utils.SboTimerManager
-import net.sbo.mod.utils.SoundHandler
-import net.sbo.mod.utils.events.DianaEvents
-import net.sbo.mod.utils.events.SBOEvent
-import net.sbo.mod.utils.overlay.OverlayManager
-import net.sbo.mod.utils.events.SboEventGeneratedRegistry
+import net.sbo.mod.settings.Settings
+import net.sbo.mod.utils.*
+import net.sbo.mod.utils.data.SboDataObject
+import net.sbo.mod.utils.events.*
 import net.sbo.mod.utils.game.InventoryUtils
+import net.sbo.mod.utils.game.Mayor
 import net.sbo.mod.utils.game.TabList
+import net.sbo.mod.utils.game.World
+import net.sbo.mod.utils.overlay.OverlayManager
 import net.sbo.mod.utils.version.UpdateChecker
-
-import net.fabricmc.api.ClientModInitializer
+import net.sbo.mod.utils.waypoint.WaypointManager
+import org.slf4j.LoggerFactory
 
 object SBOKotlin : ClientModInitializer {
 	@JvmField
@@ -93,11 +79,11 @@ object SBOKotlin : ClientModInitializer {
 	override fun onInitializeClient() {
 		version = FabricLoader.getInstance().getModContainer(MOD_ID)
 			.map { it.metadata.version.friendlyString }
-			.orElse("unknown")
+			.orElse("unknown")!!
 
 		mcVersion = FabricLoader.getInstance().getModContainer("minecraft")
 			.map { it.metadata.version.friendlyString }
-			.orElse("unknown")
+			.orElse("unknown")!!
 
 		logger.info("Initializing SBO-Kotlin, version: $version...")
 

--- a/src/main/kotlin/net/sbo/mod/diana/DianaMobDetect.kt
+++ b/src/main/kotlin/net/sbo/mod/diana/DianaMobDetect.kt
@@ -1,29 +1,28 @@
 package net.sbo.mod.diana
 
 import net.minecraft.core.component.DataComponents
-import net.minecraft.world.item.component.ResolvableProfile
 import net.minecraft.world.entity.EquipmentSlot
 import net.minecraft.world.entity.decoration.ArmorStand
 import net.minecraft.world.entity.player.Player
 import net.minecraft.world.item.ItemStack
-import net.sbo.mod.utils.events.Register
+import net.minecraft.world.item.component.ResolvableProfile
 import net.sbo.mod.SBOKotlin.mc
 import net.sbo.mod.settings.categories.Customization
 import net.sbo.mod.settings.categories.Diana
 import net.sbo.mod.utils.Helper
-import net.sbo.mod.utils.Helper.removeFormatting
 import net.sbo.mod.utils.Helper.getSecondsPassed
 import net.sbo.mod.utils.Helper.lastCocoon
 import net.sbo.mod.utils.Helper.lastInqDeath
 import net.sbo.mod.utils.Helper.lastKingDeath
 import net.sbo.mod.utils.Helper.lastMantiDeath
 import net.sbo.mod.utils.Helper.lastSphinxDeath
+import net.sbo.mod.utils.Helper.removeFormatting
 import net.sbo.mod.utils.Helper.showTitle
 import net.sbo.mod.utils.Helper.sleep
-import net.sbo.mod.utils.Player as SboPlayer
 import net.sbo.mod.utils.SoundHandler.playCustomSound
 import net.sbo.mod.utils.chat.Chat
 import net.sbo.mod.utils.chat.ChatUtils.formattedString
+import net.sbo.mod.utils.events.Register
 import net.sbo.mod.utils.events.SBOEvent
 import net.sbo.mod.utils.events.annotations.SboEvent
 import net.sbo.mod.utils.events.impl.entity.DianaMobDeathEvent
@@ -34,6 +33,7 @@ import net.sbo.mod.utils.overlay.Overlay
 import net.sbo.mod.utils.overlay.OverlayExamples
 import net.sbo.mod.utils.overlay.OverlayTextLine
 import kotlin.math.roundToInt
+import net.sbo.mod.utils.Player as SboPlayer
 
 object DianaMobDetect {
     private const val DEATH_WINDOW_SECONDS = 5
@@ -99,7 +99,7 @@ object DianaMobDetect {
             val displayName =
                 rare?.display ?: fallbackRemovePrefix(cleanName) // rare.display returns already without prefix; otherwise the fallback would remove the prefix
 
-            // Check if cocooned mob is a diana mob by checking if its either a rare mob or has the diana mob prefix like empyrean
+            // Check if cocooned mob is a diana mob by checking if it's either a rare mob or has the diana mob prefix like empyrean
             if (rare != null || prefixes.firstOrNull { cleanName.startsWith("$it ")} != null) {
                 // We need this check otherwise it could track a mob that you cocooned but someone else spawned.
                 if (DianaTracker.lastSpawnedMob == displayName) {

--- a/src/main/kotlin/net/sbo/mod/diana/DianaMobDetect.kt
+++ b/src/main/kotlin/net/sbo/mod/diana/DianaMobDetect.kt
@@ -37,13 +37,10 @@ import net.sbo.mod.utils.Player as SboPlayer
 
 object DianaMobDetect {
     private const val DEATH_WINDOW_SECONDS = 5
-    private const val COCOON_COOLDOWN_MS = 10_000L
-    private const val CHAT_DELAY_MS = 200L
     private const val ANNOUNCE_DELAY_MS = 5_000L
 
     private const val NAME_CHECK_TIMEOUT_MS = 1000L
 
-    private const val COCOON_TEXTURE = "eyJ0aW1lc3RhbXAiOjE1ODMxMjMyODkwNTMsInByb2ZpbGVJZCI6IjkxZjA0ZmU5MGYzNjQzYjU4ZjIwZTMzNzVmODZkMzllIiwicHJvZmlsZU5hbWUiOiJTdG9ybVN0b3JteSIsInNpZ25hdHVyZVJlcXVpcmVkIjp0cnVlLCJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvNGNlYjBlZDhmYzIyNzJiM2QzZDgyMDY3NmQ1MmEzOGU3YjJlOGRhOGM2ODdhMjMzZTBkYWJhYTE2YzBlOTZkZiJ9fX0="
     private val healthRegex = """([0-9]+(?:\.[0-9]+)?[MK]?)§f/""".toRegex()
 
     private val unconfirmed = mutableMapOf<Int, Pair<ArmorStand, Long>>()
@@ -111,7 +108,7 @@ object DianaMobDetect {
 
             if (rare != null) {
                 // Cocooned a rare mob if rare != null
-                announceCocoon(DetectionType.CHAT_MESSAGE, displayName)
+                announceCocoon(displayName)
             }
         }
         Register.onTick(1) {
@@ -131,8 +128,6 @@ object DianaMobDetect {
                     unconfirmedIterator.remove()
                     continue
                 }
-
-                checkCocoon(entity, now)
 
                 val name = entity.customName?.formattedString() ?: entity.name.formattedString()
                 if (name.contains("§2✿", ignoreCase = true)) {
@@ -236,41 +231,13 @@ object DianaMobDetect {
         }
     }
 
-    private fun checkCocoon(entity: ArmorStand, now: Long) {
-        if (!Diana.legacyCocoonDetection || World.getWorld() != "Hub") return
-        val recentDeath = listOf(lastInqDeath, lastKingDeath, lastSphinxDeath, lastMantiDeath)
-            .any { getSecondsPassed(it) < DEATH_WINDOW_SECONDS }
-
-        if (!recentDeath) return
-        val head: ItemStack = entity.getItemBySlot(EquipmentSlot.HEAD)
-
-        if (head.isEmpty) return
-        if (head.item.toString() != "minecraft:player_head") return
-        val profileComponent: ResolvableProfile? = head.get(DataComponents.PROFILE)
-        val texture: String =
-            profileComponent?.partialProfile()?.properties?.get("textures")?.firstOrNull()?.value ?: return
-
-        if (texture == COCOON_TEXTURE && lastCocoon + COCOON_COOLDOWN_MS < now) {
-            lastCocoon = now
-            announceCocoon(DetectionType.TEXTURE)
-        }
-    }
-
-    private enum class DetectionType {
-        TEXTURE, CHAT_MESSAGE
-    }
-
-    private fun announceCocoon(detectionType: DetectionType, mobName: String? = null) {
-        if (detectionType == DetectionType.TEXTURE && !Diana.legacyCocoonDetection) {
-            return
-        }
-
+    private fun announceCocoon(mobName: String) {
         if (Diana.announceCocoon) {
-            sleep(CHAT_DELAY_MS) { Chat.pc("" + if (mobName != null) "Cocooned a ${mobName}!" else "Cocoon!") }
+            Chat.pc("Cocooned a ${mobName}!")
         }
+
         if (Diana.cocoonTitle) {
-            val subtitle = if (mobName != null) "§b${mobName}" else null
-            showTitle("§r§6§l<§b§l§kO§6§l> §b§lCOCOON! §6§l<§b§l§kO§6§l>", subtitle, 10, 40, 10)
+            showTitle("§r§6§l<§b§l§kO§6§l> §b§lCOCOON! §6§l<§b§l§kO§6§l>", "§b${mobName}", 10, 40, 10)
             playCustomSound(Customization.cocoonSound[0], Customization.cocoonVolume)
         }
     }

--- a/src/main/kotlin/net/sbo/mod/diana/DianaStats.kt
+++ b/src/main/kotlin/net/sbo/mod/diana/DianaStats.kt
@@ -1,16 +1,16 @@
 package net.sbo.mod.diana
 
 import net.sbo.mod.overlays.DianaLoot
-import net.sbo.mod.utils.data.SboDataObject
-import net.sbo.mod.utils.chat.Chat
-import net.sbo.mod.utils.Helper
-import net.sbo.mod.utils.data.DianaTracker
-import java.util.concurrent.TimeUnit
 import net.sbo.mod.settings.categories.Diana
+import net.sbo.mod.utils.Helper
 import net.sbo.mod.utils.SboTimerManager
+import net.sbo.mod.utils.chat.Chat
+import net.sbo.mod.utils.data.DianaTracker
+import net.sbo.mod.utils.data.SboDataObject
 import net.sbo.mod.utils.events.Register
+import java.util.*
+import java.util.concurrent.TimeUnit
 import java.util.regex.Pattern
-import java.util.Locale
 
 object DianaStats {
     val STATS_PATTERN: Pattern = Pattern.compile(
@@ -19,7 +19,7 @@ object DianaStats {
     )
 
     fun registerReplaceStatsMessage() {
-        Register.onChatMessageCancable(
+        Register.onChatMessageCancelable(
             STATS_PATTERN
         ) { message, matcher ->
             val statsMessage = ArrayList<String>()

--- a/src/main/kotlin/net/sbo/mod/diana/DianaTracker.kt
+++ b/src/main/kotlin/net/sbo/mod/diana/DianaTracker.kt
@@ -10,22 +10,16 @@ import net.sbo.mod.overlays.MagicFind
 import net.sbo.mod.settings.categories.Customization
 import net.sbo.mod.settings.categories.Diana
 import net.sbo.mod.settings.categories.QOL
-import net.sbo.mod.utils.chat.Chat
 import net.sbo.mod.utils.Helper
 import net.sbo.mod.utils.Helper.allowSackTracking
-import net.sbo.mod.utils.Helper.checkDiana
 import net.sbo.mod.utils.Helper.dianaMobDiedRecently
 import net.sbo.mod.utils.Helper.gotLootShareRecently
 import net.sbo.mod.utils.Helper.removeFormatting
 import net.sbo.mod.utils.Helper.sleep
-import net.sbo.mod.utils.game.Mayor
 import net.sbo.mod.utils.Player
 import net.sbo.mod.utils.SboTimerManager
-import net.sbo.mod.utils.events.Register
-import net.sbo.mod.utils.events.annotations.SboEvent
-import net.sbo.mod.utils.events.impl.game.GameCloseEvent
 import net.sbo.mod.utils.SoundHandler.playCustomSound
-import net.sbo.mod.utils.game.World.isInSkyblock
+import net.sbo.mod.utils.chat.Chat
 import net.sbo.mod.utils.data.DianaTracker
 import net.sbo.mod.utils.data.Item
 import net.sbo.mod.utils.data.SboDataObject
@@ -35,6 +29,11 @@ import net.sbo.mod.utils.data.SboDataObject.dianaTrackerTotal
 import net.sbo.mod.utils.data.SboDataObject.pastDianaEventsData
 import net.sbo.mod.utils.data.SboDataObject.saveTrackerData
 import net.sbo.mod.utils.data.SboDataObject.sboData
+import net.sbo.mod.utils.events.Register
+import net.sbo.mod.utils.events.annotations.SboEvent
+import net.sbo.mod.utils.events.impl.game.GameCloseEvent
+import net.sbo.mod.utils.game.Mayor
+import net.sbo.mod.utils.game.World.isInSkyblock
 import java.util.regex.Pattern
 
 object DianaTracker {
@@ -70,7 +69,7 @@ object DianaTracker {
             DianaStats.updateLines()
         }
 
-        Register.onChatMessageCancable(
+        Register.onChatMessageCancelable(
             Pattern.compile("^§eThe election room is now closed\\. Clerk Seraphine is doing a final count of the votes\\.\\.\\.$", Pattern.DOTALL)
         ) { _, _ ->
             sleep(10000) {
@@ -79,7 +78,7 @@ object DianaTracker {
             true
         }
 
-        Register.onChatMessageCancable(
+        Register.onChatMessageCancelable(
             Pattern.compile("^§6§lWow! §eYou dug out §6(.*?) coins§e!$")
         ) { _, _ ->
             allowScavTracking = false
@@ -89,13 +88,13 @@ object DianaTracker {
             true
         }
 
-        Register.onChatMessageCancable(Pattern.compile("(.*?) §efound a §cPhoenix §epet!(.*?)$", Pattern.DOTALL)) { message, matchResult ->
+        Register.onChatMessageCancelable(Pattern.compile("(.*?) §efound a §cPhoenix §epet!(.*?)$", Pattern.DOTALL)) { message, matchResult ->
             if (QOL.phoenixAnnouncer) {
                 Chat.chat("§6[SBO] §cGG §eFound a §cPhoenix §epet!")
                 Helper.showTitle("§c§lPhoenix Pet!", "", 0, 25, 35)
             }
             val player = matchResult.group(1).removeFormatting().lowercase()
-            if (!player.contains((Player.getName()?: "").lowercase())) return@onChatMessageCancable true
+            if (!player.contains((Player.getName()?: "").lowercase())) return@onChatMessageCancelable true
             sleep(1000) {
                 if (isInSkyblock() && dianaMobDiedRecently(3)) unlockAchievement(77) // phoenix pet
             }
@@ -162,9 +161,9 @@ object DianaTracker {
     }
 
     fun trackMobsWithChat() {
-        Register.onChatMessageCancable(Pattern.compile("(.*?) §eYou dug (.*?)§2(.*?)§e!(.*?)$", Pattern.DOTALL)) { message, matchResult ->
+        Register.onChatMessageCancelable(Pattern.compile("(.*?) §eYou dug (.*?)§2(.*?)§e!(.*?)$", Pattern.DOTALL)) { message, matchResult ->
             val mob = matchResult.group(3)
-            if (isMobOnCooldown.getOrDefault(mob, false)) return@onChatMessageCancable !QOL.dianaMessageHider
+            if (isMobOnCooldown.getOrDefault(mob, false)) return@onChatMessageCancelable !QOL.dianaMessageHider
 
             trackMobOnSpawnAndSave(mob)
 
@@ -315,7 +314,7 @@ object DianaTracker {
     }
 
     fun trackCoinsWithChat() {
-        Register.onChatMessageCancable(Pattern.compile("^§6§lWow! §eYou dug out §6(.*?) coins§e!$", Pattern.DOTALL)) { message, matchResult ->
+        Register.onChatMessageCancelable(Pattern.compile("^§6§lWow! §eYou dug out §6(.*?) coins§e!$", Pattern.DOTALL)) { message, matchResult ->
             val coins = matchResult.group(1).replace(",", "").toIntOrNull() ?: 0
             if (coins > 0) trackItem("COINS", coins)
             true
@@ -323,7 +322,7 @@ object DianaTracker {
     }
 
     fun trackTreasuresWithChat() {
-        Register.onChatMessageCancable(Pattern.compile("^§6§lRARE DROP! §eYou dug out a (.*?)§e!$", Pattern.DOTALL)) { message, matchResult ->
+        Register.onChatMessageCancelable(Pattern.compile("^§6§lRARE DROP! §eYou dug out a (.*?)§e!$", Pattern.DOTALL)) { message, matchResult ->
             when (val drop = matchResult.group(1).drop(2)) {
                 "Griffin Feather" -> trackItem(drop, 1)
                 "Mythos Fragment" -> trackItem(drop, 1)
@@ -334,12 +333,12 @@ object DianaTracker {
     }
 
     fun trackRngDropsWithChat() {
-        Register.onChatMessageCancable(Pattern.compile("^§6§lRARE DROP! (.*?)$", Pattern.DOTALL)) { message, matchResult ->
+        Register.onChatMessageCancelable(Pattern.compile("^§6§lRARE DROP! (.*?)$", Pattern.DOTALL)) { message, matchResult ->
             trackChatRngDrop(matchResult.group(1))
             true
         }
 
-        Register.onChatMessageCancable(Pattern.compile("^§d§lWOW! (.*?) §6found a §2Mythological Dye§6!$", Pattern.DOTALL)) { message, matchResult ->
+        Register.onChatMessageCancelable(Pattern.compile("^§d§lWOW! (.*?) §6found a §2Mythological Dye§6!$", Pattern.DOTALL)) { message, matchResult ->
             val player = matchResult.group(1).removeFormatting().lowercase().trim()
             if (player.contains(Player.getName()?.lowercase()?.trim()?: "")) {
                 onRareDropFromMob("Mythological Dye",
@@ -563,14 +562,14 @@ object DianaTracker {
                     sboData.sphinxSinceFood = 0
                 } else {
                     // lootshare brain food
-                    if (Diana.sendSinceMessage) Chat.chat("§6[SBO] §eTook §c${sboData.sphinxSinceFood} §eSphinx to lootshare Brain Food!")
+                    if (Diana.sendSinceMessage) Chat.chat("§6[SBO] §eTook §c${sboData.sphinxSinceLsFood} §eSphinx to lootshare Brain Food!")
 
                     sleep(200) {
-                        if (sboData.b2bFoodLs && sboData.sphinxSinceFood == 1) {
+                        if (sboData.b2bFoodLs && sboData.sphinxSinceLsFood == 1) {
                             Chat.chat("§6[SBO] §cb2b2b Lootshare Brain Food!")
                             unlockAchievement(100) // b2b2b ls food
                         }
-                        if (sboData.sphinxSinceFood == 1 && !sboData.b2bFoodLs) {
+                        if (sboData.sphinxSinceLsFood == 1 && !sboData.b2bFoodLs) {
                             Chat.chat("§6[SBO] §cb2b Lootshare Brain Food!")
                             unlockAchievement(99) // b2b ls food
                             sboData.b2bFoodLs = true
@@ -723,7 +722,8 @@ object DianaTracker {
         }
 
         var count = ""
-        val realCount = colorAndCount.second + 1 // we didnt call trackItem yet, avoids being #0
+        val rawCount = colorAndCount.second
+        val realCount = if (rawCount != -1) rawCount + 1 else -1 // we didn't call trackItem yet, avoids being #0
         if (realCount != -1) count = " #$realCount"
 
         val price = if (Diana.lootAnnouncerPrice) "§6${Helper.getItemPriceFormatted(itemId, amount)} coins" else ""
@@ -764,7 +764,7 @@ object DianaTracker {
     }
 
     fun trackBurrowsWithChat() {
-        Register.onChatMessageCancable(Pattern.compile("^§eYou (.*?) Griffin [Bb]urrow(.*?)$", Pattern.DOTALL)) { message, matchResult ->
+        Register.onChatMessageCancelable(Pattern.compile("^§eYou (.*?) Griffin [Bb]urrow(.*?)$", Pattern.DOTALL)) { message, matchResult ->
             val burrow = matchResult.group(2).removeFormatting()
             trackItem("TOTAL_BURROWS", 1)
             if (Diana.fourEyedFish) {
@@ -789,7 +789,7 @@ object DianaTracker {
         if (replaceDropMessage) {
             if (custom) Chat.chat(customMsg)
         } else {
-            val itemId = item.uppercase().replace(" ", "_").replace("Manti-core", "MANTI_CORE") // special case for manticore
+            val itemId = item.uppercase().replace(" ", "_").replace("MANTI-CORE", "MANTI_CORE") // special case for manticore
             val price = Helper.getItemPriceFormatted(itemId, 1)
             val priceStr = if (price != "0") " (+$price coins)" else ""
 
@@ -816,15 +816,6 @@ object DianaTracker {
         val msg = lootAnnouncerBuffer.joinToString(", ")
         lootAnnouncerBuffer.clear()
         Chat.pc(msg)
-    }
-
-    fun getB2BMessage(itemName: String, streak: Int): String? { // not used yet
-        if (streak <= 1) return null
-
-        val prettyName = Helper.toTitleCase(itemName.replace("_", " "))
-        val streakText = "b" + "2b".repeat(streak - 1)
-
-        return "§6[SBO] §c$streakText $prettyName!"
     }
 
     fun checkMayorTracker() {
@@ -864,7 +855,7 @@ object DianaTracker {
     }
 
     fun trackShardsWithChat() {
-        Register.onChatMessageCancable(Pattern.compile("^(.*?) You charmed a (.*?) and captured (.*?) Shards §7from it.$", Pattern.DOTALL)) { message, matchResult ->
+        Register.onChatMessageCancelable(Pattern.compile("^(.*?) You charmed a (.*?) and captured (.*?) Shards §7from it.$", Pattern.DOTALL)) { message, matchResult ->
             val shard = matchResult.group(2).removeFormatting()
             val amount = matchResult.group(3).removeFormatting().toIntOrNull() ?: 0
             when (shard) {
@@ -877,7 +868,7 @@ object DianaTracker {
             true
         }
 
-        Register.onChatMessageCancable(Pattern.compile("^(.*?) You charmed a (.*?) and captured its §9Shard§7.$", Pattern.DOTALL)) { message, matchResult ->
+        Register.onChatMessageCancelable(Pattern.compile("^(.*?) You charmed a (.*?) and captured its §9Shard§7.$", Pattern.DOTALL)) { message, matchResult ->
             val shard = matchResult.group(2).removeFormatting()
             val amount = 1
             when (shard) {
@@ -890,7 +881,7 @@ object DianaTracker {
             true
         }
 
-        Register.onChatMessageCancable(Pattern.compile("^§aYou caught (.*?) (.*?) §aShards(.*?)$", Pattern.DOTALL)) { message, matchResult ->
+        Register.onChatMessageCancelable(Pattern.compile("^§aYou caught (.*?) (.*?) §aShards(.*?)$", Pattern.DOTALL)) { message, matchResult ->
             val shard = matchResult.group(2).removeFormatting()
             val amount = matchResult.group(1).removeFormatting().replace("x", "").trim().toIntOrNull() ?: 0
             when (shard) {
@@ -903,7 +894,7 @@ object DianaTracker {
             true
         }
 
-        Register.onChatMessageCancable(Pattern.compile("^§aYou caught a (.*?) §aShard!$", Pattern.DOTALL)) { message, matchResult ->
+        Register.onChatMessageCancelable(Pattern.compile("^§aYou caught a (.*?) §aShard!$", Pattern.DOTALL)) { message, matchResult ->
             val shard = matchResult.group(1).removeFormatting()
             val amount = 1
             when (shard) {
@@ -966,9 +957,9 @@ object DianaTracker {
         }
         if (itemName == "SPHINX_LS") sboData.sphinxSinceLsFood += 1
 
-        trackOne(dianaTrackerMayor, itemName, amount, fromInq)
-        trackOne(dianaTrackerSession, itemName, amount, fromInq)
-        trackOne(dianaTrackerTotal, itemName, amount, fromInq)
+        trackOne(dianaTrackerMayor, itemName, amount)
+        trackOne(dianaTrackerSession, itemName, amount)
+        trackOne(dianaTrackerTotal, itemName, amount)
         saveTrackerData()
         DianaStats.updateLines()
         MagicFind.updateLines()
@@ -983,7 +974,7 @@ object DianaTracker {
         }
     }
 
-    fun trackOne(tracker: DianaTracker, item: String, amount: Int, fromInq: Boolean = false) {
+    fun trackOne(tracker: DianaTracker, item: String, amount: Int) {
         when (item) {
             // SHARDS
             "KING_MINOS_SHARD" -> tracker.items.KING_MINOS_SHARD += amount

--- a/src/main/kotlin/net/sbo/mod/diana/achievements/Achievement.kt
+++ b/src/main/kotlin/net/sbo/mod/diana/achievements/Achievement.kt
@@ -1,7 +1,7 @@
 package net.sbo.mod.diana.achievements
 
-import net.minecraft.sounds.SoundSource
 import net.minecraft.sounds.SoundEvents
+import net.minecraft.sounds.SoundSource
 import net.sbo.mod.SBOKotlin.mc
 import net.sbo.mod.settings.categories.Debug
 import net.sbo.mod.utils.Helper
@@ -104,9 +104,5 @@ class Achievement(
             return achievementsData.currentEventAchievements[id] ?: false
         }
         return (achievementsData.totalAchievements[id] ?: 0) > 0
-    }
-
-    fun getDisplayName(): String {
-        return "$color$name"
     }
 }

--- a/src/main/kotlin/net/sbo/mod/diana/achievements/AchievementManager.kt
+++ b/src/main/kotlin/net/sbo/mod/diana/achievements/AchievementManager.kt
@@ -5,17 +5,16 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import net.minecraft.client.gui.screens.inventory.AbstractContainerScreen
 import net.minecraft.core.component.DataComponents
-import net.minecraft.world.item.component.CustomData
+import net.minecraft.nbt.CompoundTag
 import net.minecraft.world.entity.player.Player
 import net.minecraft.world.item.ItemStack
-import net.minecraft.nbt.CompoundTag
+import net.minecraft.world.item.component.CustomData
 import net.sbo.mod.SBOKotlin.mc
 import net.sbo.mod.diana.DianaMobDetect.RareDianaMob
 import net.sbo.mod.overlays.DianaLoot.totalProfit
 import net.sbo.mod.utils.Helper
 import net.sbo.mod.utils.Helper.removeFormatting
 import net.sbo.mod.utils.HypixelModApi.isOnHypixel
-import net.sbo.mod.utils.game.ItemLookup
 import net.sbo.mod.utils.chat.Chat
 import net.sbo.mod.utils.data.DianaTrackerMayorData
 import net.sbo.mod.utils.data.PartyPlayerStats
@@ -29,6 +28,7 @@ import net.sbo.mod.utils.events.annotations.SboEvent
 import net.sbo.mod.utils.events.impl.entity.EntitiyHitEvent
 import net.sbo.mod.utils.events.impl.game.WorldChangeEvent
 import net.sbo.mod.utils.events.impl.guis.GuiOpenEvent
+import net.sbo.mod.utils.game.ItemLookup
 import java.lang.Thread.sleep
 import java.util.concurrent.ConcurrentLinkedQueue
 import java.util.concurrent.atomic.AtomicBoolean
@@ -121,11 +121,6 @@ object AchievementManager {
                 isProcessingQueue.set(false)
             }
         }
-    }
-
-    fun lockById(id: Int) {
-        if (!achievements.containsKey(id)) return
-        achievements[id]?.lock()
     }
 
     fun backTrackAchievements() { // todo: needs rework because of new data structure

--- a/src/main/kotlin/net/sbo/mod/diana/burrows/BurrowDetector.kt
+++ b/src/main/kotlin/net/sbo/mod/diana/burrows/BurrowDetector.kt
@@ -59,8 +59,16 @@ object BurrowDetector {
 
             // We need to update lastdugOutBurrowPos manually here since BurrowDugEvent does not set it since it is not triggered.
             lastDugOutBurrowPos = DianaEvents.lastWaypointClicked ?: SboVec(0.0, 0.0, 0.0)
-            refreshBurrows(false, 1)
+            refreshBurrows(false, 1, parseTypeFromChatMsg(message.getString()))
         }
+    }
+
+    private fun parseTypeFromChatMsg(message: String): String {
+        if (message.contains("Griffin Feather") || message.contains(" coins!") || message.contains("Mythos Fragment") || message.contains("Braided Griffin Feather") || message.contains("Myth the Fish")) {
+            return "Treasure"
+        }
+
+        return "Mob" // assume mob if not a known treasure drop
     }
 
     fun requestSpade() {
@@ -103,26 +111,32 @@ object BurrowDetector {
         val posString = "${pos.x.toInt()} ${pos.y.toInt()} ${pos.z.toInt()}"
 
         if (burrowsHistory.contains(posString)) return
-        if (!burrows.containsKey(posString)) burrows[posString] = Burrow(pos)
+
+        val burrow = burrows.getOrPut(posString) {
+            Burrow(pos)
+        }
 
         when (particleType) {
-            "FOOTSTEP" -> burrows[posString]?.hasFootstep = true
-            "ENCHANT" -> burrows[posString]?.hasEnchant = true
-            "EMPTY" -> burrows[posString]?.type = "Start"
-            "MOB" -> burrows[posString]?.type = "Mob"
-            "TREASURE" -> burrows[posString]?.type = "Treasure"
+            "FOOTSTEP" -> burrow.hasFootstep = true
+            "ENCHANT" -> burrow.hasEnchant = true
+            "EMPTY" -> burrow.type = "Start"
+            "MOB" -> burrow.type = "Mob"
+            "TREASURE" -> burrow.type = "Treasure"
         }
 
-        val burrow = burrows[posString]
-        if (burrow?.type != null && burrow.waypoint == null) {
-            burrowsHistory.add(posString)
-            burrow.waypoint = Waypoint(
-                burrow.type!!,
-                pos.x, pos.y, pos.z,
-                type = "burrow"
-            )
-            WaypointManager.addWaypoint(burrow.waypoint!!)
-        }
+        val type = burrow.type ?: return
+        if (burrow.waypoint != null) return
+
+        burrowsHistory.add(posString)
+
+        val waypoint = Waypoint(
+            type,
+            pos.x, pos.y, pos.z,
+            type = "burrow"
+        )
+
+        burrow.waypoint = waypoint
+        WaypointManager.addWaypoint(waypoint)
     }
 
     fun queueRemoval(waypoint: Waypoint, condition: BooleanSupplier) {
@@ -137,9 +151,10 @@ object BurrowDetector {
         }
     }
 
-    fun refreshBurrows(deathOriginating: Boolean, expectedTimesDug: Int) {
+    fun refreshBurrows(deathOriginating: Boolean, expectedTimesDug: Int, burrowType: String? = null) {
         // Try known burrow first, then arrow, then precise
-        val dugWaypoint = WaypointManager.getWaypointAt(lastDugOutBurrowPos, "burrow") ?: WaypointManager.getWaypointAt(lastDugOutBurrowPos, "arrow") ?: WaypointManager.getWaypointAt(lastDugOutBurrowPos, "guess")
+        val pos = lastDugOutBurrowPos
+        val dugWaypoint = WaypointManager.getWaypointAt(pos, "burrow") ?: WaypointManager.getWaypointAt(pos, "arrow") ?: WaypointManager.getWaypointAt(pos, "guess")
 
         if (null != dugWaypoint) {
             // Will only work if known burrow
@@ -175,6 +190,17 @@ object BurrowDetector {
 
         // Counted timesDug above already
         flushRemovals()
+
+        if (dugWaypoint?.type != "burrow" && burrowType != null) {
+            // The user has dug the Guess waypoint before we could detect the particles and turn into a Mob/Treasure/Start waypoint.
+            // In this case, if it was a Start waypoint it would disappear instantly anyways. If it was a Mob/Treasure, we use the chat message
+            // to determine the burrow type, and add that as a known burrow and remove the old one, whilst carrying over timesDug.
+            val waypoint = Waypoint(burrowType, pos.x, pos.y, pos.z, type = "burrow")
+            waypoint.timesDug = dugWaypoint?.timesDug ?: expectedTimesDug
+
+            WaypointManager.addWaypoint(waypoint)
+            if (dugWaypoint != null) WaypointManager.removeWaypoint(dugWaypoint)
+        }
     }
 
     fun resetBurrows() {

--- a/src/main/kotlin/net/sbo/mod/diana/burrows/BurrowDetector.kt
+++ b/src/main/kotlin/net/sbo/mod/diana/burrows/BurrowDetector.kt
@@ -2,28 +2,26 @@ package net.sbo.mod.diana.burrows
 
 import net.minecraft.network.protocol.game.ClientboundLevelParticlesPacket
 import net.sbo.mod.settings.categories.Diana
-import net.sbo.mod.utils.events.Register
-import net.sbo.mod.settings.categories.Customization
-import net.sbo.mod.utils.Player
+import net.sbo.mod.utils.Helper
 import net.sbo.mod.utils.chat.Chat
 import net.sbo.mod.utils.collection.EvictingQueue
+import net.sbo.mod.utils.events.Register
+import net.sbo.mod.utils.events.DianaEvents
 import net.sbo.mod.utils.events.annotations.SboEvent
 import net.sbo.mod.utils.events.impl.diana.BurrowDugEvent
-import net.sbo.mod.utils.events.impl.packets.PacketReceiveEvent
 import net.sbo.mod.utils.events.impl.game.WorldChangeEvent
-import net.minecraft.core.particles.ParticleTypes as MCParticleTypes
-import net.sbo.mod.utils.waypoint.Waypoint
-import java.awt.Color
-import net.sbo.mod.utils.waypoint.WaypointManager
-import net.sbo.mod.utils.math.SboVec
+import net.sbo.mod.utils.events.impl.packets.PacketReceiveEvent
 import net.sbo.mod.utils.game.World
+import net.sbo.mod.utils.math.SboVec
+import net.sbo.mod.utils.waypoint.Waypoint
+import net.sbo.mod.utils.waypoint.WaypointManager
 import java.util.concurrent.ConcurrentHashMap
 import java.util.regex.Pattern
-import net.sbo.mod.utils.Helper
+import net.minecraft.core.particles.ParticleTypes as MCParticleTypes
 
 object BurrowDetector {
     internal val burrows = ConcurrentHashMap<String, Burrow>()
-    internal var removePos: SboVec = SboVec(0.0, 0.0, 0.0)
+    internal var lastDugOutBurrowPos: SboVec = SboVec(0.0, 0.0, 0.0)
     internal val burrowsHistory = EvictingQueue<String>(2)
 
     fun init() {
@@ -31,20 +29,29 @@ object BurrowDetector {
             WaypointManager.removeAllOfType("world")
             WaypointManager.removeAllOfType("guess")
             WaypointManager.removeAllOfType("arrow")
-            WaypointManager.guessWp?.hide()
+            WaypointManager.removeAllOfType("rareMob")
             resetBurrows()
             Chat.chat("§6[SBO] §4Burrow Waypoints Cleared!")
         }
 
-        Register.onChatMessageCancable(Pattern.compile("^ ☠ You (.*?)$", Pattern.DOTALL)) { message, matchResult ->
-            if (World.getWorld() != "Hub") return@onChatMessageCancable true
-            refreshBurrows()
+        Register.onChatMessageCancelable(Pattern.compile("^ ☠ You (.*?)$", Pattern.DOTALL)) { message, matchResult ->
+            if (World.getWorld() != "Hub") return@onChatMessageCancelable true
+            refreshBurrows(true)
             true
         }
 
         Register.onChatMessage(Regex("""^§eYou finished the Griffin burrow chain!.*$""")) { message, matchResult ->
             val anyClose = WaypointManager.getAllGuessesAndBurrows().filter { it.distanceToPlayer() < 90 }
             if (Diana.showTitleWhenChainEnd && anyClose.isEmpty()) requestSpade()
+        }
+
+        Register.onChatMessage(Regex(""".*§eYou (?:just )?dug out.*""")) { message, matchResult ->
+            // BurrowDugEvent only triggers when you get the "You dug out a Griffin Burrow!" message.
+            // Mob spawns, feather drops, and Myth the Fish use different chat messages.
+
+            // We need to update lastdugOutBurrowPos manually here since BurrowDugEvent does not set it since it is not triggered.
+            lastDugOutBurrowPos = DianaEvents.lastBurrowClicked ?: DianaEvents.lastBlockClicked ?: SboVec(0.0, 0.0, 0.0)
+            refreshBurrows(false)
         }
     }
 
@@ -54,15 +61,15 @@ object BurrowDetector {
 
     @SboEvent
     fun onBurrowDug(event: BurrowDugEvent) {
-        if (!Diana.dianaBurrowDetect) return
+        if (!Diana.closeBurrowDetection) return
         if (event.burrowPos == null) return
-        removePos = event.burrowPos
-        refreshBurrows()
+        lastDugOutBurrowPos = event.burrowPos
+        refreshBurrows(false)
     }
 
     @SboEvent
     fun onWorldChange(event: WorldChangeEvent) {
-        if (!Diana.dianaBurrowDetect) return
+        if (!Diana.closeBurrowDetection) return
         resetBurrows()
     }
 
@@ -70,7 +77,7 @@ object BurrowDetector {
     fun onParticleReceive(event: PacketReceiveEvent) {
         val packet = event.packet
         if (packet !is ClientboundLevelParticlesPacket) return
-        if (!Diana.dianaBurrowDetect) return
+        if (!Diana.closeBurrowDetection) return
         if (World.getWorld() != "Hub") return
 
         if (packet.particle.type == MCParticleTypes.LARGE_SMOKE && packet.maxSpeed == 0.01f && packet.xDist == 0.0f && packet.yDist == 0.0f && packet.zDist == 0.0f) {
@@ -109,11 +116,24 @@ object BurrowDetector {
         }
     }
 
-    fun refreshBurrows() {
-        WaypointManager.removeWaypointAt(removePos, "burrow")
-        val playerPos = Player.getLastPosition()
-        if (WaypointManager.guessWp != null && WaypointManager.guessWp!!.pos.distanceTo(playerPos) < 4) {
-            WaypointManager.guessWp?.hide()
+    fun refreshBurrows(deathOriginating: Boolean) {
+        val dugWaypoint = WaypointManager.getWaypointAt(lastDugOutBurrowPos, "burrow") ?: return
+        val startBurrow = dugWaypoint.text == "Start"
+        val mobBurrow = dugWaypoint.text == "Mob"
+        val shouldCount = !deathOriginating && !startBurrow
+
+        if (shouldCount) {
+            dugWaypoint.timesDug++
+        }
+
+        // Remove if:
+        // 1. Not death originating (was called from BurrowDugEvent) and the burrow type is Start (Start burrows only need to be dug once)
+        // 2. Not death originating (was called from BurrowDugEvent) and times dug is 2 or more (Treasure/Mob burrow that was fully dug out)
+        // 3. Death originating (was called after self player dies) and last dug burrows times dug is 1 or more, and it was a Mob burrow (A mob burrow was dug once and the player died to the mob)
+        val removalCondition = (!deathOriginating && startBurrow) || (!deathOriginating && dugWaypoint.timesDug >= 2) || (deathOriginating && dugWaypoint.timesDug >= 1 && mobBurrow)
+
+        if (removalCondition) {
+            WaypointManager.removeWaypoint(dugWaypoint)
         }
     }
 

--- a/src/main/kotlin/net/sbo/mod/diana/burrows/BurrowDetector.kt
+++ b/src/main/kotlin/net/sbo/mod/diana/burrows/BurrowDetector.kt
@@ -34,18 +34,25 @@ object BurrowDetector {
             Chat.chat("§6[SBO] §4Burrow Waypoints Cleared!")
         }
 
-        Register.onChatMessageCancelable(Pattern.compile("^ ☠ You (.*?)$", Pattern.DOTALL)) { message, matchResult ->
-            if (World.getWorld() != "Hub") return@onChatMessageCancelable true
+        Register.onChatMessage(Regex("""^ ☠ You .+$"""), noFormatting = true) { message, matchResult ->
+            if ("Hub" != World.getWorld()) return@onChatMessage
+            Chat.chat("§6[SBO] §eRemoved Mob burrow waypoint since you died.")
             refreshBurrows(true)
-            true
         }
 
         Register.onChatMessage(Regex("""^§eYou finished the Griffin burrow chain!.*$""")) { message, matchResult ->
+            // BurrowDugEvent only triggers when you get the "You dug out a Griffin Burrow!" message.
+            // The chain finished message does not trigger it.
+
+            // We need to update lastdugOutBurrowPos manually here since BurrowDugEvent does not set it since it is not triggered.
+            lastDugOutBurrowPos = DianaEvents.lastBurrowClicked ?: DianaEvents.lastBlockClicked ?: SboVec(0.0, 0.0, 0.0)
+            refreshBurrows(false)
+
             val anyClose = WaypointManager.getAllGuessesAndBurrows().filter { it.distanceToPlayer() < 90 }
             if (Diana.showTitleWhenChainEnd && anyClose.isEmpty()) requestSpade()
         }
 
-        Register.onChatMessage(Regex(""".*§eYou (?:just )?dug out.*""")) { message, matchResult ->
+        Register.onChatMessage(Regex(""".*§eYou (?:just )?dug out(?!.*\(\d+/\d+\)$).*""")) { message, matchResult ->
             // BurrowDugEvent only triggers when you get the "You dug out a Griffin Burrow!" message.
             // Mob spawns, feather drops, and Myth the Fish use different chat messages.
 

--- a/src/main/kotlin/net/sbo/mod/diana/burrows/BurrowDetector.kt
+++ b/src/main/kotlin/net/sbo/mod/diana/burrows/BurrowDetector.kt
@@ -17,12 +17,14 @@ import net.sbo.mod.utils.waypoint.Waypoint
 import net.sbo.mod.utils.waypoint.WaypointManager
 import java.util.concurrent.ConcurrentHashMap
 import java.util.regex.Pattern
+import java.util.function.BooleanSupplier
 import net.minecraft.core.particles.ParticleTypes as MCParticleTypes
 
 object BurrowDetector {
     internal val burrows = ConcurrentHashMap<String, Burrow>()
     internal var lastDugOutBurrowPos: SboVec = SboVec(0.0, 0.0, 0.0)
     internal val burrowsHistory = EvictingQueue<String>(2)
+    internal val toRemove = ConcurrentHashMap<Waypoint, BooleanSupplier>()
 
     fun init() {
         Register.command("sboclearburrows", "sbocb") {
@@ -36,8 +38,7 @@ object BurrowDetector {
 
         Register.onChatMessage(Regex("""^ ☠ You .+$"""), noFormatting = true) { message, matchResult ->
             if ("Hub" != World.getWorld()) return@onChatMessage
-            Chat.chat("§6[SBO] §eRemoved Mob burrow waypoint since you died.")
-            refreshBurrows(true)
+            refreshBurrows(true, 1)
         }
 
         Register.onChatMessage(Regex("""^§eYou finished the Griffin burrow chain!.*$""")) { message, matchResult ->
@@ -45,8 +46,8 @@ object BurrowDetector {
             // The chain finished message does not trigger it.
 
             // We need to update lastdugOutBurrowPos manually here since BurrowDugEvent does not set it since it is not triggered.
-            lastDugOutBurrowPos = DianaEvents.lastBurrowClicked ?: DianaEvents.lastBlockClicked ?: SboVec(0.0, 0.0, 0.0)
-            refreshBurrows(false)
+            lastDugOutBurrowPos = DianaEvents.lastWaypointClicked ?: SboVec(0.0, 0.0, 0.0)
+            refreshBurrows(false, 2)
 
             val anyClose = WaypointManager.getAllGuessesAndBurrows().filter { it.distanceToPlayer() < 90 }
             if (Diana.showTitleWhenChainEnd && anyClose.isEmpty()) requestSpade()
@@ -57,8 +58,8 @@ object BurrowDetector {
             // Mob spawns, feather drops, and Myth the Fish use different chat messages.
 
             // We need to update lastdugOutBurrowPos manually here since BurrowDugEvent does not set it since it is not triggered.
-            lastDugOutBurrowPos = DianaEvents.lastBurrowClicked ?: DianaEvents.lastBlockClicked ?: SboVec(0.0, 0.0, 0.0)
-            refreshBurrows(false)
+            lastDugOutBurrowPos = DianaEvents.lastWaypointClicked ?: SboVec(0.0, 0.0, 0.0)
+            refreshBurrows(false, 1)
         }
     }
 
@@ -69,9 +70,8 @@ object BurrowDetector {
     @SboEvent
     fun onBurrowDug(event: BurrowDugEvent) {
         if (!Diana.closeBurrowDetection) return
-        if (event.burrowPos == null) return
-        lastDugOutBurrowPos = event.burrowPos
-        refreshBurrows(false)
+        lastDugOutBurrowPos = DianaEvents.lastWaypointClicked ?: SboVec(0.0, 0.0, 0.0)
+        refreshBurrows(false, 2)
     }
 
     @SboEvent
@@ -90,6 +90,8 @@ object BurrowDetector {
         if (packet.particle.type == MCParticleTypes.LARGE_SMOKE && packet.maxSpeed == 0.01f && packet.xDist == 0.0f && packet.yDist == 0.0f && packet.zDist == 0.0f) {
             val pos = SboVec(packet.x, packet.y, packet.z).roundLocationToBlock().down(1.0)
             WaypointManager.removeWaypointAt(pos, "burrow")
+            WaypointManager.removeWaypointAt(pos, "arrow")
+            WaypointManager.removeWaypointAt(pos, "guess")
             WaypointManager.removeWaypointAt(pos, "rareMob")
         }
         burrowDetect(packet)
@@ -123,25 +125,56 @@ object BurrowDetector {
         }
     }
 
-    fun refreshBurrows(deathOriginating: Boolean) {
-        val dugWaypoint = WaypointManager.getWaypointAt(lastDugOutBurrowPos, "burrow") ?: return
-        val startBurrow = dugWaypoint.text == "Start"
-        val mobBurrow = dugWaypoint.text == "Mob"
-        val shouldCount = !deathOriginating && !startBurrow
+    fun queueRemoval(waypoint: Waypoint, condition: BooleanSupplier) {
+        toRemove.put(waypoint, condition)
+    }
 
-        if (shouldCount) {
-            dugWaypoint.timesDug++
+    private fun flushRemovals() {
+        toRemove.forEach { waypoint, condition ->
+            if (condition.getAsBoolean()) {
+                WaypointManager.removeWaypoint(waypoint)
+            }
+        }
+    }
+
+    fun refreshBurrows(deathOriginating: Boolean, expectedTimesDug: Int) {
+        // Try known burrow first, then arrow, then precise
+        val dugWaypoint = WaypointManager.getWaypointAt(lastDugOutBurrowPos, "burrow") ?: WaypointManager.getWaypointAt(lastDugOutBurrowPos, "arrow") ?: WaypointManager.getWaypointAt(lastDugOutBurrowPos, "guess")
+
+        if (null != dugWaypoint) {
+            // Will only work if known burrow
+            val startBurrow = dugWaypoint.text == "Start"
+            val mobBurrow = dugWaypoint.text == "Mob"
+
+            // Count if not death originating and not start burrow (will still count if was a guess and not known burrow)
+            val shouldCount = !deathOriginating && !startBurrow
+
+            if (shouldCount) {
+                dugWaypoint.timesDug++
+            }
+
+            if (dugWaypoint.timesDug < expectedTimesDug) {
+                // Fix up the times dug from chat message in case it ever desyncs
+                dugWaypoint.timesDug = expectedTimesDug
+            }
+
+            // Remove if:
+            // 1. Not death originating (was called from BurrowDugEvent) and the burrow type is Start (Start burrows only need to be dug once)
+            // 2. Not death originating (was called from BurrowDugEvent) and times dug is 2 or more (Treasure/Mob burrow that was fully dug out)
+            // 3. Death originating (was called after self player dies) and last dug burrows times dug is 1 or more, and it was a Mob burrow (A mob burrow was dug once and the player died to the mob)
+            val death = deathOriginating && dugWaypoint.timesDug >= 1 && mobBurrow
+            val removalCondition = (!deathOriginating && startBurrow) || (!deathOriginating && dugWaypoint.timesDug >= 2) || (death)
+
+            if (removalCondition) {
+                if (death) {
+                    Chat.chat("§6[SBO] §eRemoved Mob burrow waypoint since you died.")
+                }
+                WaypointManager.removeWaypoint(dugWaypoint)
+            }
         }
 
-        // Remove if:
-        // 1. Not death originating (was called from BurrowDugEvent) and the burrow type is Start (Start burrows only need to be dug once)
-        // 2. Not death originating (was called from BurrowDugEvent) and times dug is 2 or more (Treasure/Mob burrow that was fully dug out)
-        // 3. Death originating (was called after self player dies) and last dug burrows times dug is 1 or more, and it was a Mob burrow (A mob burrow was dug once and the player died to the mob)
-        val removalCondition = (!deathOriginating && startBurrow) || (!deathOriginating && dugWaypoint.timesDug >= 2) || (deathOriginating && dugWaypoint.timesDug >= 1 && mobBurrow)
-
-        if (removalCondition) {
-            WaypointManager.removeWaypoint(dugWaypoint)
-        }
+        // Counted timesDug above already
+        flushRemovals()
     }
 
     fun resetBurrows() {

--- a/src/main/kotlin/net/sbo/mod/diana/burrows/BurrowDetector.kt
+++ b/src/main/kotlin/net/sbo/mod/diana/burrows/BurrowDetector.kt
@@ -32,11 +32,13 @@ object BurrowDetector {
             WaypointManager.removeAllOfType("guess")
             WaypointManager.removeAllOfType("arrow")
             WaypointManager.removeAllOfType("rareMob")
-            resetBurrows()
+            WaypointManager.removeAllOfType("burrow")
+            burrows.clear()
+            burrowsHistory.clear()
             Chat.chat("§6[SBO] §4Burrow Waypoints Cleared!")
         }
 
-        Register.onChatMessage(Regex("""^ ☠ You .+$"""), noFormatting = true) { message, matchResult ->
+        Register.onChatMessage(Regex("""^§c ☠ §7You .+$""")) { message, matchResult ->
             if ("Hub" != World.getWorld()) return@onChatMessage
             refreshBurrows(true, 1)
         }
@@ -83,12 +85,6 @@ object BurrowDetector {
     }
 
     @SboEvent
-    fun onWorldChange(event: WorldChangeEvent) {
-        if (!Diana.closeBurrowDetection) return
-        resetBurrows()
-    }
-
-    @SboEvent
     fun onParticleReceive(event: PacketReceiveEvent) {
         val packet = event.packet
         if (packet !is ClientboundLevelParticlesPacket) return
@@ -101,6 +97,7 @@ object BurrowDetector {
             WaypointManager.removeWaypointAt(pos, "arrow")
             WaypointManager.removeWaypointAt(pos, "guess")
             WaypointManager.removeWaypointAt(pos, "rareMob")
+            WaypointManager.removeWaypointAt(pos, "world")
         }
         burrowDetect(packet)
     }
@@ -108,32 +105,61 @@ object BurrowDetector {
     private fun burrowDetect(packet: ClientboundLevelParticlesPacket) {
         val particleType = ParticleTypes.getParticleType(packet) ?: return
         val pos = SboVec(packet.x, packet.y, packet.z).roundLocationToBlock().down()
+
+        val type = when (particleType) {
+            "FOOTSTEP" -> {
+                burrows.getOrPut("${pos.x.toInt()} ${pos.y.toInt()} ${pos.z.toInt()}") { Burrow(pos) }.hasFootstep = true
+                return
+            }
+            "ENCHANT" -> {
+                burrows.getOrPut("${pos.x.toInt()} ${pos.y.toInt()} ${pos.z.toInt()}") { Burrow(pos) }.hasEnchant = true
+                return
+            }
+            "EMPTY" -> "Start"
+            "MOB" -> "Mob"
+            "TREASURE" -> "Treasure"
+            else -> return
+        }
+
+        registerBurrow(pos, type)
+    }
+
+    private fun registerBurrow(
+        pos: SboVec,
+        type: String,
+        source: String = "particle",
+        carriedTimesDug: Int? = null
+    ) {
         val posString = "${pos.x.toInt()} ${pos.y.toInt()} ${pos.z.toInt()}"
 
         if (burrowsHistory.contains(posString)) return
+        if (WaypointManager.waypointExists("burrow", pos).first) return
 
         val burrow = burrows.getOrPut(posString) {
             Burrow(pos)
         }
 
-        when (particleType) {
-            "FOOTSTEP" -> burrow.hasFootstep = true
-            "ENCHANT" -> burrow.hasEnchant = true
-            "EMPTY" -> burrow.type = "Start"
-            "MOB" -> burrow.type = "Mob"
-            "TREASURE" -> burrow.type = "Treasure"
-        }
+        burrow.type = type
 
-        val type = burrow.type ?: return
         if (burrow.waypoint != null) return
 
-        burrowsHistory.add(posString)
+        val existingTimesDug =
+            carriedTimesDug
+                ?: burrows[posString]?.waypoint?.timesDug
+                ?: WaypointManager.getWaypointAt(pos, "burrow")?.timesDug
+                ?: WaypointManager.getWaypointAt(pos, "arrow")?.timesDug
+                ?: WaypointManager.getWaypointAt(pos, "guess")?.timesDug
+                ?: 0
 
         val waypoint = Waypoint(
             type,
             pos.x, pos.y, pos.z,
             type = "burrow"
         )
+
+        waypoint.timesDug = existingTimesDug
+
+        burrowsHistory.add(posString)
 
         burrow.waypoint = waypoint
         WaypointManager.addWaypoint(waypoint)
@@ -159,7 +185,7 @@ object BurrowDetector {
         if (null != dugWaypoint) {
             // Will only work if known burrow
             val startBurrow = dugWaypoint.text == "Start"
-            val mobBurrow = dugWaypoint.text == "Mob"
+            val mobBurrow = dugWaypoint.text == "Mob" || burrowType == "Mob"
 
             // Count if not death originating and not start burrow (will still count if was a guess and not known burrow)
             val shouldCount = !deathOriginating && !startBurrow
@@ -168,7 +194,7 @@ object BurrowDetector {
                 dugWaypoint.timesDug++
             }
 
-            if (dugWaypoint.timesDug < expectedTimesDug) {
+            if (dugWaypoint.timesDug != expectedTimesDug) {
                 // Fix up the times dug from chat message in case it ever desyncs
                 dugWaypoint.timesDug = expectedTimesDug
             }
@@ -192,20 +218,18 @@ object BurrowDetector {
         flushRemovals()
 
         if (dugWaypoint?.type != "burrow" && burrowType != null) {
-            // The user has dug the Guess waypoint before we could detect the particles and turn into a Mob/Treasure/Start waypoint.
-            // In this case, if it was a Start waypoint it would disappear instantly anyways. If it was a Mob/Treasure, we use the chat message
-            // to determine the burrow type, and add that as a known burrow and remove the old one, whilst carrying over timesDug.
-            val waypoint = Waypoint(burrowType, pos.x, pos.y, pos.z, type = "burrow")
-            waypoint.timesDug = dugWaypoint?.timesDug ?: expectedTimesDug
+            // The user dug a Guess waypoint before particles updated it into a real burrow type.
+            // We promote it into a real burrow and preserve progression state.
+            registerBurrow(
+                pos = pos,
+                type = burrowType,
+                source = "chat",
+                carriedTimesDug = dugWaypoint?.timesDug ?: expectedTimesDug
+            )
 
-            WaypointManager.addWaypoint(waypoint)
-            if (dugWaypoint != null) WaypointManager.removeWaypoint(dugWaypoint)
+            if (dugWaypoint != null) {
+                WaypointManager.removeWaypoint(dugWaypoint)
+            }
         }
-    }
-
-    fun resetBurrows() {
-        WaypointManager.removeAllOfType("burrow")
-        burrows.clear()
-        burrowsHistory.clear()
     }
 }

--- a/src/main/kotlin/net/sbo/mod/diana/burrows/ParticleTypes.kt
+++ b/src/main/kotlin/net/sbo/mod/diana/burrows/ParticleTypes.kt
@@ -1,8 +1,8 @@
 package net.sbo.mod.diana.burrows
 
 import net.minecraft.network.protocol.game.ClientboundLevelParticlesPacket
-import net.minecraft.core.particles.ParticleTypes as MCParticleTypes
 import net.sbo.mod.utils.NumberUtil.roundTo
+import net.minecraft.core.particles.ParticleTypes as MCParticleTypes
 
 internal object ParticleTypes {
     internal val PARTICLE_CHECKS = mutableMapOf(

--- a/src/main/kotlin/net/sbo/mod/diana/guesses/ArrowGuessBurrow.kt
+++ b/src/main/kotlin/net/sbo/mod/diana/guesses/ArrowGuessBurrow.kt
@@ -299,6 +299,10 @@ object ArrowGuessBurrow {
 
     internal fun isBlockValid(pos: SboVec): Boolean {
         if (!pos.isInLoadedChunk()) return true
+        return isBlockTrulyValid(pos)
+    }
+
+    internal fun isBlockTrulyValid(pos: SboVec): Boolean {
         val isGround = pos.getBlockAt() == Blocks.GRASS_BLOCK
         val isValidBlockAbove = pos.up().getBlockAt() in allowedBlocksAboveGround
         return isGround && isValidBlockAbove

--- a/src/main/kotlin/net/sbo/mod/diana/guesses/ArrowGuessBurrow.kt
+++ b/src/main/kotlin/net/sbo/mod/diana/guesses/ArrowGuessBurrow.kt
@@ -118,16 +118,6 @@ object ArrowGuessBurrow {
             locations.clear()
         }
         if (currentChain == 1) return
-
-        val containList = allGuesses.filter { guessEntry ->
-            guessEntry.guesses.any { guess -> guess.distanceTo(event.lastBlock) <= 3 }
-        }
-
-        containList.forEach { entry ->
-            entry.removeGuesses()
-        }
-
-        allGuesses.removeAll(containList.toSet())
     }
 
     private fun detectArrow(): RaycastUtils.Ray? {

--- a/src/main/kotlin/net/sbo/mod/diana/guesses/ArrowGuessBurrow.kt
+++ b/src/main/kotlin/net/sbo/mod/diana/guesses/ArrowGuessBurrow.kt
@@ -1,15 +1,14 @@
 package net.sbo.mod.diana.guesses
 
-import net.minecraft.world.level.block.Blocks
-import net.minecraft.world.phys.AABB
-import net.minecraft.network.protocol.game.ClientboundLevelParticlesPacket
 import net.minecraft.core.particles.DustParticleOptions
 import net.minecraft.core.particles.ParticleTypes
+import net.minecraft.network.protocol.game.ClientboundLevelParticlesPacket
+import net.minecraft.world.level.block.Blocks
+import net.minecraft.world.phys.AABB
 import net.sbo.mod.SBOKotlin
 import net.sbo.mod.diana.burrows.BurrowDetector
 import net.sbo.mod.settings.categories.Diana
 import net.sbo.mod.utils.NumberUtil.roundTo
-import net.sbo.mod.utils.math.RaycastUtils
 import net.sbo.mod.utils.collection.TimeLimitedSet
 import net.sbo.mod.utils.events.annotations.SboEvent
 import net.sbo.mod.utils.events.impl.diana.BurrowDugEvent
@@ -17,10 +16,11 @@ import net.sbo.mod.utils.events.impl.game.TickEvent
 import net.sbo.mod.utils.events.impl.packets.PacketReceiveEvent
 import net.sbo.mod.utils.game.InventoryUtils
 import net.sbo.mod.utils.game.World
+import net.sbo.mod.utils.math.RaycastUtils
 import net.sbo.mod.utils.math.SboVec
 import net.sbo.mod.utils.math.SboVec.Companion.toSboVec
 import net.sbo.mod.utils.waypoint.WaypointManager
-import java.util.Collections
+import java.util.*
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.CopyOnWriteArrayList
 import kotlin.math.abs

--- a/src/main/kotlin/net/sbo/mod/diana/guesses/GuessEntry.kt
+++ b/src/main/kotlin/net/sbo/mod/diana/guesses/GuessEntry.kt
@@ -1,7 +1,9 @@
 package net.sbo.mod.diana.guesses
 
 import net.sbo.mod.utils.math.SboVec
+import net.sbo.mod.utils.chat.Chat
 import net.sbo.mod.utils.waypoint.WaypointManager
+import net.sbo.mod.diana.burrows.BurrowDetector
 
 class GuessEntry(val guesses: List<SboVec>) {
     private var currentIndex = 0
@@ -17,7 +19,19 @@ class GuessEntry(val guesses: List<SboVec>) {
     }
 
     fun moveToNext(): Boolean {
-        WaypointManager.removeArrowGuess(getCurrent())
+        val current = getCurrent()
+        val currentWaypoint = WaypointManager.getWaypointAt(current, "arrow")
+
+        if (currentWaypoint != null) {
+            if (currentWaypoint.userInteractedWith) {
+                // If the user interacted with the waypoint, we queue it to be removed when we get the "You dug out a Griffin Burrow!" chat message (dug 2 times).
+                BurrowDetector.queueRemoval(currentWaypoint, { currentWaypoint.timesDug != 1 })
+            } else {
+                // Otherwise, we directly remove it (most likely a waypoint that was in a wrong position, so moveToNext was called before player can do any interaction, since this is checked every tick)
+                WaypointManager.removeWaypoint(currentWaypoint)
+            }
+        }
+
         val nextIndex = currentIndex + 1
 
         if (nextIndex in guesses.indices) {

--- a/src/main/kotlin/net/sbo/mod/diana/guesses/PreciseGuessBurrow.kt
+++ b/src/main/kotlin/net/sbo/mod/diana/guesses/PreciseGuessBurrow.kt
@@ -1,7 +1,7 @@
 package net.sbo.mod.diana.guesses
 
-import net.minecraft.network.protocol.game.ClientboundLevelParticlesPacket
 import net.minecraft.core.particles.ParticleTypes
+import net.minecraft.network.protocol.game.ClientboundLevelParticlesPacket
 import net.sbo.mod.SBOKotlin
 import net.sbo.mod.settings.categories.Diana
 import net.sbo.mod.utils.events.annotations.SboEvent
@@ -12,12 +12,7 @@ import net.sbo.mod.utils.game.World
 import net.sbo.mod.utils.math.PolynomialFitter
 import net.sbo.mod.utils.math.SboVec
 import net.sbo.mod.utils.waypoint.WaypointManager
-import kotlin.math.PI
-import kotlin.math.atan2
-import kotlin.math.cos
-import kotlin.math.pow
-import kotlin.math.sin
-import kotlin.math.sqrt
+import kotlin.math.*
 
 object PreciseGuessBurrow {
     private var particleLocations = mutableListOf<SboVec>()
@@ -30,7 +25,7 @@ object PreciseGuessBurrow {
 
     @SboEvent
     fun onWorldChange(event: WorldChangeEvent) {
-        if (!Diana.dianaBurrowGuess) return
+        if (!Diana.spadeGuess) return
         this.guessPoint = null
         this.particleLocations.clear()
         finalLocation = null
@@ -41,7 +36,7 @@ object PreciseGuessBurrow {
     fun onReceiveParticle(event: PacketReceiveEvent) {
         val packet = event.packet
         if (packet !is ClientboundLevelParticlesPacket) return
-        if (!Diana.dianaBurrowGuess || World.getWorld() != "Hub") return
+        if (!Diana.spadeGuess || World.getWorld() != "Hub") return
         if (packet.particle.type != ParticleTypes.DRIPPING_LAVA || packet.count != 2 || packet.maxSpeed != -0.5f) return
         val currLoc = SboVec(packet.x, packet.y, packet.z)
         this.lastLavaParticle = System.currentTimeMillis()
@@ -65,7 +60,7 @@ object PreciseGuessBurrow {
 
     @SboEvent
     fun onUseSpade(event: PlayerInteractEvent) {
-        if (!Diana.dianaBurrowGuess) return
+        if (!Diana.spadeGuess) return
         val action = event.action
         if (action != "useItem" && action != "useBlock") return
         val player = SBOKotlin.mc.player

--- a/src/main/kotlin/net/sbo/mod/diana/sphinx/SphinxSolver.kt
+++ b/src/main/kotlin/net/sbo/mod/diana/sphinx/SphinxSolver.kt
@@ -36,10 +36,10 @@ object SphinxSolver {
 
 
     fun detectQuestion() {
-        Register.onChatMessageCancable(
+        Register.onChatMessageCancelable(
             Pattern.compile("^(.*?)$", Pattern.DOTALL)
         ) { message, matchResult ->
-            if (!Diana.sphinxSolver) return@onChatMessageCancable true
+            if (!Diana.sphinxSolver) return@onChatMessageCancelable true
             val questionText = matchResult.group(1).trim()
             for (sphinxQuestion in SphinxQuestions.QUESTIONS) {
                 if (sphinxQuestion.question.equals(questionText.removeFormatting(), ignoreCase = true)) {
@@ -51,10 +51,10 @@ object SphinxSolver {
             true
         }
 
-        Register.onChatMessageCancable(
+        Register.onChatMessageCancelable(
             Pattern.compile("^§7 {3}([ABC])\\) §f(.*?)$")
         ) { msg, matcher ->
-            if (!Diana.sphinxSolver) return@onChatMessageCancable true
+            if (!Diana.sphinxSolver) return@onChatMessageCancelable true
 
             val letter = matcher.group(1)
             val possibleAnswer = matcher.group(2).trim()

--- a/src/main/kotlin/net/sbo/mod/general/HelpCommand.kt
+++ b/src/main/kotlin/net/sbo/mod/general/HelpCommand.kt
@@ -1,10 +1,10 @@
 package net.sbo.mod.general
 
+import net.minecraft.ChatFormatting
 import net.minecraft.network.chat.ClickEvent.RunCommand
+import net.minecraft.network.chat.Component
 import net.minecraft.network.chat.HoverEvent.ShowText
 import net.minecraft.network.chat.Style
-import net.minecraft.network.chat.Component
-import net.minecraft.ChatFormatting
 import net.sbo.mod.utils.Helper
 import net.sbo.mod.utils.SoundHandler
 import net.sbo.mod.utils.chat.Chat

--- a/src/main/kotlin/net/sbo/mod/general/PartyCommands.kt
+++ b/src/main/kotlin/net/sbo/mod/general/PartyCommands.kt
@@ -1,26 +1,26 @@
 package net.sbo.mod.general
 
 import net.sbo.mod.SBOKotlin
-import net.sbo.mod.utils.events.Register
-import net.sbo.mod.settings.categories.PartyCommands
-import net.sbo.mod.utils.chat.Chat
-import net.sbo.mod.utils.data.SboDataObject.sboData
-import net.sbo.mod.utils.data.SboDataObject.dianaTrackerMayor
-import net.sbo.mod.utils.Helper.getPlayerName
-import net.sbo.mod.utils.Helper.calcPercentOne
-import net.sbo.mod.utils.Helper.formatNumber
-import net.sbo.mod.utils.Helper.formatTime
 import net.sbo.mod.diana.DianaStats
 import net.sbo.mod.overlays.DianaLoot
 import net.sbo.mod.settings.categories.Diana
+import net.sbo.mod.settings.categories.PartyCommands
 import net.sbo.mod.utils.Helper
+import net.sbo.mod.utils.Helper.calcPercentOne
+import net.sbo.mod.utils.Helper.formatNumber
+import net.sbo.mod.utils.Helper.formatTime
+import net.sbo.mod.utils.Helper.getPlayerName
 import net.sbo.mod.utils.Helper.removeFormatting
 import net.sbo.mod.utils.Player
 import net.sbo.mod.utils.SboTimerManager
+import net.sbo.mod.utils.chat.Chat
+import net.sbo.mod.utils.data.SboDataObject.dianaTrackerMayor
+import net.sbo.mod.utils.data.SboDataObject.sboData
+import net.sbo.mod.utils.events.Register
 import net.sbo.mod.utils.game.ServerStats
-import java.util.concurrent.TimeUnit
 import java.text.SimpleDateFormat
-import java.util.Date
+import java.util.*
+import java.util.concurrent.TimeUnit
 
 object PartyCommands {
     // How to add a new party command:

--- a/src/main/kotlin/net/sbo/mod/general/Pickuplog.kt
+++ b/src/main/kotlin/net/sbo/mod/general/Pickuplog.kt
@@ -5,16 +5,12 @@ import net.sbo.mod.SBOKotlin.mc
 import net.sbo.mod.diana.DianaTracker
 import net.sbo.mod.settings.categories.QOL
 import net.sbo.mod.utils.Helper
-import net.sbo.mod.utils.events.Register
-import net.sbo.mod.utils.game.World
 import net.sbo.mod.utils.data.Item
+import net.sbo.mod.utils.events.Register
 import net.sbo.mod.utils.events.annotations.SboEvent
 import net.sbo.mod.utils.events.impl.game.InventorySlotUpdateEvent
-import net.sbo.mod.utils.overlay.Overlay
-import net.sbo.mod.utils.overlay.CHAT_SCREEN_FILTER
-import net.sbo.mod.utils.overlay.CRAFTING_PLAYER_INVENTORY_FILTER
-import net.sbo.mod.utils.overlay.OverlayExamples
-import net.sbo.mod.utils.overlay.OverlayTextLine
+import net.sbo.mod.utils.game.World
+import net.sbo.mod.utils.overlay.*
 import java.util.regex.Pattern
 
 object Pickuplog {
@@ -37,7 +33,7 @@ object Pickuplog {
         overlay.init()
         overlay.setCondition { QOL.pickuplogOverlay }
 
-        Register.onChatMessageCancable(Pattern.compile("(.*?) item(.*?) (.*?)", Pattern.DOTALL)) { message, matchResult ->
+        Register.onChatMessageCancelable(Pattern.compile("(.*?) item(.*?) (.*?)", Pattern.DOTALL)) { message, matchResult ->
             var cancel = true
             if (World.isInSkyblock() && matchResult.group(1).contains("Sacks")) {
                 message.siblings.forEach { part ->

--- a/src/main/kotlin/net/sbo/mod/guis/AchievementsGUI.kt
+++ b/src/main/kotlin/net/sbo/mod/guis/AchievementsGUI.kt
@@ -3,31 +3,18 @@ package net.sbo.mod.guis
 import gg.essential.elementa.ElementaVersion
 import gg.essential.elementa.UIComponent
 import gg.essential.elementa.WindowScreen
-import gg.essential.elementa.components.ScrollComponent
-import gg.essential.elementa.components.UIBlock
-import gg.essential.elementa.components.UIRoundedRectangle
-import gg.essential.elementa.components.UIText
-import gg.essential.elementa.components.UIWrappedText
+import gg.essential.elementa.components.*
 import gg.essential.elementa.components.input.UITextInput
-import gg.essential.elementa.constraints.AdditiveConstraint
-import gg.essential.elementa.constraints.CenterConstraint
-import gg.essential.elementa.constraints.ChildBasedSizeConstraint
-import gg.essential.elementa.constraints.FillConstraint
-import gg.essential.elementa.constraints.SiblingConstraint
-import gg.essential.elementa.constraints.SubtractiveConstraint
-import gg.essential.elementa.dsl.childOf
-import gg.essential.elementa.dsl.constrain
-import gg.essential.elementa.dsl.percent
-import gg.essential.elementa.dsl.pixels
-import gg.essential.elementa.dsl.toConstraint
+import gg.essential.elementa.constraints.*
+import gg.essential.elementa.dsl.*
 import gg.essential.universal.UKeyboard
+import net.minecraft.ChatFormatting
+import net.sbo.mod.SBOKotlin.mc
 import net.sbo.mod.diana.achievements.Achievement
 import net.sbo.mod.diana.achievements.AchievementManager
 import net.sbo.mod.utils.data.SboDataObject
 import java.awt.Color
 import kotlin.math.floor
-import net.minecraft.ChatFormatting
-import net.sbo.mod.SBOKotlin.mc
 
 class AchievementsGUI : WindowScreen(ElementaVersion.V10) {
     enum class AchievementFilter {

--- a/src/main/kotlin/net/sbo/mod/guis/Guis.kt
+++ b/src/main/kotlin/net/sbo/mod/guis/Guis.kt
@@ -1,18 +1,18 @@
 package net.sbo.mod.guis
 
 import gg.essential.universal.UScreen
+import net.minecraft.ChatFormatting
+import net.minecraft.network.chat.Component
+import net.minecraft.network.chat.Style
 import net.sbo.mod.SBOKotlin
 import net.sbo.mod.SBOKotlin.mc
 import net.sbo.mod.guis.partyfinder.PartyFinderGUI
 import net.sbo.mod.utils.chat.Chat
-import net.sbo.mod.utils.events.SBOEvent
 import net.sbo.mod.utils.events.Register
+import net.sbo.mod.utils.events.SBOEvent
 import net.sbo.mod.utils.events.impl.partyfinder.PartyFinderOpenEvent
 import net.sbo.mod.utils.game.World
 import net.sbo.mod.utils.http.Http
-import net.minecraft.network.chat.Component
-import net.minecraft.network.chat.Style
-import net.minecraft.ChatFormatting
 
 object Guis {
     private var partyFinderGui: PartyFinderGUI? = null

--- a/src/main/kotlin/net/sbo/mod/guis/PastEventsGui.kt
+++ b/src/main/kotlin/net/sbo/mod/guis/PastEventsGui.kt
@@ -3,10 +3,10 @@ package net.sbo.mod.guis
 
 import gg.essential.elementa.ElementaVersion
 import gg.essential.elementa.WindowScreen
+import gg.essential.elementa.components.ScrollComponent
 import gg.essential.elementa.components.UIBlock
 import gg.essential.elementa.components.UIRoundedRectangle
 import gg.essential.elementa.components.UIText
-import gg.essential.elementa.components.ScrollComponent
 import gg.essential.elementa.constraints.*
 import gg.essential.elementa.dsl.childOf
 import gg.essential.elementa.dsl.constrain

--- a/src/main/kotlin/net/sbo/mod/guis/partyfinder/GuiHandler.kt
+++ b/src/main/kotlin/net/sbo/mod/guis/partyfinder/GuiHandler.kt
@@ -6,11 +6,7 @@ import gg.essential.elementa.components.UIRoundedRectangle
 import gg.essential.elementa.components.UIText
 import gg.essential.elementa.components.UIWrappedText
 import gg.essential.elementa.components.input.UITextInput
-import gg.essential.elementa.constraints.CenterConstraint
-import gg.essential.elementa.constraints.ChildBasedSizeConstraint
-import gg.essential.elementa.constraints.PositionConstraint
-import gg.essential.elementa.constraints.SiblingConstraint
-import gg.essential.elementa.constraints.SizeConstraint
+import gg.essential.elementa.constraints.*
 import gg.essential.elementa.dsl.childOf
 import gg.essential.elementa.dsl.constrain
 import gg.essential.elementa.dsl.pixels
@@ -40,10 +36,10 @@ object GuiHandler {
         private val y: PositionConstraint,
         private val width: SizeConstraint,
         private val height: SizeConstraint,
-        private val color: Color,
-        private val parent: UIComponent? = null,
-        private val rounded: Boolean = false,
-        private val roundness: Float = 5f
+        color: Color,
+        parent: UIComponent? = null,
+        rounded: Boolean = false,
+        roundness: Float = 5f
     ) {
         val uiObject: UIComponent = if (rounded) UIRoundedRectangle(roundness) else UIBlock()
 
@@ -62,17 +58,17 @@ object GuiHandler {
     }
 
     class Button(
-        private val text: String,
+        text: String,
         private val x: PositionConstraint,
         private val y: PositionConstraint,
         private val width: SizeConstraint,
         private val height: SizeConstraint,
         private val color: Color,
         private val textColor: Color? = null,
-        private val outline: Effect? = null,
-        private val parent: UIComponent? = null,
-        private val rounded: Boolean = false,
-        private val wrapped: Boolean = false,
+        outline: Effect? = null,
+        parent: UIComponent? = null,
+        rounded: Boolean = false,
+        wrapped: Boolean = false,
     ) {
         val uiObject: UIComponent = if (rounded) UIRoundedRectangle(10f) else UIBlock()
         val textObject: UIComponent = if (wrapped) UIWrappedText(text) else UIText(text)
@@ -139,8 +135,8 @@ object GuiHandler {
         private val color: Color,
         private val checkedColor: Color,
         private val text: String = "",
-        private val rounded: Boolean = false,
-        private val roundness: Float = 10f,
+        rounded: Boolean = false,
+        roundness: Float = 10f,
         private val filter: Boolean = false
     ) {
         private lateinit var onClick: () -> Unit
@@ -181,21 +177,10 @@ object GuiHandler {
 
         private val bgbox = if (rounded) UIRoundedRectangle(roundness) else UIBlock()
         private val checkbox = if (rounded) UIRoundedRectangle(roundness) else UIBlock()
-        private val outlineBlock = if (rounded) UIRoundedRectangle(roundness) else UIBlock()
         internal lateinit var textObject: UIText
 
         fun setBgBoxColor(color: Color): Checkbox {
             bgbox.setColor(color)
-            return this
-        }
-
-        fun setCheckBoxDimensions(width: SizeConstraint, height: SizeConstraint): Checkbox {
-            checkbox.setWidth(width).setHeight(height)
-            return this
-        }
-
-        fun setTextColor(color: Color): Checkbox {
-            textObject.setColor(color)
             return this
         }
 
@@ -255,8 +240,8 @@ object GuiHandler {
         private val inputWidth: SizeConstraint,
         private val color: Color,
         private val textColor: Color,
-        private val rounded: Boolean = false,
-        private val roundness: Float = 5f
+        rounded: Boolean = false,
+        roundness: Float = 5f
     ) {
         internal var onlyNumbers = false
         internal var onlyText = false

--- a/src/main/kotlin/net/sbo/mod/guis/partyfinder/PartyFinderGUI.kt
+++ b/src/main/kotlin/net/sbo/mod/guis/partyfinder/PartyFinderGUI.kt
@@ -5,17 +5,8 @@ import com.teamresourceful.resourcefulconfig.api.client.ResourcefulConfigScreen
 import gg.essential.elementa.ElementaVersion
 import gg.essential.elementa.UIComponent
 import gg.essential.elementa.WindowScreen
-import gg.essential.elementa.components.ScrollComponent
-import gg.essential.elementa.components.UIBlock
-import gg.essential.elementa.components.UIRoundedRectangle
-import gg.essential.elementa.components.UIText
-import gg.essential.elementa.components.UIWrappedText
-import gg.essential.elementa.components.Window
-import gg.essential.elementa.constraints.CenterConstraint
-import gg.essential.elementa.constraints.FillConstraint
-import gg.essential.elementa.constraints.PixelConstraint
-import gg.essential.elementa.constraints.PositionConstraint
-import gg.essential.elementa.constraints.SiblingConstraint
+import gg.essential.elementa.components.*
+import gg.essential.elementa.constraints.*
 import gg.essential.elementa.dsl.childOf
 import gg.essential.elementa.dsl.constrain
 import gg.essential.elementa.dsl.percent
@@ -37,8 +28,8 @@ import net.sbo.mod.partyfinder.PartyFinderManager.removePartyFromQueue
 import net.sbo.mod.partyfinder.PartyFinderManager.sendJoinRequest
 import net.sbo.mod.partyfinder.PartyPlayer.getPartyPlayerStats
 import net.sbo.mod.settings.categories.PartyFinder
-import net.sbo.mod.utils.chat.Chat
 import net.sbo.mod.utils.Helper
+import net.sbo.mod.utils.chat.Chat
 import net.sbo.mod.utils.data.HighlightElement
 import net.sbo.mod.utils.data.Party
 import net.sbo.mod.utils.data.PartyPlayerStats
@@ -162,11 +153,6 @@ class PartyFinderGUI : WindowScreen(ElementaVersion.V10) {
     internal fun getTextScale(base: Float = 1f): PixelConstraint {
         return if (base + PartyFinder.scaleText <= 0f) 0.1f.pixels()
         else (base + PartyFinder.scaleText).pixels()
-    }
-
-    private fun getIconScale(base: Int = 18): PixelConstraint {
-        return if (base + PartyFinder.scaleIcon <= 0) 1.pixels()
-        else (base + PartyFinder.scaleIcon).pixels()
     }
 
     private fun getMemberColor(members: Int, patySize: Int): Color {

--- a/src/main/kotlin/net/sbo/mod/guis/partyfinder/pages/CustomPage.kt
+++ b/src/main/kotlin/net/sbo/mod/guis/partyfinder/pages/CustomPage.kt
@@ -15,8 +15,8 @@ import gg.essential.elementa.dsl.pixels
 import net.sbo.mod.guis.partyfinder.GuiHandler
 import net.sbo.mod.guis.partyfinder.PartyFinderGUI
 import net.sbo.mod.partyfinder.PartyPlayer.getPartyPlayerStats
-import net.sbo.mod.utils.chat.Chat
 import net.sbo.mod.utils.Helper
+import net.sbo.mod.utils.chat.Chat
 import net.sbo.mod.utils.data.PartyPlayerStats
 import net.sbo.mod.utils.data.Reqs
 import net.sbo.mod.utils.data.SboDataObject.pfConfigState

--- a/src/main/kotlin/net/sbo/mod/guis/partyfinder/pages/DianaPage.kt
+++ b/src/main/kotlin/net/sbo/mod/guis/partyfinder/pages/DianaPage.kt
@@ -15,8 +15,8 @@ import gg.essential.elementa.dsl.pixels
 import net.sbo.mod.guis.partyfinder.GuiHandler
 import net.sbo.mod.guis.partyfinder.PartyFinderGUI
 import net.sbo.mod.partyfinder.PartyPlayer.getPartyPlayerStats
-import net.sbo.mod.utils.chat.Chat
 import net.sbo.mod.utils.Helper
+import net.sbo.mod.utils.chat.Chat
 import net.sbo.mod.utils.data.PartyPlayerStats
 import net.sbo.mod.utils.data.Reqs
 import net.sbo.mod.utils.data.SboDataObject.pfConfigState

--- a/src/main/kotlin/net/sbo/mod/overlays/Bobber.kt
+++ b/src/main/kotlin/net/sbo/mod/overlays/Bobber.kt
@@ -1,10 +1,10 @@
 package net.sbo.mod.overlays
 
-import net.sbo.mod.utils.events.Register
-import net.sbo.mod.settings.categories.General
-import net.sbo.mod.utils.game.World
 import net.minecraft.world.entity.projectile.FishingHook
 import net.sbo.mod.SBOKotlin.mc
+import net.sbo.mod.settings.categories.General
+import net.sbo.mod.utils.events.Register
+import net.sbo.mod.utils.game.World
 import net.sbo.mod.utils.overlay.Overlay
 import net.sbo.mod.utils.overlay.OverlayTextLine
 

--- a/src/main/kotlin/net/sbo/mod/overlays/DianaLoot.kt
+++ b/src/main/kotlin/net/sbo/mod/overlays/DianaLoot.kt
@@ -1,13 +1,9 @@
 package net.sbo.mod.overlays
 
-import net.sbo.mod.settings.categories.Diana
-import net.sbo.mod.utils.overlay.Overlay
-import net.sbo.mod.utils.overlay.isCraftingScreenOpen
-import net.sbo.mod.utils.overlay.CHAT_SCREEN_FILTER
-import net.sbo.mod.utils.overlay.CRAFTING_PLAYER_INVENTORY_FILTER
-import net.sbo.mod.utils.overlay.OverlayTextLine
 import net.minecraft.ChatFormatting.*
 import net.sbo.mod.SBOKotlin.mc
+import net.sbo.mod.overlays.OverlayUtils.LootItemData
+import net.sbo.mod.settings.categories.Diana
 import net.sbo.mod.utils.Helper
 import net.sbo.mod.utils.Helper.calcPercentOne
 import net.sbo.mod.utils.Helper.removeFormatting
@@ -18,9 +14,8 @@ import net.sbo.mod.utils.events.Register
 import net.sbo.mod.utils.events.annotations.SboEvent
 import net.sbo.mod.utils.events.impl.guis.GuiCloseEvent
 import net.sbo.mod.utils.events.impl.guis.GuiOpenEvent
+import net.sbo.mod.utils.overlay.*
 import net.sbo.mod.utils.render.RenderUtils2D
-import net.sbo.mod.overlays.OverlayUtils.LootItemData
-import net.sbo.mod.utils.overlay.DirtyFlushableOverlay
 import java.util.concurrent.TimeUnit
 
 object DianaLoot : DirtyFlushableOverlay() {
@@ -297,7 +292,7 @@ object DianaLoot : DirtyFlushableOverlay() {
     }
 
     private fun createCoinLine(tracker: DianaTracker): OverlayTextLine {
-        return OverlayTextLine("${GOLD}Total Coins: $AQUA${Helper.formatNumber(tracker.items.COINS)}" + if (Diana.excludeCoinsFromProfit) "$GRAY[$RED EXCLUDED$GRAY]" else "")
+        return OverlayTextLine("${GOLD}Total Coins: $AQUA${Helper.formatNumber(tracker.items.COINS)}" + if (Diana.excludeCoinsFromProfit) " $GRAY[${RED}EXCLUDED$GRAY]" else "")
             .onHover { drawContext, textRenderer ->
                 val scaleFactor = mc.window.guiScale
                 val mouseX = mc.mouseHandler.xpos() / scaleFactor

--- a/src/main/kotlin/net/sbo/mod/overlays/DianaMobs.kt
+++ b/src/main/kotlin/net/sbo/mod/overlays/DianaMobs.kt
@@ -1,16 +1,11 @@
 package net.sbo.mod.overlays
 /* todo: Refactoring
-* This Code definetly needs refactoring, but I don't have the time to do it right now.
+* This Code definitely needs refactoring, but I don't have the time to do it right now.
 * I will do it in the future, but for now it works and I don't want to break it.
 * If you want to refactor it, feel free to do so, but please keep the functionality intact.
 */
-import net.sbo.mod.settings.categories.Diana
-import net.sbo.mod.utils.overlay.Overlay
-import net.sbo.mod.utils.overlay.isCraftingScreenOpen
-import net.sbo.mod.utils.overlay.CHAT_SCREEN_FILTER
-import net.sbo.mod.utils.overlay.CRAFTING_PLAYER_INVENTORY_FILTER
-import net.sbo.mod.utils.overlay.OverlayTextLine
 import net.minecraft.ChatFormatting.*
+import net.sbo.mod.settings.categories.Diana
 import net.sbo.mod.utils.Helper
 import net.sbo.mod.utils.Helper.calcPercentOne
 import net.sbo.mod.utils.Helper.removeFormatting
@@ -19,10 +14,10 @@ import net.sbo.mod.utils.events.Register
 import net.sbo.mod.utils.events.annotations.SboEvent
 import net.sbo.mod.utils.events.impl.guis.GuiCloseEvent
 import net.sbo.mod.utils.events.impl.guis.GuiOpenEvent
+import net.sbo.mod.utils.overlay.*
 import java.math.BigDecimal
 import java.math.RoundingMode
 import java.util.concurrent.TimeUnit
-import net.sbo.mod.utils.overlay.DirtyFlushableOverlay
 
 object DianaMobs : DirtyFlushableOverlay() {
     override val overlay = Overlay("Diana Mobs", 10f, 10f, 1f, listOf(CHAT_SCREEN_FILTER, CRAFTING_PLAYER_INVENTORY_FILTER)).setCondition { Diana.mobTracker != Diana.Tracker.OFF && (Helper.checkDiana() || Helper.hasSpade) }

--- a/src/main/kotlin/net/sbo/mod/overlays/DianaStats.kt
+++ b/src/main/kotlin/net/sbo/mod/overlays/DianaStats.kt
@@ -1,12 +1,12 @@
 package net.sbo.mod.overlays
 
-import net.sbo.mod.settings.categories.Diana
-import net.sbo.mod.utils.overlay.Overlay
-import net.sbo.mod.utils.overlay.OverlayTextLine
 import net.minecraft.ChatFormatting.*
+import net.sbo.mod.settings.categories.Diana
 import net.sbo.mod.utils.Helper
 import net.sbo.mod.utils.data.SboDataObject.sboData
 import net.sbo.mod.utils.overlay.DirtyFlushableOverlay
+import net.sbo.mod.utils.overlay.Overlay
+import net.sbo.mod.utils.overlay.OverlayTextLine
 
 object DianaStats : DirtyFlushableOverlay() {
     override val overlay = Overlay("Diana Stats", 10f, 10f, 1f).setCondition { Diana.statsTracker && (Helper.checkDiana() || Helper.hasSpade)}

--- a/src/main/kotlin/net/sbo/mod/overlays/Legion.kt
+++ b/src/main/kotlin/net/sbo/mod/overlays/Legion.kt
@@ -2,12 +2,12 @@ package net.sbo.mod.overlays
 
 import net.minecraft.client.Minecraft
 import net.sbo.mod.SBOKotlin.mc
-import net.sbo.mod.utils.events.Register
 import net.sbo.mod.settings.categories.General
+import net.sbo.mod.utils.events.Register
 import net.sbo.mod.utils.game.World
 import net.sbo.mod.utils.overlay.Overlay
 import net.sbo.mod.utils.overlay.OverlayTextLine
-import java.util.UUID
+import java.util.*
 
 object Legion {
     var legionCount: Int = 0

--- a/src/main/kotlin/net/sbo/mod/overlays/MagicFind.kt
+++ b/src/main/kotlin/net/sbo/mod/overlays/MagicFind.kt
@@ -1,12 +1,12 @@
 package net.sbo.mod.overlays
 
-import net.sbo.mod.settings.categories.Diana
-import net.sbo.mod.utils.overlay.Overlay
-import net.sbo.mod.utils.overlay.OverlayTextLine
 import net.minecraft.ChatFormatting.*
+import net.sbo.mod.settings.categories.Diana
 import net.sbo.mod.utils.Helper
 import net.sbo.mod.utils.data.SboDataObject.sboData
 import net.sbo.mod.utils.overlay.DirtyFlushableOverlay
+import net.sbo.mod.utils.overlay.Overlay
+import net.sbo.mod.utils.overlay.OverlayTextLine
 
 object MagicFind : DirtyFlushableOverlay() {
     override val overlay = Overlay("Diana MagicFind", 10f, 10f, 1f).setCondition { Diana.magicFindTracker && (Helper.checkDiana() || Helper.hasSpade) }

--- a/src/main/kotlin/net/sbo/mod/partyfinder/PartyCheck.kt
+++ b/src/main/kotlin/net/sbo/mod/partyfinder/PartyCheck.kt
@@ -3,13 +3,13 @@ package net.sbo.mod.partyfinder
 import net.sbo.mod.SBOKotlin.API_URL
 import net.sbo.mod.SBOKotlin.logger
 import net.sbo.mod.diana.achievements.AchievementManager.trackWithCheckPlayer
-import net.sbo.mod.utils.chat.Chat
 import net.sbo.mod.utils.Helper
 import net.sbo.mod.utils.HypixelModApi
 import net.sbo.mod.utils.Player
-import net.sbo.mod.utils.events.Register
+import net.sbo.mod.utils.chat.Chat
 import net.sbo.mod.utils.data.PartyInfo
 import net.sbo.mod.utils.data.PartyPlayerStats
+import net.sbo.mod.utils.events.Register
 import net.sbo.mod.utils.http.Http
 
 object PartyCheck {

--- a/src/main/kotlin/net/sbo/mod/partyfinder/PartyFinderManager.kt
+++ b/src/main/kotlin/net/sbo/mod/partyfinder/PartyFinderManager.kt
@@ -2,35 +2,28 @@ package net.sbo.mod.partyfinder
 
 import gg.essential.universal.utils.toFormattedString
 import net.azureaaron.hmapi.network.packet.v2.s2c.PartyInfoS2CPacket
-import net.sbo.mod.settings.categories.PartyFinder
-import net.sbo.mod.utils.HypixelModApi
-import net.sbo.mod.utils.events.Register
-import net.sbo.mod.utils.chat.Chat
-import net.sbo.mod.utils.Helper.sleep
-import net.sbo.mod.utils.Player
-import net.sbo.mod.utils.data.SboDataObject
-import net.sbo.mod.utils.http.Http
-import net.sbo.mod.utils.http.Http.getBoolean
-import net.sbo.mod.utils.http.Http.getString
-import net.sbo.mod.utils.data.SboDataObject.sboData
 import net.sbo.mod.SBOKotlin.API_URL
 import net.sbo.mod.partyfinder.PartyPlayer.getPartyPlayerStats
-import net.sbo.mod.utils.events.SBOEvent
+import net.sbo.mod.settings.categories.PartyFinder
 import net.sbo.mod.utils.Helper
-import net.sbo.mod.utils.data.PartyPlayerStats
-import net.sbo.mod.utils.data.GetAllParties
-import net.sbo.mod.utils.data.Party
-import net.sbo.mod.utils.data.PartyAddResponse
-import net.sbo.mod.utils.data.PartyUpdateResponse
-import net.sbo.mod.utils.data.Reqs
+import net.sbo.mod.utils.Helper.sleep
+import net.sbo.mod.utils.HypixelModApi
+import net.sbo.mod.utils.Player
+import net.sbo.mod.utils.chat.Chat
+import net.sbo.mod.utils.data.*
+import net.sbo.mod.utils.data.SboDataObject.sboData
+import net.sbo.mod.utils.events.Register
+import net.sbo.mod.utils.events.SBOEvent
 import net.sbo.mod.utils.events.annotations.SboEvent
+import net.sbo.mod.utils.events.impl.game.ChatMessageEvent
 import net.sbo.mod.utils.events.impl.game.DisconnectEvent
 import net.sbo.mod.utils.events.impl.partyfinder.PartyFinderRefreshListEvent
-import net.sbo.mod.utils.events.impl.game.ChatMessageEvent
+import net.sbo.mod.utils.http.Http
+import net.sbo.mod.utils.http.Http.getBoolean
 import net.sbo.mod.utils.http.Http.getInt
-import java.util.UUID
+import net.sbo.mod.utils.http.Http.getString
+import java.util.*
 import java.util.regex.Pattern
-import kotlin.collections.mutableMapOf
 
 object PartyFinderManager {
     var creatingParty = false
@@ -113,7 +106,7 @@ object PartyFinderManager {
             Chat.chat("§6[SBO] §aKey has been cleared")
         }
 
-        Register.onChatMessageCancable(
+        Register.onChatMessageCancelable(
             Pattern.compile("§d(.*?) (.*?)§7: (.*?) join party request - id:(.*)", Pattern.DOTALL)
         ) { message, matchResult ->
             if (matchResult.group(1).contains("From")) {
@@ -136,7 +129,7 @@ object PartyFinderManager {
             false
         }
 
-        Register.onChatMessageCancable(
+        Register.onChatMessageCancelable(
             Pattern.compile("^§9§m(.*?) §ehas invited you to join their party!(.*?)$", Pattern.DOTALL)
         ) { message, matchResult ->
             val playername = Helper.getPlayerName(matchResult.group(1) ?: "")

--- a/src/main/kotlin/net/sbo/mod/partyfinder/PartyPlayer.kt
+++ b/src/main/kotlin/net/sbo/mod/partyfinder/PartyPlayer.kt
@@ -2,12 +2,12 @@ package net.sbo.mod.partyfinder
 
 import net.sbo.mod.SBOKotlin.API_URL
 import net.sbo.mod.diana.achievements.AchievementManager.trackWithCheckPlayer
-import net.sbo.mod.utils.chat.Chat
 import net.sbo.mod.utils.Helper.sleep
 import net.sbo.mod.utils.Player
-import net.sbo.mod.utils.events.Register
+import net.sbo.mod.utils.chat.Chat
 import net.sbo.mod.utils.data.PartyInfo
 import net.sbo.mod.utils.data.PartyPlayerStats
+import net.sbo.mod.utils.events.Register
 import net.sbo.mod.utils.http.Http
 
 object PartyPlayer {

--- a/src/main/kotlin/net/sbo/mod/qol/MessageHider.kt
+++ b/src/main/kotlin/net/sbo/mod/qol/MessageHider.kt
@@ -21,7 +21,7 @@ object MessageHider {
 
     fun init() {
         (generalRules + dianaRules).forEach { rule ->
-            Register.onChatMessageCancable(rule.pattern) { _, _ -> !rule.isEnabled() }
+            Register.onChatMessageCancelable(rule.pattern) { _, _ -> !rule.isEnabled() }
         }
     }
 }

--- a/src/main/kotlin/net/sbo/mod/settings/Settings.kt
+++ b/src/main/kotlin/net/sbo/mod/settings/Settings.kt
@@ -3,14 +3,7 @@ package net.sbo.mod.settings
 import com.teamresourceful.resourcefulconfig.api.types.options.TranslatableValue
 import com.teamresourceful.resourcefulconfigkt.api.ConfigKt
 import net.sbo.mod.SBOKotlin
-import net.sbo.mod.settings.categories.General
-import net.sbo.mod.settings.categories.Diana
-import net.sbo.mod.settings.categories.PartyCommands
-import net.sbo.mod.settings.categories.Customization
-import net.sbo.mod.settings.categories.QOL
-import net.sbo.mod.settings.categories.Credits
-import net.sbo.mod.settings.categories.Debug
-import net.sbo.mod.settings.categories.PartyFinder
+import net.sbo.mod.settings.categories.*
 
 object Settings : ConfigKt("sbo/config") {
     override val name: TranslatableValue

--- a/src/main/kotlin/net/sbo/mod/settings/categories/Customization.kt
+++ b/src/main/kotlin/net/sbo/mod/settings/categories/Customization.kt
@@ -92,10 +92,10 @@ object Customization : CategoryKt("Customization") {
         this.slider = true
     }
 
-    var showDistanceCutoff by int(0) {
+    var showDistanceCutoff by int(50) {
         this.range = 0..150
-        this.name = Literal("Show Distance Cutoff")
-        this.description = Literal("The distance cutoff at which the distance text disappears. For example if set to 50 will not display the distance text if 50m or closer. (0 to always show distance)")
+        this.name = Literal("Show Distance & Times Dug Cutoff")
+        this.description = Literal("The distance cutoff at which the distance text disappears, and the times dug text appears. For example if set to 50 will not display the distance text if 50m or closer, and will only display the times dug when 50m or closer. (0 to always show distance and times dug, if times dug is enabled)")
     }
 
     var showTimesDug by boolean(false) {

--- a/src/main/kotlin/net/sbo/mod/settings/categories/Customization.kt
+++ b/src/main/kotlin/net/sbo/mod/settings/categories/Customization.kt
@@ -62,6 +62,18 @@ object Customization : CategoryKt("Customization") {
         this.allowAlpha = true
     }
 
+    var waypointOpacity by int(50) {
+        this.range = 0..100
+        this.name = Literal("Waypoint Opacity")
+        this.description = Literal("The opacity of the rendered waypoints. 50 will make it 50% transparent, 100% fully opaque, 0% fully invisible, etc. (default 50)")
+    }
+
+    var waypointTextOpacity by int(100) {
+        this.range = 0..100
+        this.name = Literal("Waypoint Text Opacity")
+        this.description = Literal("The opacity of the text on the rendered waypoints. 50 will make it 50% transparent, 100% fully opaque, 0% fully invisible, etc. (default 100)")
+    }
+
     init {
         separator {
             this.title = "Waypoint Text Customization"
@@ -78,6 +90,17 @@ object Customization : CategoryKt("Customization") {
         this.description = Literal("Scale of the waypoint text")
         this.range = 0.3f..2.0f
         this.slider = true
+    }
+
+    var showDistanceCutoff by int(0) {
+        this.range = 0..150
+        this.name = Literal("Show Distance Cutoff")
+        this.description = Literal("The distance cutoff at which the distance text disappears. For example if set to 50 will not display the distance text if 50m or closer. (0 to always show distance)")
+    }
+
+    var showTimesDug by boolean(false) {
+        this.name = Literal("Show Times Dug")
+        this.description = Literal("Shows times dug on the waypoint text for known burrows.")
     }
 
     init {

--- a/src/main/kotlin/net/sbo/mod/settings/categories/Customization.kt
+++ b/src/main/kotlin/net/sbo/mod/settings/categories/Customization.kt
@@ -103,7 +103,7 @@ object Customization : CategoryKt("Customization") {
         this.description = Literal("The distance cutoff at which the distance text disappears, and the times dug text appears. For example if set to 50 will not display the distance text if 50m or closer, and will only display the times dug when 50m or closer. (0 to always show distance and times dug, if times dug is enabled)")
     }
 
-    var showTimesDug by boolean(false) {
+    var showTimesDug by boolean(true) {
         this.name = Literal("Show Times Dug")
         this.description = Literal("Shows times dug on the waypoint text for known burrows.")
     }

--- a/src/main/kotlin/net/sbo/mod/settings/categories/Customization.kt
+++ b/src/main/kotlin/net/sbo/mod/settings/categories/Customization.kt
@@ -62,6 +62,11 @@ object Customization : CategoryKt("Customization") {
         this.allowAlpha = true
     }
 
+    var dynamicWaypointOpacity by boolean(true) {
+        this.name = Literal("Dynamic Waypoint Opacity")
+        this.description = Literal("Uses a dynamic waypoint opacity that changes based on how far or close you are to the waypoints. If you enable this, the Waypoint Opacity setting below will not take effect.")
+    }
+
     var waypointOpacity by int(50) {
         this.range = 0..100
         this.name = Literal("Waypoint Opacity")

--- a/src/main/kotlin/net/sbo/mod/settings/categories/Debug.kt
+++ b/src/main/kotlin/net/sbo/mod/settings/categories/Debug.kt
@@ -19,7 +19,7 @@ object Debug : CategoryKt("Debug") {
     }
 
     var repeatableAchie by boolean(true) {
-        this.name = Literal("[WIP] Enable Repetable Achievements")
+        this.name = Literal("[WIP] Enable Repeatable Achievements")
         this.description = Literal("[WIP] allows you to unlock repeatable achievements for each new event")
     }
 }

--- a/src/main/kotlin/net/sbo/mod/settings/categories/Diana.kt
+++ b/src/main/kotlin/net/sbo/mod/settings/categories/Diana.kt
@@ -474,7 +474,7 @@ object Diana : CategoryKt("Diana") {
 
     var HighlightRareMobs by boolean(true) {
         this.name = Literal("Highlight Rare Mobs")
-        this.description = Literal("Highlights rare mobs(King, Manti, Sphinx, Inq) with a glowing effect")
+        this.description = Literal("Highlights rare mobs (King, Manti, Sphinx, Inq) with a glowing effect")
     }
 
     var HighlightColor by color(
@@ -486,7 +486,7 @@ object Diana : CategoryKt("Diana") {
 
     var allWaypointsAreInqs by boolean(false) {
         this.name = Literal("All Waypoints are Rare Mobs")
-        this.description = Literal("All coordinates from chat are considered rare mobs(King, Manti, Sphinx, Inq) only works in hub during diana")
+        this.description = Literal("All coordinates from chat are considered rare mobs (King, Manti, Sphinx, Inq)")
     }
 
     var announceInqText by strings("") {

--- a/src/main/kotlin/net/sbo/mod/settings/categories/Diana.kt
+++ b/src/main/kotlin/net/sbo/mod/settings/categories/Diana.kt
@@ -448,13 +448,6 @@ object Diana : CategoryKt("Diana") {
         this.description = Literal("The width of the lines drawn for Diana waypoints")
     }
 
-    var removeBeam by int(8) {
-        this.range = 0..20
-        this.slider = true
-        this.name = Literal("Remove Rare Mob Beam Distance")
-        this.description = Literal("Removes the rare mob waypoint beam when you are within this distance of it (0 to disable)")
-    }
-
     init {
         separator {
             this.title = "Rare Mobs"
@@ -529,11 +522,6 @@ object Diana : CategoryKt("Diana") {
     var cocoonTitle by boolean(true) {
         this.name = Literal("Show Title On Cocoon")
         this.description = Literal("Shows a title on cocoon")
-    }
-
-    var legacyCocoonDetection by boolean(false) {
-        this.name = Literal("Legacy Cocoon Detection")
-        this.description = Literal("Uses egg sac player head texture to detect cocoon instead of the new cocoon chat message when enabled. Only enable if chat detection does not work.")
     }
 
     var hpAlert by double(0.0) {

--- a/src/main/kotlin/net/sbo/mod/settings/categories/Diana.kt
+++ b/src/main/kotlin/net/sbo/mod/settings/categories/Diana.kt
@@ -97,11 +97,6 @@ object Diana : CategoryKt("Diana") {
         this.description = Literal("Shows a title to guess normally when the burrow chain is complete and there's no more guesses or burrows at least 90 blocks nearby")
     }
 
-    var dontClearArrowGuess by boolean(true) {
-        this.name = Literal("Don't Clear Arrow Guess on World Change")
-        this.description = Literal("If enabled, the arrow guess waypoints will not be cleared when changing worlds/lobby")
-    }
-
     init {
         separator {
             this.title = "Diana Warp"

--- a/src/main/kotlin/net/sbo/mod/settings/categories/Diana.kt
+++ b/src/main/kotlin/net/sbo/mod/settings/categories/Diana.kt
@@ -2,15 +2,15 @@ package net.sbo.mod.settings.categories
 
 import com.teamresourceful.resourcefulconfigkt.api.CategoryKt
 import com.teamresourceful.resourcefulconfigkt.api.ObservableEntry
+import gg.essential.universal.UScreen
+import net.sbo.mod.SBOKotlin.mc
+import net.sbo.mod.guis.PastEventsGui
 import net.sbo.mod.overlays.DianaLoot
 import net.sbo.mod.overlays.DianaMobs
 import net.sbo.mod.utils.Helper
 import net.sbo.mod.utils.chat.Chat
 import net.sbo.mod.utils.waypoint.AdditionalHubWarps
 import java.awt.Color
-import gg.essential.universal.UScreen
-import net.sbo.mod.SBOKotlin.mc
-import net.sbo.mod.guis.PastEventsGui
 
 object Diana : CategoryKt("Diana") {
     enum class ShareList {
@@ -53,26 +53,33 @@ object Diana : CategoryKt("Diana") {
     init {
         separator {
             this.title = "Diana Burrows"
+            this.description = "You should keep all of these On for the optimal experience. Without the Arrow Guess, your rates will be much worse, and without the Close Burrow Detection your burrows will not turn into Mob/Treasure/Start burrows when getting close and holding a spade, and it will also make your experience and rates worse."
         }
     }
 
-    var dianaBurrowGuess by boolean(true) {
+    var spadeGuess by boolean(true) {
         this.name = Literal("Spade Guess")
-        this.description = Literal("Guess the burrow location when using spade ability. Needs Driping Lava Partciles and set /particlequality to Extreme for more accuracy")
+        this.description = Literal("Guess the burrow location when using spade ability. Needs Dripping Lava Particles and set /particlequality to Extreme for more accuracy")
     }
 
     var arrowGuess by boolean(true) {
         this.name = Literal("Arrow Guess")
         this.description = Literal("Guesses the burrow location from the arrow direction after digging a burrow \n" +
             "§bNOTE!: This replaces the old Multi guess system!\n" +
-            "§cHave Dust Particles enabled!!!\n" +
-            "§aDo every burrow you see for doing diana the fastest way!"
+            "§cHave Dust Particles enabled!\n" +
+            "§aDo every burrow you see for doing Diana the fastest way!"
         )
     }
 
-    var dianaBurrowDetect by boolean(true) {
+    var closeBurrowDetection by boolean(true) {
         this.name = Literal("Close Burrow Detection")
-        this.description = Literal("Detects Diana burrows when being close and holding shovel to show it as treasure or mob burrow. | to reset waypoints /sboclearburrows")
+        this.description = Literal("Detects burrow locations when being close to them from the particles when holding shovel to register/update it as a Treasure, Mob or Start burrow. To reset waypoints type /sboclearburrows")
+    }
+
+    init {
+        separator {
+            this.title = "Diana Burrows Preferences"
+        }
     }
 
     var showBeaconBeam by boolean(true) {
@@ -132,7 +139,7 @@ object Diana : CategoryKt("Diana") {
     var badWarpDistance by int(0) {
         this.range = 0..150
         this.name = Literal("Bad Warp Distance")
-        this.description = Literal("Blocks at which good warps are prioritized over bad ones (Currently only Castle and Crypt). For example, when the Crypt warp is closest warp but Castle is second closest and the distance is less than this value, Castle will be preferred over Crypt warp for accessibility. (0 to disable)")
+        this.description = Literal("Blocks at which good warps are prioritized over bad ones (Currently only Castle and Crypt). For example, if you set it to 100, when the Crypt warp is the closest warp to a burrow, and the Castle is second closest, with Crypt warp being only 100 blocks or less closer than Castle, Castle will be preferred over Crypt warp for accessibility, as it can be faster to AOTV out of castle to reach the burrow whereas Crypt is longer to get out. (0 to disable)")
     }
 
     var warpDelay by int(0) {
@@ -305,34 +312,6 @@ object Diana : CategoryKt("Diana") {
         }
     }
 
-    init {
-        separator {
-            this.title = "Title Timings"
-            this.description = "Customize fade-in, display and fade-out ticks for titles"
-        }
-    }
-
-    var rareTitleFadeIn by int(0) {
-        this.name = Literal("Rare Title Fade In")
-        this.description = Literal("Fade-in (ticks) for rare mob titles")
-        this.range = 0..100
-        this.slider = true
-    }
-
-    var rareTitleTime by int(90) {
-        this.name = Literal("Rare Title Time")
-        this.description = Literal("Display time (ticks) for rare mob titles")
-        this.range = 0..100
-        this.slider = true
-    }
-
-    var rareTitleFadeOut by int(20) {
-        this.name = Literal("Rare Title Fade Out")
-        this.description = Literal("Fade-out (ticks) for rare mob titles")
-        this.range = 0..100
-        this.slider = true
-    }
-
     var lootAnnouncerParty by boolean(true) {
         this.name = Literal("Loot Party Announcer")
         this.description = Literal("Announces chimera/wool/stinger/food in party chat")
@@ -412,6 +391,33 @@ object Diana : CategoryKt("Diana") {
         }
     }
 
+    init {
+        separator {
+            this.title = "Title Timings"
+            this.description = "Customize fade-in, display and fade-out ticks for titles"
+        }
+    }
+
+    var rareTitleFadeIn by int(0) {
+        this.name = Literal("Rare Title Fade In")
+        this.description = Literal("Fade-in (ticks) for rare mob titles")
+        this.range = 0..100
+        this.slider = true
+    }
+
+    var rareTitleTime by int(90) {
+        this.name = Literal("Rare Title Time")
+        this.description = Literal("Display time (ticks) for rare mob titles")
+        this.range = 0..100
+        this.slider = true
+    }
+
+    var rareTitleFadeOut by int(20) {
+        this.name = Literal("Rare Title Fade Out")
+        this.description = Literal("Fade-out (ticks) for rare mob titles")
+        this.range = 0..100
+        this.slider = true
+    }
 
     init {
         separator {
@@ -440,18 +446,6 @@ object Diana : CategoryKt("Diana") {
         this.slider = true
         this.name = Literal("Diana Line Width")
         this.description = Literal("The width of the lines drawn for Diana waypoints")
-    }
-
-    var removeGuessDistance by int(3) {
-        this.range = 0..20
-        this.slider = true
-        this.name = Literal("Remove Guess When Close")
-        this.description = Literal("Removes the guess waypoint when you are within this distance of it (0 to disable)")
-    }
-
-    var removeRareMobwaypoint by boolean(true) {
-        this.name = Literal("Remove Rare Mob Waypoint when near")
-        this.description = Literal("Removes the rare mob waypoint when you are within 3 blocks of it")
     }
 
     var removeBeam by int(8) {
@@ -486,7 +480,7 @@ object Diana : CategoryKt("Diana") {
         this.name = Literal("Which Mobs to Receive")
         this.description = Literal(
         "Select which mobs to receive\n" +
-            "§bOTHER = Rare mobs from players that dont ping with sbo (mainly skyhanni)"
+            "§bOTHER = Rare mobs from players that don't ping with sbo (mainly skyhanni)"
         )
     }
 
@@ -584,6 +578,6 @@ object Diana : CategoryKt("Diana") {
 
     var sphinxSolver by boolean(true) {
         this.name = Literal("Sphinx Solver")
-        this.description = Literal("Helps you solve the sphinx riddle by showing you the answer choices in chat and it automatically clicks the correct one for you when you click anywehre while the chat is open.")
+        this.description = Literal("Helps you solve the sphinx riddle by showing you the answer choices in chat and it automatically clicks the correct one for you when you click anywhere while the chat is open.")
     }
 }

--- a/src/main/kotlin/net/sbo/mod/utils/Helper.kt
+++ b/src/main/kotlin/net/sbo/mod/utils/Helper.kt
@@ -2,22 +2,16 @@ package net.sbo.mod.utils
 
 import net.minecraft.client.gui.screens.Screen
 import net.minecraft.core.component.DataComponents
-import net.minecraft.world.item.ItemStack
 import net.minecraft.network.chat.Component
+import net.minecraft.world.item.ItemStack
 import net.sbo.mod.SBOKotlin
 import net.sbo.mod.SBOKotlin.mc
 import net.sbo.mod.diana.DianaTracker
-import net.sbo.mod.utils.data.DianaTracker as DianaTrackerDataClass
 import net.sbo.mod.overlays.DianaLoot
 import net.sbo.mod.settings.categories.Debug
 import net.sbo.mod.settings.categories.Diana
 import net.sbo.mod.utils.chat.Chat
-import net.sbo.mod.utils.data.SboDataObject
-import net.sbo.mod.utils.data.DianaItemsData
-import net.sbo.mod.utils.data.DianaMobsData
-import net.sbo.mod.utils.data.npcSellValueMap
-import net.sbo.mod.utils.data.HypixelBazaarResponse
-import net.sbo.mod.utils.data.Item
+import net.sbo.mod.utils.data.*
 import net.sbo.mod.utils.events.Register
 import net.sbo.mod.utils.events.annotations.SboEvent
 import net.sbo.mod.utils.events.impl.entity.DianaMobDeathEvent
@@ -31,14 +25,15 @@ import net.sbo.mod.utils.http.Http
 import net.sbo.mod.utils.waypoint.WaypointManager.removeNearbyRareMobWaypoints
 import java.math.BigDecimal
 import java.math.RoundingMode
-import kotlin.reflect.full.memberProperties
 import java.text.DecimalFormat
-import java.util.Locale
-import java.util.regex.Pattern
-import java.util.concurrent.Executors
+import java.util.*
 import java.util.concurrent.ExecutorService
+import java.util.concurrent.Executors
+import java.util.regex.Pattern
 import kotlin.math.roundToInt
 import kotlin.math.roundToLong
+import kotlin.reflect.full.memberProperties
+import net.sbo.mod.utils.data.DianaTracker as DianaTrackerDataClass
 
 object Helper {
     var lastLootShare: Long = 0L
@@ -76,7 +71,7 @@ object Helper {
     }
 
     fun init() {
-        Register.onChatMessageCancable(Pattern.compile("^§e§lLOOT SHARE §fYou received loot for assisting (.*?)$", Pattern.DOTALL)) { message, matchResult ->
+        Register.onChatMessageCancelable(Pattern.compile("^§e§lLOOT SHARE §fYou received loot for assisting (.*?)$", Pattern.DOTALL)) { message, matchResult ->
             onLootShare()
             true
         }
@@ -439,14 +434,6 @@ object Helper {
         return invItems
     }
 
-    fun timestampToDate(timestamp: Long): String {
-        if (timestamp <= 0) return "Unknown"
-        val date = java.util.Date(timestamp)
-        val format = java.text.SimpleDateFormat("dd/MM/yyyy HH:mm:ss")
-        format.timeZone = java.util.TimeZone.getTimeZone("UTC")
-        return format.format(date)
-    }
-
     fun toUpperSnakeCase(input: String): String {
         return input.replace("-", " ").split(" ").joinToString("_") { it.uppercase() }
     }
@@ -470,10 +457,6 @@ object Helper {
     private fun hasMythologicalRitualActive(): Boolean = Mayor.mayor == "Jerry" || Mayor.mayor == "Aura" || Mayor.ministerPerk == "Mythological Ritual" || Mayor.perks.contains("Mythological Ritual")
 
     fun checkDiana(): Boolean = Debug.itsAlwaysDiana || hasSpade && hasMythologicalRitualActive() && World.getWorld() == "Hub"
-
-    fun getGuiName(): String {
-        return currentScreen?.title?.string ?: ""
-    }
 
     fun showTitle(title: String?, subtitle: String?, fadeIn: Int, time: Int, fadeOut: Int) {
         mc.gui.apply {
@@ -583,7 +566,7 @@ object Helper {
                     // no price data available - notify user
                     Chat.chat("§6[SBO] §4Unexpected error while fetching AH item prices: $error")
                 } else {
-                    // if a previous request succeeded and this request failed, it might be temporary and we still
+                    // if a previous request succeeded and this request failed, it might be temporary, and we still
                     // have some price data even if outdated. so only log to logs
                     SBOKotlin.logger.error("Unexpected error while fetching AH item prices", error)
                 }
@@ -597,7 +580,7 @@ object Helper {
                     // no price data available - notify user
                     Chat.chat("§6[SBO] §4Unexpected error while fetching Bazaar item prices: $error")
                 } else {
-                    // if a previous request succeeded and this request failed, it might be temporary and we still
+                    // if a previous request succeeded and this request failed, it might be temporary, and we still
                     // have some price data even if outdated. so only log to logs
                     SBOKotlin.logger.error("Unexpected error while fetching Bazaar item prices", error)
                 }

--- a/src/main/kotlin/net/sbo/mod/utils/Player.kt
+++ b/src/main/kotlin/net/sbo/mod/utils/Player.kt
@@ -3,7 +3,7 @@ package net.sbo.mod.utils
 import net.minecraft.world.item.ItemStack
 import net.sbo.mod.SBOKotlin.mc
 import net.sbo.mod.utils.math.SboVec
-import java.util.UUID
+import java.util.*
 
 object Player {
     fun getLastPosition(): SboVec {

--- a/src/main/kotlin/net/sbo/mod/utils/SboKeyBinds.kt
+++ b/src/main/kotlin/net/sbo/mod/utils/SboKeyBinds.kt
@@ -1,11 +1,11 @@
 package net.sbo.mod.utils
 
-import net.sbo.mod.SBOKotlin
+import com.mojang.blaze3d.platform.InputConstants
 import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientTickEvents
 import net.fabricmc.fabric.api.client.keybinding.v1.KeyBindingHelper
-import net.minecraft.client.Minecraft
 import net.minecraft.client.KeyMapping
-import com.mojang.blaze3d.platform.InputConstants
+import net.minecraft.client.Minecraft
+import net.sbo.mod.SBOKotlin
 import net.sbo.mod.utils.chat.Chat
 import net.sbo.mod.utils.waypoint.WaypointManager
 import org.lwjgl.glfw.GLFW

--- a/src/main/kotlin/net/sbo/mod/utils/SboTimerManager.kt
+++ b/src/main/kotlin/net/sbo/mod/utils/SboTimerManager.kt
@@ -1,11 +1,11 @@
 package net.sbo.mod.utils
 
-import net.sbo.mod.utils.data.SboDataObject
+import net.sbo.mod.settings.categories.Diana
 import net.sbo.mod.utils.data.DianaTracker
+import net.sbo.mod.utils.data.SboDataObject
 import net.sbo.mod.utils.events.Register
 import net.sbo.mod.utils.events.annotations.SboEvent
 import net.sbo.mod.utils.events.impl.game.DisconnectEvent
-import net.sbo.mod.settings.categories.Diana
 import java.util.concurrent.CopyOnWriteArraySet
 import java.util.concurrent.TimeUnit
 
@@ -36,10 +36,6 @@ object SboTimerManager {
 
     private fun removeTimer(timer: SBOTimer) {
         activeTimers.remove(timer)
-    }
-
-    private fun getTimer(name: String): SBOTimer? {
-        return SBOTimer.timerList.find { it.name.equals(name, ignoreCase = true) }
     }
 
     @SboEvent
@@ -77,6 +73,12 @@ object SboTimerManager {
         }
 
         init {
+            val storedTimeMs = tracker.items.TIME
+
+            if (storedTimeMs > 0L) {
+                elapsedNanoTime = TimeUnit.MILLISECONDS.toNanos(storedTimeMs)
+            }
+
             timerList.add(this)
         }
 

--- a/src/main/kotlin/net/sbo/mod/utils/SoundHandler.kt
+++ b/src/main/kotlin/net/sbo/mod/utils/SoundHandler.kt
@@ -1,7 +1,5 @@
 package net.sbo.mod.utils
 
-import net.sbo.mod.utils.data.SboDataObject
-
 import net.fabricmc.loader.api.FabricLoader
 import net.minecraft.SharedConstants
 import net.minecraft.client.resources.sounds.SimpleSoundInstance
@@ -9,9 +7,10 @@ import net.minecraft.server.packs.PackType
 import net.minecraft.sounds.SoundEvent
 import net.sbo.mod.SBOKotlin
 import net.sbo.mod.SBOKotlin.MOD_ID
-import net.sbo.mod.SBOKotlin.mc
 import net.sbo.mod.SBOKotlin.logger
+import net.sbo.mod.SBOKotlin.mc
 import net.sbo.mod.utils.chat.Chat
+import net.sbo.mod.utils.data.SboDataObject
 import java.io.File
 
 object SoundHandler {

--- a/src/main/kotlin/net/sbo/mod/utils/accessors/EntityAccessor.kt
+++ b/src/main/kotlin/net/sbo/mod/utils/accessors/EntityAccessor.kt
@@ -4,7 +4,7 @@ import net.minecraft.world.entity.Entity
 import java.awt.Color
 
 /**
- * Interface to inject into Entity.class via Mixin
+ * Interface to inject via Mixin
  */
 internal interface EntityAccessor {
     fun `sbo$setGlowing`(glowing: Boolean)

--- a/src/main/kotlin/net/sbo/mod/utils/chat/Chat.kt
+++ b/src/main/kotlin/net/sbo/mod/utils/chat/Chat.kt
@@ -1,14 +1,14 @@
 package net.sbo.mod.utils.chat
 
-import net.sbo.mod.SBOKotlin.mc
-import net.minecraft.network.chat.Component
+import net.minecraft.ChatFormatting
+import net.minecraft.client.gui.components.ChatComponent
 import net.minecraft.network.chat.ClickEvent
+import net.minecraft.network.chat.Component
 import net.minecraft.network.chat.HoverEvent
 import net.minecraft.network.chat.Style
-import net.minecraft.client.gui.components.ChatComponent
-import net.minecraft.ChatFormatting
-import net.sbo.mod.utils.events.ClickActionManager
+import net.sbo.mod.SBOKotlin.mc
 import net.sbo.mod.settings.categories.General
+import net.sbo.mod.utils.events.ClickActionManager
 
 object Chat {
 
@@ -22,8 +22,8 @@ object Chat {
      */
     fun pc(text: String) {
         if (General.assumeMuted) {
-            // User is muted (or we assume it bc of the opt-in setting thats false by default)
-            // trying send message will show up a huge output about the remaining mute time,
+            // User is muted (or we assume it bc of the opt-in setting that's false by default)
+            // trying to send message will show up a huge output about the remaining mute time,
             // server rules and all that yapping with no other output about the text we want
             // to send, so send locally instead via the chat method. We can have color since it's regular chat.
             chat("§6[SBO] §e${text}")
@@ -180,7 +180,7 @@ object Chat {
 
     /**
      * Gets a message that fills one line of chat by repeating the separator.
-     * @param separator The string to repeat. Defaults to "-".
+     * @param separator The string to repeat. Defaults to -.
      * @return The message string that fills the chat line.
      */
     fun getChatBreak(separator: String = "-", colorcodes: String = "§b"): String {

--- a/src/main/kotlin/net/sbo/mod/utils/chat/ChatMessageQueue.kt
+++ b/src/main/kotlin/net/sbo/mod/utils/chat/ChatMessageQueue.kt
@@ -2,11 +2,11 @@ package net.sbo.mod.utils.chat
 
 import it.unimi.dsi.fastutil.objects.ObjectArrayFIFOQueue
 import net.minecraft.client.player.LocalPlayer
-import net.sbo.mod.utils.events.Register
 import net.sbo.mod.SBOKotlin.mc
+import net.sbo.mod.utils.events.Register
 import net.sbo.mod.utils.events.annotations.SboEvent
-import net.sbo.mod.utils.events.impl.game.SentMessageEvent
 import net.sbo.mod.utils.events.impl.game.SentCommandEvent
+import net.sbo.mod.utils.events.impl.game.SentMessageEvent
 
 object ChatMessageQueue {
     private const val DELAY_NANOS = 200_000_000L

--- a/src/main/kotlin/net/sbo/mod/utils/chat/ChatUtils.kt
+++ b/src/main/kotlin/net/sbo/mod/utils/chat/ChatUtils.kt
@@ -1,11 +1,7 @@
 package net.sbo.mod.utils.chat
 
-import net.minecraft.network.chat.ClickEvent
-import net.minecraft.network.chat.HoverEvent
-import net.minecraft.network.chat.Style
-import net.minecraft.network.chat.TextColor
-import net.minecraft.network.chat.Component
 import net.minecraft.ChatFormatting
+import net.minecraft.network.chat.*
 import java.util.*
 
 object ChatUtils {

--- a/src/main/kotlin/net/sbo/mod/utils/collection/CacheSet.kt
+++ b/src/main/kotlin/net/sbo/mod/utils/collection/CacheSet.kt
@@ -26,10 +26,6 @@ abstract class CacheSet<T : Any> : MutableSet<T> {
         return true
     }
 
-    fun addIfAbsent(element: T) {
-        if (!contains(element)) add(element)
-    }
-
     override fun addAll(elements: Collection<T>): Boolean {
         var value = false
         for (element in elements) {

--- a/src/main/kotlin/net/sbo/mod/utils/data/SboDataObject.kt
+++ b/src/main/kotlin/net/sbo/mod/utils/data/SboDataObject.kt
@@ -10,29 +10,16 @@ import net.sbo.mod.SBOKotlin
 import net.sbo.mod.utils.events.Register
 import net.sbo.mod.utils.events.annotations.SboEvent
 import net.sbo.mod.utils.events.impl.game.GameCloseEvent
-import java.io.File
-import java.io.FileReader
-import java.io.Writer
-import java.io.FileWriter
-import java.io.BufferedWriter
-import java.io.FileInputStream
-import java.io.FileOutputStream
-import java.io.IOException
-import java.nio.file.Path
-import java.nio.file.Files
-import java.nio.file.StandardCopyOption
-import java.nio.file.FileVisitResult
-import java.nio.file.SimpleFileVisitor
+import java.io.*
+import java.nio.file.*
 import java.nio.file.attribute.BasicFileAttributes
-import java.nio.file.AtomicMoveNotSupportedException
-import java.util.zip.ZipEntry
-import java.util.zip.ZipOutputStream
-import java.util.concurrent.Executors
-import java.util.concurrent.ExecutorService
-import kotlin.collections.iterator
-import kotlin.reflect.KMutableProperty1
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.Executors
+import java.util.zip.ZipEntry
+import java.util.zip.ZipOutputStream
+import kotlin.reflect.KMutableProperty1
 
 object SboDataObject {
     @JvmField
@@ -391,7 +378,7 @@ object SboDataObject {
                     Int::class -> value.toIntOrNull()
                     String::class -> value
                     else -> {
-                        SBOKotlin.logger.warn("[$key] hasn an Unsupported type: ${prop.returnType.classifier}")
+                        SBOKotlin.logger.warn("[$key] has an an Unsupported type: ${prop.returnType.classifier}")
                         null
                     }
                 }
@@ -608,7 +595,7 @@ object SboDataObject {
                     } catch (e: AtomicMoveNotSupportedException) {
                         // Supported on all major OS unless trying to move to a different partition or drive
                         // The most likely culprit would be that MC was installed to a OneDrive sync folder
-                        // Fallbacking to regular move should be OK here at this point.
+                        // Fall-backing to regular move should be OK here at this point.
                         val success = tempZipFile.renameTo(zipFile)
                         if (!success) {
                             throw IOException("Failed to rename temp zip to final zip")
@@ -645,7 +632,7 @@ object SboDataObject {
         }
     }
 
-    val configMapforSave = mapOf(
+    val configMapForSave = mapOf(
         "SboData" to Pair({ save(dataDir, sboData, "SboData.json") }, sboData),
         "AchievementsData" to Pair({ save(dataDir, achievementsData, "sbo_achievements.json") }, achievementsData),
         "PastDianaEventsData" to Pair({ save(dataDir, pastDianaEventsData, "pastDianaEvents.json") }, pastDianaEventsData),
@@ -658,7 +645,7 @@ object SboDataObject {
     )
 
     private fun saveAllData() {
-        configMapforSave.forEach { (_, configData) ->
+        configMapForSave.forEach { (_, configData) ->
             configData.first.invoke()
         }
     }
@@ -708,7 +695,7 @@ object SboDataObject {
     }
 
     /**
-     * Writes json data to a temporary file, then replaces the original file with it
+     * Writes JSON data to a temporary file, then replaces the original file with it
      * only after the temp file has finished fully writing. Performs atomic move to avoid
      * data loss if crash or power loss during the move.
      */
@@ -764,7 +751,7 @@ object SboDataObject {
      */
     fun save(configName: String) {
         DATA_SAVER_EXECUTOR.execute {
-            configMapforSave[configName]?.first?.invoke()
+            configMapForSave[configName]?.first?.invoke()
                 ?: SBOKotlin.logger.warn("[$configName] is not a valid config name. Please use a valid config name")
         }
     }

--- a/src/main/kotlin/net/sbo/mod/utils/events/ClickActionManager.kt
+++ b/src/main/kotlin/net/sbo/mod/utils/events/ClickActionManager.kt
@@ -1,6 +1,6 @@
 package net.sbo.mod.utils.events
 
-import java.util.UUID
+import java.util.*
 
 /**
  * Manages click actions by mapping a unique ID to a lambda function.

--- a/src/main/kotlin/net/sbo/mod/utils/events/DianaEvents.kt
+++ b/src/main/kotlin/net/sbo/mod/utils/events/DianaEvents.kt
@@ -12,8 +12,8 @@ import net.sbo.mod.utils.math.SboVec
 import java.util.regex.Pattern
 
 object DianaEvents {
-    private var lastBlockClicked: SboVec? = null
-    private var lastBurrowClicked: SboVec? = null
+    var lastBlockClicked: SboVec? = null
+    var lastBurrowClicked: SboVec? = null
 
     internal fun init() {
         registerBurrowDug()
@@ -70,9 +70,9 @@ object DianaEvents {
     }
 
     private fun registerBurrowDug() {
-        Register.onChatMessageCancable(Pattern.compile("^§eYou (.*?) Griffin [Bb]urrow(.*?) §7\\((.*?)/(.*?)\\)$", Pattern.DOTALL)) { message, matchResult ->
-            val currentBurrow = matchResult.group(3).toIntOrNull() ?: return@onChatMessageCancable true
-            val maxBurrow = matchResult.group(4).toIntOrNull() ?: return@onChatMessageCancable true
+        Register.onChatMessageCancelable(Pattern.compile("^§eYou (.*?) Griffin [Bb]urrow(.*?) §7\\((.*?)/(.*?)\\)$", Pattern.DOTALL)) { message, matchResult ->
+            val currentBurrow = matchResult.group(3).toIntOrNull() ?: return@onChatMessageCancelable true
+            val maxBurrow = matchResult.group(4).toIntOrNull() ?: return@onChatMessageCancelable true
             SBOEvent.emit(BurrowDugEvent(
                 lastBurrowClicked,
                 lastBlockClicked,

--- a/src/main/kotlin/net/sbo/mod/utils/events/DianaEvents.kt
+++ b/src/main/kotlin/net/sbo/mod/utils/events/DianaEvents.kt
@@ -9,10 +9,13 @@ import net.sbo.mod.utils.events.impl.game.PlayerInteractEvent
 import net.sbo.mod.utils.events.impl.packets.PacketSendEvent
 import net.sbo.mod.utils.game.World
 import net.sbo.mod.utils.math.SboVec
+import net.sbo.mod.utils.math.SboVec.Companion.toSboVec
+import net.sbo.mod.utils.waypoint.WaypointManager
 import java.util.regex.Pattern
 
 object DianaEvents {
     var lastBlockClicked: SboVec? = null
+    var lastWaypointClicked: SboVec? = null
     var lastBurrowClicked: SboVec? = null
 
     internal fun init() {
@@ -25,6 +28,12 @@ object DianaEvents {
         if (packet !is ServerboundPlayerActionPacket) return
         if (World.getWorld() != "Hub") return
         if (packet.action != ServerboundPlayerActionPacket.Action.START_DESTROY_BLOCK) return
+
+        val waypoint = WaypointManager.getWaypointAt(packet.pos.toSboVec(), "burrow") ?: WaypointManager.getWaypointAt(packet.pos.toSboVec(), "arrow") ?: WaypointManager.getWaypointAt(packet.pos.toSboVec(), "guess")
+        if (waypoint != null) {
+            waypoint.userInteractedWith = true
+            lastWaypointClicked = waypoint.pos
+        }
 
         val posString = "${packet.pos.x} ${packet.pos.y} ${packet.pos.z}"
         if (BurrowDetector.burrows.containsKey(posString)) {
@@ -53,6 +62,12 @@ object DianaEvents {
         if (item == null || !item.hoverName.string.contains("Spade")) return
         if (event.pos ==  null) return
 
+        val waypoint = WaypointManager.getWaypointAt(event.pos.toSboVec(), "burrow") ?: WaypointManager.getWaypointAt(event.pos.toSboVec(), "arrow") ?: WaypointManager.getWaypointAt(event.pos.toSboVec(), "guess")
+        if (waypoint != null) {
+            waypoint.userInteractedWith = true
+            lastWaypointClicked = waypoint.pos
+        }
+
         val posString = "${event.pos.x} ${event.pos.y} ${event.pos.z}"
         if (BurrowDetector.burrows.containsKey(posString)) {
             lastBurrowClicked = SboVec(
@@ -75,6 +90,7 @@ object DianaEvents {
             val maxBurrow = matchResult.group(4).toIntOrNull() ?: return@onChatMessageCancelable true
             SBOEvent.emit(BurrowDugEvent(
                 lastBurrowClicked,
+                lastWaypointClicked,
                 lastBlockClicked,
                 currentBurrow,
                 maxBurrow

--- a/src/main/kotlin/net/sbo/mod/utils/events/Register.kt
+++ b/src/main/kotlin/net/sbo/mod/utils/events/Register.kt
@@ -101,12 +101,12 @@ object Register {
     /**
      * Registers an event that listens for chat messages that match a regex.
      * The action receives both the message and the regex matcher for easy value extraction.
-     * If the action returns true, the message will be cancelled (not displayed in chat).
+     * If the action returns true, the message will be canceled (not displayed in chat).
      *
      * @param regex The regular expression to filter messages with.
      * @param action The action to execute. It receives the message and the `Matcher`.
      */
-    fun onChatMessageCancable(
+    fun onChatMessageCancelable(
         regex: Pattern,
         action: (message: Component, matchResult: Matcher) -> Boolean
     ) {

--- a/src/main/kotlin/net/sbo/mod/utils/events/SBOEvent.kt
+++ b/src/main/kotlin/net/sbo/mod/utils/events/SBOEvent.kt
@@ -7,19 +7,14 @@ import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientWorldEvents
 import net.fabricmc.fabric.api.client.message.v1.ClientReceiveMessageEvents
 import net.fabricmc.fabric.api.client.networking.v1.ClientPlayConnectionEvents
 import net.fabricmc.fabric.api.client.screen.v1.ScreenEvents
+import net.fabricmc.fabric.api.client.screen.v1.ScreenMouseEvents
 import net.fabricmc.fabric.api.event.player.AttackEntityCallback
 import net.minecraft.world.InteractionResult
-import net.sbo.mod.utils.events.impl.entity.EntitiyHitEvent
-import net.fabricmc.fabric.api.client.screen.v1.ScreenMouseEvents
 import net.sbo.mod.utils.events.annotations.SboEvent
+import net.sbo.mod.utils.events.impl.entity.EntitiyHitEvent
 import net.sbo.mod.utils.events.impl.entity.EntityLoadEvent
 import net.sbo.mod.utils.events.impl.entity.EntityUnloadEvent
-import net.sbo.mod.utils.events.impl.game.ChatMessageAllowEvent
-import net.sbo.mod.utils.events.impl.game.ChatMessageEvent
-import net.sbo.mod.utils.events.impl.game.DisconnectEvent
-import net.sbo.mod.utils.events.impl.game.GameCloseEvent
-import net.sbo.mod.utils.events.impl.game.TickEvent
-import net.sbo.mod.utils.events.impl.game.WorldChangeEvent
+import net.sbo.mod.utils.events.impl.game.*
 import net.sbo.mod.utils.events.impl.guis.GuiCloseEvent
 import net.sbo.mod.utils.events.impl.guis.GuiMouseClickAfter
 import net.sbo.mod.utils.events.impl.guis.GuiMouseClickBefore
@@ -84,7 +79,7 @@ object SBOEvent {
          * Allows for filtering of spammy messages.
          */
         ClientReceiveMessageEvents.ALLOW_GAME.register { message, signed ->
-            val event = ChatMessageAllowEvent(message, signed, true)
+            val event = ChatMessageAllowEvent(message, true)
             emit(event)
             event.isAllowed
         }

--- a/src/main/kotlin/net/sbo/mod/utils/events/impl/diana/BurrowDugEvent.kt
+++ b/src/main/kotlin/net/sbo/mod/utils/events/impl/diana/BurrowDugEvent.kt
@@ -5,13 +5,15 @@ import net.sbo.mod.utils.math.SboVec
 /**
  * Event emitted when a burrow is dug.
  *
- * @param burrowPos The position of the burrow that was dug.
- * @param lastBlock The position of the last block interacted with. (this may be off by 1-2 blocks from the actual burrow position) useful for the case that the burrow was not found.
+ * @param burrowPos   The position of the burrow that was dug.
+ * @param waypointPos The position of the waypoint that was dug.
+ * @param lastBlock   The position of the last block interacted with. (this may be off by 1-2 blocks from the actual burrow position) useful for the case that the burrow was not found.
  * @param currentBurrow The current number of burrows dug.
- * @param maxBurrow The maximum number of burrows that can be dug.
+ * @param maxBurrow     The maximum number of burrows that can be dug.
  */
 class BurrowDugEvent (
     val burrowPos: SboVec?,
+    val waypointPos: SboVec?,
     val lastBlock: SboVec?,
     val currentBurrow: Int,
     val maxBurrow: Int

--- a/src/main/kotlin/net/sbo/mod/utils/events/impl/entity/EntitiyHitEvent.kt
+++ b/src/main/kotlin/net/sbo/mod/utils/events/impl/entity/EntitiyHitEvent.kt
@@ -1,8 +1,8 @@
 package net.sbo.mod.utils.events.impl.entity
 
+import net.minecraft.world.InteractionHand
 import net.minecraft.world.entity.Entity
 import net.minecraft.world.entity.player.Player
-import net.minecraft.world.InteractionHand
 import net.minecraft.world.level.Level
 import net.minecraft.world.phys.EntityHitResult
 

--- a/src/main/kotlin/net/sbo/mod/utils/events/impl/game/ChatMessageAllowEvent.kt
+++ b/src/main/kotlin/net/sbo/mod/utils/events/impl/game/ChatMessageAllowEvent.kt
@@ -2,4 +2,4 @@ package net.sbo.mod.utils.events.impl.game
 
 import net.minecraft.network.chat.Component
 
-class ChatMessageAllowEvent(val message: Component, val signed: Boolean, var isAllowed: Boolean)
+class ChatMessageAllowEvent(val message: Component, var isAllowed: Boolean)

--- a/src/main/kotlin/net/sbo/mod/utils/events/impl/game/PlayerInteractEvent.kt
+++ b/src/main/kotlin/net/sbo/mod/utils/events/impl/game/PlayerInteractEvent.kt
@@ -1,8 +1,8 @@
 package net.sbo.mod.utils.events.impl.game
 
 import net.minecraft.client.player.LocalPlayer
-import net.minecraft.world.level.Level
 import net.minecraft.core.BlockPos
+import net.minecraft.world.level.Level
 
 /**
  * Called when the player interacts with the world.

--- a/src/main/kotlin/net/sbo/mod/utils/events/impl/game/SentMessageEvent.kt
+++ b/src/main/kotlin/net/sbo/mod/utils/events/impl/game/SentMessageEvent.kt
@@ -3,7 +3,7 @@ package net.sbo.mod.utils.events.impl.game
 /**
  * Event fired when a chat message is sent by the player to the server.
  * Includes messages sent automatically by any mod in behalf of the player.
- * Triggers in all channels (all, guild, party, officer, etc.,)
+ * Triggers in all channels (all, guild, party, officer, etc.,
  *
  * @param content The content of the message. Never begins with a slash ('/').
  * For commands, use {@link SentCommandEvent}.

--- a/src/main/kotlin/net/sbo/mod/utils/events/impl/guis/GuiPostRenderEvent.kt
+++ b/src/main/kotlin/net/sbo/mod/utils/events/impl/guis/GuiPostRenderEvent.kt
@@ -1,7 +1,7 @@
 package net.sbo.mod.utils.events.impl.guis
 
-import net.minecraft.client.gui.screens.Screen
 import net.minecraft.client.gui.GuiGraphics
+import net.minecraft.client.gui.screens.Screen
 
 /**
  * Event fired after a GUI screen has been rendered.

--- a/src/main/kotlin/net/sbo/mod/utils/events/impl/guis/GuiRenderEvent.kt
+++ b/src/main/kotlin/net/sbo/mod/utils/events/impl/guis/GuiRenderEvent.kt
@@ -1,8 +1,8 @@
 package net.sbo.mod.utils.events.impl.guis
 
 import net.minecraft.client.Minecraft
-import net.minecraft.client.gui.screens.Screen
 import net.minecraft.client.gui.GuiGraphics
+import net.minecraft.client.gui.screens.Screen
 
 /**
  * Event fired when a GUI is rendered.

--- a/src/main/kotlin/net/sbo/mod/utils/game/InventoryUtils.kt
+++ b/src/main/kotlin/net/sbo/mod/utils/game/InventoryUtils.kt
@@ -1,8 +1,8 @@
 package net.sbo.mod.utils.game
 
 import net.minecraft.client.Minecraft
-import net.minecraft.world.item.ItemStack
 import net.minecraft.core.registries.BuiltInRegistries
+import net.minecraft.world.item.ItemStack
 import net.sbo.mod.SBOKotlin
 import net.sbo.mod.utils.events.Register
 import kotlin.time.Duration

--- a/src/main/kotlin/net/sbo/mod/utils/game/Mayor.kt
+++ b/src/main/kotlin/net/sbo/mod/utils/game/Mayor.kt
@@ -4,9 +4,7 @@ import net.sbo.mod.SBOKotlin
 import net.sbo.mod.utils.data.MayorResponse
 import net.sbo.mod.utils.events.Register
 import net.sbo.mod.utils.http.Http
-import java.util.Calendar
-import java.util.Date
-import java.util.GregorianCalendar
+import java.util.*
 import kotlin.math.floor
 
 object Mayor {

--- a/src/main/kotlin/net/sbo/mod/utils/game/ScoreBoard.kt
+++ b/src/main/kotlin/net/sbo/mod/utils/game/ScoreBoard.kt
@@ -1,9 +1,11 @@
 package net.sbo.mod.utils.game
 
+import net.minecraft.world.scores.DisplaySlot
+import net.minecraft.world.scores.PlayerScoreEntry
+import net.minecraft.world.scores.PlayerTeam
 import net.sbo.mod.SBOKotlin
-import net.minecraft.world.scores.*
-import java.lang.String.CASE_INSENSITIVE_ORDER
 import net.sbo.mod.utils.events.Register
+import java.lang.String.CASE_INSENSITIVE_ORDER
 
 object ScoreBoard {
     private val COMPARATOR: Comparator<PlayerScoreEntry> = Comparator.comparing { obj: PlayerScoreEntry -> obj.value() }

--- a/src/main/kotlin/net/sbo/mod/utils/game/ServerStats.kt
+++ b/src/main/kotlin/net/sbo/mod/utils/game/ServerStats.kt
@@ -1,9 +1,9 @@
 package net.sbo.mod.utils.game
 
-import net.sbo.mod.utils.events.annotations.SboEvent
-import net.sbo.mod.utils.events.impl.packets.PacketReceiveEvent
 import net.minecraft.network.protocol.game.ClientboundLoginPacket
 import net.minecraft.network.protocol.game.ClientboundSetTimePacket
+import net.sbo.mod.utils.events.annotations.SboEvent
+import net.sbo.mod.utils.events.impl.packets.PacketReceiveEvent
 import kotlin.math.max
 
 object ServerStats {

--- a/src/main/kotlin/net/sbo/mod/utils/game/TabList.kt
+++ b/src/main/kotlin/net/sbo/mod/utils/game/TabList.kt
@@ -4,7 +4,6 @@ import net.minecraft.client.multiplayer.PlayerInfo
 import net.minecraft.network.chat.Component
 import net.sbo.mod.SBOKotlin.mc
 import net.sbo.mod.utils.events.Register
-import java.util.ArrayList
 
 object TabList {
     /**

--- a/src/main/kotlin/net/sbo/mod/utils/game/World.kt
+++ b/src/main/kotlin/net/sbo/mod/utils/game/World.kt
@@ -13,17 +13,6 @@ object World {
     }
 
     /**
-     * Retrieves the current zone from the ScoreBoard.
-     * If no zone is found, it returns "None".
-     */
-    fun getZone(): String {
-        val lines = ScoreBoard.getLines()
-        if (lines.isEmpty()) return "None"
-        val zoneLine = lines.find { line -> line.contains("⏣") || line.contains("ф") }
-        return zoneLine?.trim()?.removePrefix("⏣")?.removePrefix("ф")?.trim() ?: "None"
-    }
-
-    /**
      * Checks if the player is currently in Skyblock.
      * This is determined by checking if the scoreboard title contains "skyblock".
      * @return true if the player is in Skyblock, false otherwise.

--- a/src/main/kotlin/net/sbo/mod/utils/http/Http.kt
+++ b/src/main/kotlin/net/sbo/mod/utils/http/Http.kt
@@ -1,21 +1,16 @@
 package net.sbo.mod.utils.http
 
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.booleanOrNull
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonPrimitive
+import net.minecraft.SharedConstants
 import net.sbo.mod.SBOKotlin
 import java.net.HttpURLConnection
 import java.net.URI
 import java.util.concurrent.CompletableFuture
-import kotlinx.serialization.json.Json
-import kotlinx.serialization.json.JsonObject
-import kotlinx.serialization.json.booleanOrNull
-import kotlinx.serialization.json.contentOrNull
-import kotlinx.serialization.json.jsonObject
-import kotlinx.serialization.json.jsonPrimitive
-import kotlinx.serialization.json.jsonArray
-
-import net.minecraft.SharedConstants
 
 object Http {
-    val jsonParser = Json { ignoreUnknownKeys = true }
     private const val CONNECT_TIMEOUT = 10000
     private const val READ_TIMEOUT = 10000
     private val USER_AGENT = "SBO-Kotlin-Mod/" + SBOKotlin.version + "+" + SharedConstants.getCurrentVersion().name()
@@ -37,39 +32,6 @@ object Http {
                     readTimeout = READ_TIMEOUT
                     setRequestProperty("User-Agent", USER_AGENT)
                 }
-                handleConnection(connection, handle)
-            } catch (e: Exception) {
-                handle.fail(e)
-            }
-        }
-        return handle
-    }
-
-    /**
-     * Sends an asynchronous HTTP POST request with a JSON body.
-     *
-     * @param urlString The URL to send the request to.
-     * @param jsonBody The JSON data to be sent in the request body.
-     * @return An [HttpRequestHandle].
-     */
-    fun sendPostRequest(urlString: String, jsonBody: String): HttpRequestHandle {
-        val handle = HttpRequestHandle()
-        CompletableFuture.runAsync {
-            try {
-                val url = URI(urlString).toURL()
-                val connection = (url.openConnection() as HttpURLConnection).apply {
-                    requestMethod = "POST"
-                    connectTimeout = CONNECT_TIMEOUT
-                    readTimeout = READ_TIMEOUT
-                    doOutput = true // Important for POST
-                    setRequestProperty("Content-Type", "application/json; utf-8")
-                    setRequestProperty("Accept", "application/json")
-                    setRequestProperty("User-Agent", USER_AGENT)
-                }
-
-                // Write JSON body
-                connection.outputStream.bufferedWriter(Charsets.UTF_8).use { it.write(jsonBody) }
-
                 handleConnection(connection, handle)
             } catch (e: Exception) {
                 handle.fail(e)
@@ -112,31 +74,5 @@ object Http {
 
     fun JsonObject.getInt(key: String): Int? {
         return this[key]?.jsonPrimitive?.contentOrNull?.toIntOrNull()
-    }
-
-    fun JsonObject.getLong(key: String): Long? {
-        return this[key]?.jsonPrimitive?.contentOrNull?.toLongOrNull()
-    }
-
-    fun JsonObject.getDouble(key: String): Double? {
-        return this[key]?.jsonPrimitive?.contentOrNull?.toDoubleOrNull()
-    }
-
-    fun JsonObject.getMutableMap(key: String): MutableMap<String, Any>? {
-        return this[key]?.jsonObject?.mapValues { entry ->
-            when (val value = entry.value) {
-                is JsonObject -> value.toMutableMap()
-                else -> value.jsonPrimitive.contentOrNull ?: value
-            }
-        }?.toMutableMap()
-    }
-
-    fun JsonObject.getArray(key: String): List<Any>? {
-        return this[key]?.jsonArray?.map { element ->
-            when (element) {
-                is JsonObject -> element.toMutableMap()
-                else -> element.jsonPrimitive.contentOrNull ?: element
-            }
-        }
     }
 }

--- a/src/main/kotlin/net/sbo/mod/utils/math/RaycastUtils.kt
+++ b/src/main/kotlin/net/sbo/mod/utils/math/RaycastUtils.kt
@@ -7,7 +7,7 @@ import kotlin.math.min
 
 /**
  * Utility functions for raycasting and geometric intersections.
- * The credits to this object go fully to the Skyhanni Mod: https://github.com/hannibal002/SkyHanni/blob/beta/src/main/java/at/hannibal2/skyhanni/utils/RaycastUtils.kt
+ * The credits to this object go fully to the SkyHanni Mod: https://github.com/hannibal002/SkyHanni/blob/beta/src/main/java/at/hannibal2/skyhanni/utils/RaycastUtils.kt
  */
 object RaycastUtils {
     const val EPSILON = 1e-12

--- a/src/main/kotlin/net/sbo/mod/utils/math/SboVec.kt
+++ b/src/main/kotlin/net/sbo/mod/utils/math/SboVec.kt
@@ -1,8 +1,8 @@
 package net.sbo.mod.utils.math
 
+import net.minecraft.core.BlockPos
 import net.minecraft.world.level.block.Block
 import net.minecraft.world.level.block.state.BlockState
-import net.minecraft.core.BlockPos
 import net.minecraft.world.phys.Vec3
 import net.sbo.mod.SBOKotlin
 import kotlin.math.absoluteValue
@@ -12,7 +12,7 @@ import kotlin.math.sqrt
 
 /**
  * A 3D vector class for mathematical operations and Minecraft world interactions.
- * The credits to this class go fully to the Skyhanni Mod: https://github.com/hannibal002/SkyHanni/blob/beta/src/main/java/at/hannibal2/skyhanni/utils/LorenzVec.kt
+ * The credits to this class go fully to the SkyHanni Mod: https://github.com/hannibal002/SkyHanni/blob/beta/src/main/java/at/hannibal2/skyhanni/utils/LorenzVec.kt
  */
 data class SboVec(var x: Double, var y: Double, var z: Double) {
 
@@ -42,8 +42,6 @@ data class SboVec(var x: Double, var y: Double, var z: Double) {
         return SboVec(this.x * d, this.y * d, this.z * d)
     }
 
-    fun clone(): SboVec = this.copy()
-
     fun down(amount: Double = 1.0): SboVec {
         return this.copy(y = this.y - amount)
     }
@@ -68,10 +66,6 @@ data class SboVec(var x: Double, var y: Double, var z: Double) {
 
     fun center(): SboVec {
         return SboVec(this.x + 0.5, this.y + 0.5, this.z + 0.5)
-    }
-
-    fun toCleanString(): String {
-        return "%.2f, %.2f, %.2f".format(this.x, this.y, this.z)
     }
 
     fun toDoubleArray(): DoubleArray {

--- a/src/main/kotlin/net/sbo/mod/utils/overlay/Overlay.kt
+++ b/src/main/kotlin/net/sbo/mod/utils/overlay/Overlay.kt
@@ -1,14 +1,14 @@
 package net.sbo.mod.utils.overlay
 
 import net.minecraft.client.gui.GuiGraphics
-import net.minecraft.client.gui.screens.Screen
 import net.minecraft.client.gui.screens.ChatScreen
+import net.minecraft.client.gui.screens.Screen
 import net.minecraft.client.gui.screens.inventory.InventoryScreen
 import net.sbo.mod.SBOKotlin.mc
 import net.sbo.mod.utils.Helper
-import net.sbo.mod.utils.game.World
 import net.sbo.mod.utils.data.OverlayValues
 import net.sbo.mod.utils.data.SboDataObject.overlayData
+import net.sbo.mod.utils.game.World
 import java.awt.Color
 
 fun isCraftingScreenOpen(): Boolean {
@@ -63,20 +63,8 @@ class Overlay(
         return this
     }
 
-    fun checkCondition(): Boolean {
-        return condition()
-    }
-
     fun addLine(line: OverlayTextLine) {
         lines.add(line)
-    }
-
-    fun addLineAt(index: Int, line: OverlayTextLine) {
-        lines.add(index, line)
-    }
-
-    fun addLines(newLines: List<OverlayTextLine>) {
-        lines.addAll(newLines)
     }
 
     fun setLines(newLines: List<OverlayTextLine>) {
@@ -180,7 +168,7 @@ class Overlay(
         var currentX = (x / scale)
 
         // We don't need thread safety as we are in method-local context
-        // Making these vars lazy ensures they are only computed when needed (e.g not computed if both of the if conditions below are false)
+        // Making these vars lazy ensures they are only computed when needed (e.g., not computed if both of the if conditions below are false)
         // and only computed once when both of the if conditions are true.
         val totalWidth by lazy(LazyThreadSafetyMode.NONE) { getTotalWidth() }
         val totalHeight by lazy(LazyThreadSafetyMode.NONE) { getTotalHeight() }

--- a/src/main/kotlin/net/sbo/mod/utils/overlay/OverlayEditScreen.kt
+++ b/src/main/kotlin/net/sbo/mod/utils/overlay/OverlayEditScreen.kt
@@ -2,12 +2,12 @@ package net.sbo.mod.utils.overlay
 
 import net.minecraft.client.gui.GuiGraphics
 import net.minecraft.client.gui.screens.Screen
+import net.minecraft.client.input.KeyEvent
+import net.minecraft.client.input.MouseButtonEvent
 import net.minecraft.network.chat.Component
 import net.sbo.mod.utils.data.SboDataObject
 import net.sbo.mod.utils.data.SboDataObject.overlayData
 import org.lwjgl.glfw.GLFW
-import net.minecraft.client.input.MouseButtonEvent
-import net.minecraft.client.input.KeyEvent
 
 class OverlayEditScreen : Screen(Component.literal("SBO_Overlay_Editor")) {
     private var selectedOverlay: Overlay? = null

--- a/src/main/kotlin/net/sbo/mod/utils/overlay/OverlayManager.kt
+++ b/src/main/kotlin/net/sbo/mod/utils/overlay/OverlayManager.kt
@@ -4,11 +4,11 @@ import net.minecraft.client.gui.GuiGraphics
 import net.minecraft.client.gui.screens.Screen
 import net.sbo.mod.SBOKotlin.mc
 import net.sbo.mod.utils.events.Register
-import net.sbo.mod.utils.game.World
 import net.sbo.mod.utils.events.annotations.SboEvent
-import net.sbo.mod.utils.events.impl.render.RenderEvent
 import net.sbo.mod.utils.events.impl.guis.GuiMouseClickAfter
 import net.sbo.mod.utils.events.impl.guis.GuiPostRenderEvent
+import net.sbo.mod.utils.events.impl.render.RenderEvent
+import net.sbo.mod.utils.game.World
 
 object OverlayManager {
     val overlays = mutableListOf<Overlay>()

--- a/src/main/kotlin/net/sbo/mod/utils/overlay/OverlayTextLine.kt
+++ b/src/main/kotlin/net/sbo/mod/utils/overlay/OverlayTextLine.kt
@@ -1,13 +1,10 @@
 package net.sbo.mod.utils.overlay
 
-import net.sbo.mod.SBOKotlin.mc
-
-import net.minecraft.client.gui.GuiGraphics
 import net.minecraft.client.gui.Font
-
-import net.minecraft.util.FormattedCharSequence
+import net.minecraft.client.gui.GuiGraphics
 import net.minecraft.network.chat.Component
-
+import net.minecraft.util.FormattedCharSequence
+import net.sbo.mod.SBOKotlin.mc
 import java.awt.Color
 
 class OverlayTextLine(

--- a/src/main/kotlin/net/sbo/mod/utils/render/RenderUtils3D.kt
+++ b/src/main/kotlin/net/sbo/mod/utils/render/RenderUtils3D.kt
@@ -228,7 +228,7 @@ object RenderUtils3D {
         phase: Boolean = false
     ) {
         val player = mc.player ?: return
-        if (vec.center().distanceTo(player.x, player.y, player.z) < Diana.removeBeam) return
+        if (vec.center().distanceTo(player.x, player.y, player.z) < 8) return
 
         val consumers = ctx.consumers()
         val world = mc.level ?: return

--- a/src/main/kotlin/net/sbo/mod/utils/render/RenderUtils3D.kt
+++ b/src/main/kotlin/net/sbo/mod/utils/render/RenderUtils3D.kt
@@ -1,27 +1,25 @@
 package net.sbo.mod.utils.render
 
-import net.minecraft.client.gui.Font
-import net.minecraft.client.renderer.texture.OverlayTexture
-import net.minecraft.client.Camera
+import com.mojang.blaze3d.vertex.PoseStack
 import com.mojang.blaze3d.vertex.VertexConsumer
 import com.mojang.math.Axis
+import net.fabricmc.fabric.api.client.rendering.v1.world.WorldRenderContext
+import net.minecraft.client.Camera
+import net.minecraft.client.gui.Font
+import net.minecraft.client.renderer.MultiBufferSource
+import net.minecraft.client.renderer.texture.OverlayTexture
+import net.minecraft.gizmos.GizmoStyle
+import net.minecraft.gizmos.Gizmos
+import net.minecraft.util.ARGB
+import net.minecraft.util.Mth
+import net.minecraft.world.phys.AABB
 import net.minecraft.world.phys.Vec3
 import net.sbo.mod.SBOKotlin.mc
 import net.sbo.mod.settings.categories.Customization
+import net.sbo.mod.settings.categories.Diana
 import net.sbo.mod.utils.math.SboVec
 import java.awt.Color
 import kotlin.math.max
-import com.mojang.blaze3d.vertex.PoseStack
-import net.minecraft.client.renderer.MultiBufferSource
-import net.minecraft.util.Mth
-import net.minecraft.util.ARGB
-import net.sbo.mod.settings.categories.Diana
-
-import net.fabricmc.fabric.api.client.rendering.v1.world.WorldRenderContext
-
-import net.minecraft.gizmos.Gizmos
-import net.minecraft.gizmos.GizmoStyle
-import net.minecraft.world.phys.AABB
 
 object RenderUtils3D {
     fun renderWaypoint(
@@ -233,7 +231,7 @@ object RenderUtils3D {
         if (vec.center().distanceTo(player.x, player.y, player.z) < Diana.removeBeam) return
 
         val consumers = ctx.consumers()
-        val wolrd = mc.level ?: return
+        val world = mc.level ?: return
         val partialTicks = mc.deltaTracker.getGameTimeDeltaPartialTick(true)
         val cam = ctx.getCamera().position()
         val beamColor = floatArrayOf(colorComponents[0], colorComponents[1], colorComponents[2], 1.0f)
@@ -244,7 +242,7 @@ object RenderUtils3D {
             renderBeam(
                 consumers,
                 partialTicks,
-                wolrd.gameTime,
+                world.gameTime,
                 Color(beamColor[0], beamColor[1], beamColor[2]).rgb,
                 phase
             )
@@ -258,8 +256,8 @@ object RenderUtils3D {
         color: Int,
         phase: Boolean = false
     ) {
-        val opaqueLayyer = if (phase) SboRenderLayers.BEACON_BEAM_OPAQUE_THROUGH_WALLS else SboRenderLayers.BEACON_BEAM_OPAQUE
-        val transluscentLayer = if (phase) SboRenderLayers.BEACON_BEAM_TRANSLUCENT_THROUGH_WALLS else SboRenderLayers.BEACON_BEAM_TRANSLUCENT
+        val opaqueLayer = if (phase) SboRenderLayers.BEACON_BEAM_OPAQUE_THROUGH_WALLS else SboRenderLayers.BEACON_BEAM_OPAQUE
+        val translucentLayer = if (phase) SboRenderLayers.BEACON_BEAM_TRANSLUCENT_THROUGH_WALLS else SboRenderLayers.BEACON_BEAM_TRANSLUCENT
         val heightScale = 1f
         val height = 320
         val innerRadius = 0.2f
@@ -277,7 +275,7 @@ object RenderUtils3D {
                 mulPose(Axis.YP.rotationDegrees(time * 2.25f - 45f))
 
                 renderBeamLayer(
-                    vertices.getBuffer(opaqueLayyer),
+                    vertices.getBuffer(opaqueLayer),
                     color,
                     0f,
                     innerRadius,
@@ -295,7 +293,7 @@ object RenderUtils3D {
             renderYOffest = height.toFloat() * heightScale + animationStep
 
             renderBeamLayer(
-                vertices.getBuffer(transluscentLayer),
+                vertices.getBuffer(translucentLayer),
                 ARGB.color(32, color),
                 -outerRadius,
                 -outerRadius,

--- a/src/main/kotlin/net/sbo/mod/utils/render/SboRenderLayers.kt
+++ b/src/main/kotlin/net/sbo/mod/utils/render/SboRenderLayers.kt
@@ -1,8 +1,8 @@
 package net.sbo.mod.utils.render
 
-import net.minecraft.client.renderer.rendertype.RenderType
 import net.minecraft.client.renderer.blockentity.BeaconRenderer
 import net.minecraft.client.renderer.rendertype.RenderSetup
+import net.minecraft.client.renderer.rendertype.RenderType
 
 object SboRenderLayers {
     @JvmField

--- a/src/main/kotlin/net/sbo/mod/utils/render/SboRenderPipelines.kt
+++ b/src/main/kotlin/net/sbo/mod/utils/render/SboRenderPipelines.kt
@@ -5,9 +5,9 @@ import com.mojang.blaze3d.pipeline.RenderPipeline
 //#if MC < 26.1
 import com.mojang.blaze3d.platform.DepthTestFunction
 //#endif
+import com.mojang.blaze3d.vertex.DefaultVertexFormat
 import com.mojang.blaze3d.vertex.VertexFormat.Mode
 import net.minecraft.client.renderer.RenderPipelines
-import com.mojang.blaze3d.vertex.DefaultVertexFormat
 import net.sbo.mod.SBOKotlin
 
 /** Add new pipelines to [net.sbo.mod.compat.IrisCompatibility] */

--- a/src/main/kotlin/net/sbo/mod/utils/render/WaypointRenderer.kt
+++ b/src/main/kotlin/net/sbo/mod/utils/render/WaypointRenderer.kt
@@ -1,9 +1,8 @@
 package net.sbo.mod.utils.render
 
-import net.sbo.mod.utils.waypoint.WaypointManager
-
-import net.fabricmc.fabric.api.client.rendering.v1.world.WorldRenderEvents
 import net.fabricmc.fabric.api.client.rendering.v1.world.WorldRenderContext
+import net.fabricmc.fabric.api.client.rendering.v1.world.WorldRenderEvents
+import net.sbo.mod.utils.waypoint.WaypointManager
 
 object WaypointRenderer : WorldRenderEvents.BeforeTranslucent {
     override fun beforeTranslucent(context: WorldRenderContext) {

--- a/src/main/kotlin/net/sbo/mod/utils/waypoint/WarpPoint.kt
+++ b/src/main/kotlin/net/sbo/mod/utils/waypoint/WarpPoint.kt
@@ -13,7 +13,8 @@ data class WarpPoint(
     val unlocked: Boolean,
     val setting: String? = null, // Nullable, since not all warps have a setting
     val warpType: AdditionalHubWarps? = null, // null for hub, set for all others
-    val preferWarpAgainstCompetitive: AdditionalHubWarps? = null
+    val preferWarpAgainstCompetitive: AdditionalHubWarps? = null,
+    val extraBlocks: Int = 0
 )
 
 val hubWarps: Map<String, WarpPoint> = mapOf(
@@ -23,7 +24,7 @@ val hubWarps: Map<String, WarpPoint> = mapOf(
 val additionalHubWarps: Map<String, WarpPoint> = mapOf(
     "castle" to WarpPoint(SboVec(-250.00, 130.00, 45.00), true, "castleWarp", AdditionalHubWarps.CASTLE, AdditionalHubWarps.CRYPT),
     "wizard" to WarpPoint(SboVec(44.50, 119.00, 93.50), true, "wizardWarp", AdditionalHubWarps.WIZARD),
-    "crypt" to WarpPoint(SboVec(-160.50, 62.00, -106.50), true, "cryptWarp", AdditionalHubWarps.CRYPT),
+    "crypt" to WarpPoint(SboVec(-160.50, 62.00, -106.50), true, "cryptWarp", AdditionalHubWarps.CRYPT, extraBlocks = 10),
     "stonks" to WarpPoint(SboVec(-36.50, 70.00, -81.50), true, "stonksWarp", AdditionalHubWarps.STONKS),
     "da" to WarpPoint(SboVec(91.50, 75.00, 173.50), true, "darkAuctionWarp", AdditionalHubWarps.DA),
     "taylor" to WarpPoint(SboVec(29.50, 73.00, -41.50), true, "taylorWarp", AdditionalHubWarps.TAYLOR),

--- a/src/main/kotlin/net/sbo/mod/utils/waypoint/WarpPoint.kt
+++ b/src/main/kotlin/net/sbo/mod/utils/waypoint/WarpPoint.kt
@@ -2,8 +2,6 @@ package net.sbo.mod.utils.waypoint
 
 import net.sbo.mod.utils.math.SboVec
 
-const val COMPETITIVE_WARP_DISTANCE_THRESHOLD = 15.0
-
 /**
  * Represents a single warp point with coordinates and optional data.
  * @property pos The position of the warp point in the game world.

--- a/src/main/kotlin/net/sbo/mod/utils/waypoint/WarpPoint.kt
+++ b/src/main/kotlin/net/sbo/mod/utils/waypoint/WarpPoint.kt
@@ -13,7 +13,6 @@ data class WarpPoint(
     val unlocked: Boolean,
     val setting: String? = null, // Nullable, since not all warps have a setting
     val warpType: AdditionalHubWarps? = null, // null for hub, set for all others
-    val ignoreYLevel: Boolean = false,
     val preferWarpAgainstCompetitive: AdditionalHubWarps? = null
 )
 
@@ -22,8 +21,8 @@ val hubWarps: Map<String, WarpPoint> = mapOf(
 )
 
 val additionalHubWarps: Map<String, WarpPoint> = mapOf(
-    "castle" to WarpPoint(SboVec(-250.00, 130.00, 45.00), true, "castleWarp", AdditionalHubWarps.CASTLE, true, AdditionalHubWarps.CRYPT),
-    "wizard" to WarpPoint(SboVec(44.50, 119.00, 93.50), true, "wizardWarp", AdditionalHubWarps.WIZARD, true),
+    "castle" to WarpPoint(SboVec(-250.00, 130.00, 45.00), true, "castleWarp", AdditionalHubWarps.CASTLE, AdditionalHubWarps.CRYPT),
+    "wizard" to WarpPoint(SboVec(44.50, 119.00, 93.50), true, "wizardWarp", AdditionalHubWarps.WIZARD),
     "crypt" to WarpPoint(SboVec(-160.50, 62.00, -106.50), true, "cryptWarp", AdditionalHubWarps.CRYPT),
     "stonks" to WarpPoint(SboVec(-36.50, 70.00, -81.50), true, "stonksWarp", AdditionalHubWarps.STONKS),
     "da" to WarpPoint(SboVec(91.50, 75.00, 173.50), true, "darkAuctionWarp", AdditionalHubWarps.DA),

--- a/src/main/kotlin/net/sbo/mod/utils/waypoint/Waypoint.kt
+++ b/src/main/kotlin/net/sbo/mod/utils/waypoint/Waypoint.kt
@@ -13,6 +13,11 @@ import kotlin.math.pow
 import kotlin.math.roundToInt
 import kotlin.math.sqrt
 
+private const val MIN_OPACITY = 0.2f
+private const val MAX_OPACITY = 1.0f
+private const val FADE_START_DISTANCE = 4.5
+private const val FADE_END_DISTANCE = 100.0
+
 /**
  * @class Waypoint
  * @description A class to create waypoints in the game.
@@ -49,6 +54,11 @@ class Waypoint(
         return sqrt((playerPos.x - this.pos.x).pow(2) + (playerPos.y - this.pos.y).pow(2) + (playerPos.z - this.pos.z).pow(2))
     }
 
+    fun distanceToPlayerIgnoringY(): Double {
+        val playerPos = Player.getLastPosition()
+        return sqrt((playerPos.x - this.pos.x).pow(2) + (playerPos.z - this.pos.z).pow(2))
+    }
+
     private fun setWarpText() {
         val showTimesDug = Customization.showTimesDug && this.type == "burrow" && this.text != "Start"
         val timesDug = this.timesDug
@@ -70,6 +80,21 @@ class Waypoint(
         } else {
             this.formattedText = "${this.text}${this.distanceText}$timesDugText"
         }
+    }
+
+    private fun getDynamicOpacity(): Float {
+        val distance = this.distanceRaw
+
+        if (distance <= FADE_START_DISTANCE) {
+            return MIN_OPACITY
+        }
+
+        if (distance >= FADE_END_DISTANCE) {
+            return MAX_OPACITY
+        }
+
+        val progress = ((distance - FADE_START_DISTANCE) / (FADE_END_DISTANCE - FADE_START_DISTANCE)).toFloat()
+        return MIN_OPACITY + ((MAX_OPACITY - MIN_OPACITY) * progress)
     }
 
     private fun getColor(): Color {
@@ -161,7 +186,12 @@ class Waypoint(
 
         val rgbAndHex = getRgbAndHex()
 
-        val waypointOpacity = (Customization.waypointOpacity / 100.0).toFloat()
+        val waypointOpacity = if (Customization.dynamicWaypointOpacity) {
+            getDynamicOpacity()
+        } else {
+            (Customization.waypointOpacity / 100.0).toFloat()
+        }
+
         val waypointTextOpacity = (Customization.waypointTextOpacity / 100.0).toFloat()
 
         RenderUtils3D.renderWaypoint(

--- a/src/main/kotlin/net/sbo/mod/utils/waypoint/Waypoint.kt
+++ b/src/main/kotlin/net/sbo/mod/utils/waypoint/Waypoint.kt
@@ -51,7 +51,8 @@ class Waypoint(
     private fun setWarpText() {
         val showTimesDug = Customization.showTimesDug && this.type == "burrow" && this.text != "Start"
         val timesDug = this.timesDug
-        val timesDugText = if (showTimesDug) " §7[§" + (if (timesDug >= 1) "6" else "e") + timesDug + "§7/§a2§7]" else ""
+        val dist = Customization.showDistanceCutoff == 0 || this.distanceToPlayer() < Customization.showDistanceCutoff
+        val timesDugText = if (showTimesDug && dist) " §7[§" + (if (timesDug >= 1) "6" else "e") + timesDug + "§7/§a2§7]" else ""
 
         if (isClosest) {
             val closest = WaypointManager.getClosestWarp(this.pos)
@@ -63,7 +64,7 @@ class Waypoint(
             val title = Diana.showTitleWhenWarpAvailable
             if (title && closest != null && World.getWorld() == "Hub" && Helper.hasSpade) {
                  val warpName = closest.replaceFirstChar(Char::titlecase)
-                 Helper.showTitle("§bWarp §e$warpName$distanceText$timesDugText", "", 0, 1, 0) // 1 ticks because next tick this will be called again
+                 Helper.showTitle("§bWarp §e$warpName$distanceText", "", 0, 1, 0) // 1 ticks because next tick this will be called again
             }
         } else {
             this.formattedText = "${this.text}${this.distanceText}$timesDugText"

--- a/src/main/kotlin/net/sbo/mod/utils/waypoint/Waypoint.kt
+++ b/src/main/kotlin/net/sbo/mod/utils/waypoint/Waypoint.kt
@@ -1,18 +1,17 @@
 package net.sbo.mod.utils.waypoint
 
+import net.fabricmc.fabric.api.client.rendering.v1.world.WorldRenderContext
 import net.sbo.mod.settings.categories.Customization
 import net.sbo.mod.settings.categories.Diana
-import net.sbo.mod.utils.Player
 import net.sbo.mod.utils.Helper
+import net.sbo.mod.utils.Player
+import net.sbo.mod.utils.game.World
 import net.sbo.mod.utils.math.SboVec
 import net.sbo.mod.utils.render.RenderUtils3D
-import net.sbo.mod.utils.game.World
+import java.awt.Color
 import kotlin.math.pow
 import kotlin.math.roundToInt
 import kotlin.math.sqrt
-import java.awt.Color
-
-import net.fabricmc.fabric.api.client.rendering.v1.world.WorldRenderContext
 
 /**
  * @class Waypoint
@@ -21,13 +20,9 @@ import net.fabricmc.fabric.api.client.rendering.v1.world.WorldRenderContext
  * @param x The x-coordinate of the waypoint.
  * @param y The y-coordinate of the waypoint.
  * @param z The z-coordinate of the waypoint.
- * @param r The red color component of the waypoint.
- * @param g The green color component of the waypoint.
- * @param b The blue color component of the waypoint.
  * @param ttl The time to live for the waypoint in seconds (0 for infinite).
  * @param type The type of the waypoint for customization.
  * @param line Whether to draw a line to the waypoint.
- * @param distance Whether to display the distance in meters (blocks) to the waypoint.
  */
 class Waypoint(
     var text: String,
@@ -36,11 +31,9 @@ class Waypoint(
     val z: Double,
     val ttl: Int = 1800,
     val type: String = "normal",
-    var line: Boolean = false,
-    var distance: Boolean = true
+    var line: Boolean = false
 ) {
     var pos: SboVec = SboVec(this.x, this.y, this.z)
-    val alpha: Double = 0.5
     var hidden: Boolean = false
     val creation: Long = System.currentTimeMillis()
     var formatted: Boolean = false
@@ -48,6 +41,7 @@ class Waypoint(
     var distanceText: String = ""
     var formattedText: String = ""
     var isClosest = false
+    var timesDug = 0
 
     fun distanceToPlayer(): Double {
         val playerPos = Player.getLastPosition()
@@ -55,20 +49,24 @@ class Waypoint(
     }
 
     private fun setWarpText() {
+        val showTimesDug = Customization.showTimesDug && this.type == "burrow" && this.text != "Start"
+        val timesDug = this.timesDug
+        val timesDugText = if (showTimesDug) " §7[§" + (if (timesDug >= 1) "6" else "e") + timesDug + "§7/§a2§7]" else ""
+
         if (isClosest) {
             val closest = WaypointManager.getClosestWarp(this.pos)
 
             this.formattedText = closest?.let {
-                "$text§7 (warp $it)${this.distanceText}"
-            } ?: "${this.text}${this.distanceText}"
+                "$text§7 (warp $it)${this.distanceText}$timesDugText"
+            } ?: "${this.text}${this.distanceText}$timesDugText"
 
             val title = Diana.showTitleWhenWarpAvailable
             if (title && closest != null && World.getWorld() == "Hub" && Helper.hasSpade) {
                  val warpName = closest.replaceFirstChar(Char::titlecase)
-                 Helper.showTitle("§bWarp §e$warpName$distanceText", "", 0, 1, 0) // 1 ticks because next tick this will be called again
+                 Helper.showTitle("§bWarp §e$warpName$distanceText$timesDugText", "", 0, 1, 0) // 1 ticks because next tick this will be called again
             }
         } else {
-            this.formattedText = "${this.text}${this.distanceText}"
+            this.formattedText = "${this.text}${this.distanceText}$timesDugText"
         }
     }
 
@@ -114,7 +112,10 @@ class Waypoint(
         inqWaypoints: List<Waypoint>
     ) {
         this.distanceRaw = distanceToPlayer()
-        this.distanceText = if (distance) " §b[${distanceRaw.roundToInt()}m]" else ""
+        val dist = distanceRaw.roundToInt()
+
+        val showDistance = Customization.showDistanceCutoff <= 0 || dist > Customization.showDistanceCutoff
+        this.distanceText = if (showDistance) " §b[${dist}m]" else ""
 
         when (this.type) {
             "guess", "arrow" -> {
@@ -148,24 +149,26 @@ class Waypoint(
         return this
     }
 
-    fun show(): Waypoint {
-        this.hidden = false
-        return this
+    private fun applyAlpha(color: Int, alpha: Float): Int {
+        val clampedAlpha = (alpha.coerceIn(0f, 1f) * 255f).toInt()
+        return (color and 0x00FFFFFF) or (clampedAlpha shl 24)
     }
 
     fun render(context: WorldRenderContext) {
         if (!this.formatted || this.hidden) return
-        if (this.type == "guess" && this.distanceRaw <= Diana.removeGuessDistance) return
 
         val rgbAndHex = getRgbAndHex()
+
+        val waypointOpacity = (Customization.waypointOpacity / 100.0).toFloat()
+        val waypointTextOpacity = (Customization.waypointTextOpacity / 100.0).toFloat()
 
         RenderUtils3D.renderWaypoint(
             context,
             this.formattedText,
             this.pos,
             rgbAndHex.rgb,
-            rgbAndHex.hex,
-            this.alpha.toFloat(),
+            applyAlpha(rgbAndHex.hex, waypointTextOpacity),
+            waypointOpacity,
             true,
             this.line,
             Diana.dianaLineWidth.toFloat(),

--- a/src/main/kotlin/net/sbo/mod/utils/waypoint/Waypoint.kt
+++ b/src/main/kotlin/net/sbo/mod/utils/waypoint/Waypoint.kt
@@ -8,13 +8,14 @@ import net.sbo.mod.utils.Player
 import net.sbo.mod.utils.game.World
 import net.sbo.mod.utils.math.SboVec
 import net.sbo.mod.utils.render.RenderUtils3D
+import net.sbo.mod.diana.guesses.ArrowGuessBurrow
 import java.awt.Color
-import kotlin.math.pow
+import java.time.Duration
 import kotlin.math.roundToInt
 import kotlin.math.sqrt
 
 private const val MIN_OPACITY = 0.2f
-private const val MAX_OPACITY = 1.0f
+private const val MAX_OPACITY = 0.99f
 private const val FADE_START_DISTANCE = 4.5
 private const val FADE_END_DISTANCE = 100.0
 
@@ -48,15 +49,40 @@ class Waypoint(
     var isClosest = false
     var timesDug = 0
     var userInteractedWith = false
+    var dynamicOpacity = 0.99f
+    var inaccurateArrow = false
+
+    fun hasStrongerStateThan(other: Waypoint): Boolean = this.timesDug > other.timesDug || (this.userInteractedWith && !other.userInteractedWith)
+
+    fun carryOverState(other: Waypoint) {
+        val otherTimesDug = other.timesDug
+
+        if (otherTimesDug > this.timesDug) {
+            this.timesDug = otherTimesDug
+        }
+
+        val otherInteractedWith = other.userInteractedWith
+
+        if (otherInteractedWith && !this.userInteractedWith) {
+            this.userInteractedWith = true
+        }
+    }
 
     fun distanceToPlayer(): Double {
         val playerPos = Player.getLastPosition()
-        return sqrt((playerPos.x - this.pos.x).pow(2) + (playerPos.y - this.pos.y).pow(2) + (playerPos.z - this.pos.z).pow(2))
+        val dx = playerPos.x - this.pos.x
+        val dy = playerPos.y - this.pos.y
+        val dz = playerPos.z - this.pos.z
+
+        return sqrt(dx * dx + dy * dy + dz * dz)
     }
 
     fun distanceToPlayerIgnoringY(): Double {
         val playerPos = Player.getLastPosition()
-        return sqrt((playerPos.x - this.pos.x).pow(2) + (playerPos.z - this.pos.z).pow(2))
+        val dx = playerPos.x - this.pos.x
+        val dz = playerPos.z - this.pos.z
+
+        return sqrt(dx * dx + dz * dz)
     }
 
     private fun setWarpText() {
@@ -82,8 +108,12 @@ class Waypoint(
         }
     }
 
-    private fun getDynamicOpacity(): Float {
+    private fun updateDynamicOpacity(): Float {
         val distance = this.distanceRaw
+
+        if (!distance.isFinite()) {
+            return MAX_OPACITY
+        }
 
         if (distance <= FADE_START_DISTANCE) {
             return MIN_OPACITY
@@ -93,8 +123,11 @@ class Waypoint(
             return MAX_OPACITY
         }
 
-        val progress = ((distance - FADE_START_DISTANCE) / (FADE_END_DISTANCE - FADE_START_DISTANCE)).toFloat()
-        return MIN_OPACITY + ((MAX_OPACITY - MIN_OPACITY) * progress)
+        val progress = ((distance - FADE_START_DISTANCE) /
+            (FADE_END_DISTANCE - FADE_START_DISTANCE)).toFloat()
+
+        return (MIN_OPACITY + ((MAX_OPACITY - MIN_OPACITY) * progress))
+            .coerceIn(MIN_OPACITY, MAX_OPACITY)
     }
 
     private fun getColor(): Color {
@@ -139,6 +172,8 @@ class Waypoint(
         inqWaypoints: List<Waypoint>
     ) {
         this.distanceRaw = distanceToPlayer()
+        this.dynamicOpacity = if (Customization.dynamicWaypointOpacity) updateDynamicOpacity() else (Customization.waypointOpacity / 100.0).toFloat().coerceIn(0f, 1f)
+
         val dist = distanceRaw.roundToInt()
 
         val showDistance = Customization.showDistanceCutoff <= 0 || dist > Customization.showDistanceCutoff
@@ -181,17 +216,17 @@ class Waypoint(
         return (color and 0x00FFFFFF) or (clampedAlpha shl 24)
     }
 
+    fun isOlderThan(duration: Duration): Boolean {
+        return System.currentTimeMillis() - this.creation > duration.toMillis()
+    }
+
     fun render(context: WorldRenderContext) {
         if (!this.formatted || this.hidden) return
+        if (inaccurateArrow) return
 
         val rgbAndHex = getRgbAndHex()
 
-        val waypointOpacity = if (Customization.dynamicWaypointOpacity) {
-            getDynamicOpacity()
-        } else {
-            (Customization.waypointOpacity / 100.0).toFloat()
-        }
-
+        val waypointOpacity = this.dynamicOpacity
         val waypointTextOpacity = (Customization.waypointTextOpacity / 100.0).toFloat()
 
         RenderUtils3D.renderWaypoint(

--- a/src/main/kotlin/net/sbo/mod/utils/waypoint/Waypoint.kt
+++ b/src/main/kotlin/net/sbo/mod/utils/waypoint/Waypoint.kt
@@ -42,6 +42,7 @@ class Waypoint(
     var formattedText: String = ""
     var isClosest = false
     var timesDug = 0
+    var userInteractedWith = false
 
     fun distanceToPlayer(): Double {
         val playerPos = Player.getLastPosition()

--- a/src/main/kotlin/net/sbo/mod/utils/waypoint/WaypointManager.kt
+++ b/src/main/kotlin/net/sbo/mod/utils/waypoint/WaypointManager.kt
@@ -164,15 +164,17 @@ object WaypointManager {
                 }
             }
 
-            closestWaypoint = getClosestWaypointFrom(playerPos) ?: (null to 1000.0)
-            val bestGuessWp = getBestGuess()
-
             this.forEachWaypoint { waypoint ->
                 if (waypoint.ttl > 0 && waypoint.creation + waypoint.ttl * 1000L < System.currentTimeMillis()) {
                     removeWaypoint(waypoint)
                     return@forEachWaypoint
                 }
+            }
 
+            closestWaypoint = getClosestWaypointFrom(playerPos) ?: (null to 1000.0)
+            val bestGuessWp = getBestGuess()
+
+            this.forEachWaypoint { waypoint ->
                 waypoint.isClosest = waypoint == bestGuessWp
                 waypoint.format(rareWp)
             }
@@ -414,7 +416,9 @@ object WaypointManager {
             }
         }
 
-        if (Diana.badWarpDistance > 0 && secondClosestWarpPoint?.preferWarpAgainstCompetitive == closestWarpPoint?.warpType && secondClosestDistance - closestDistance < Diana.badWarpDistance) {
+        val preferredAgainst = secondClosestWarpPoint?.preferWarpAgainstCompetitive
+
+        if (Diana.badWarpDistance > 0 && preferredAgainst != null && preferredAgainst == closestWarpPoint?.warpType && secondClosestDistance - closestDistance < Diana.badWarpDistance) {
             closestWarp = secondClosestWarp
             closestWarpPoint = secondClosestWarpPoint
             closestDistance = secondClosestDistance

--- a/src/main/kotlin/net/sbo/mod/utils/waypoint/WaypointManager.kt
+++ b/src/main/kotlin/net/sbo/mod/utils/waypoint/WaypointManager.kt
@@ -125,6 +125,14 @@ object WaypointManager {
             // These do not change location when using the shovel
             val allStaticBurrowWaypoints = knownBurrows + arrowGuesses
 
+            // Remove all TTL expired waypoints
+            this.forEachWaypoint { waypoint ->
+                if (waypoint.ttl > 0 && waypoint.creation + waypoint.ttl * 1000L < System.currentTimeMillis()) {
+                    removeWaypoint(waypoint)
+                    return@forEachWaypoint
+                }
+            }
+
             // Remove all waypoints that are under the world (y < 60)
             val guessesToRemove = allWaypoints.filter { waypoint -> waypoint.pos.y < 60 }
 
@@ -161,13 +169,6 @@ object WaypointManager {
                     }
                 ) {
                     removeWaypoint(arrowGuess)
-                }
-            }
-
-            this.forEachWaypoint { waypoint ->
-                if (waypoint.ttl > 0 && waypoint.creation + waypoint.ttl * 1000L < System.currentTimeMillis()) {
-                    removeWaypoint(waypoint)
-                    return@forEachWaypoint
                 }
             }
 

--- a/src/main/kotlin/net/sbo/mod/utils/waypoint/WaypointManager.kt
+++ b/src/main/kotlin/net/sbo/mod/utils/waypoint/WaypointManager.kt
@@ -359,7 +359,7 @@ object WaypointManager {
     fun getBestGuess(): Waypoint? {
         return getAllGuessesAndBurrows()
             .filter { !it.hidden }
-            .minByOrNull { it.distanceToPlayer() }
+            .minByOrNull { if (Diana.ignoreYLevel) it.distanceToPlayerIgnoringY() else it.distanceToPlayer() }
     }
 
     private fun getClosestWaypointFrom(pos: SboVec): Pair<Waypoint, Double>? {
@@ -391,7 +391,7 @@ object WaypointManager {
             }
         }
 
-        var playerDistance = pos.distanceTo(Player.getLastPosition())
+        var playerDistance = if (Diana.ignoreYLevel) pos.distanceToIgnoringY(Player.getLastPosition()) else pos.distanceTo(Player.getLastPosition())
 
         var closestWarp: String? = null
         var closestWarpPoint: WarpPoint? = null
@@ -429,7 +429,7 @@ object WaypointManager {
 
         if (Diana.ignoreYLevel) playerDistance = pos.distanceToIgnoringY(Player.getLastPosition())
 
-        val condition1 = playerDistance > (closestDistance + Diana.warpDiff)
+        val condition1 = playerDistance > (closestDistance + Diana.warpDiff + (closestWarpPoint?.extraBlocks ?: 0))
         val condition2 = condition1 && (closestWaypoint.second > 60 || getWaypointsOfType("rareMob").isNotEmpty())
 
         val condition = if (Diana.dontWarpIfBurrowClose) condition2 else condition1

--- a/src/main/kotlin/net/sbo/mod/utils/waypoint/WaypointManager.kt
+++ b/src/main/kotlin/net/sbo/mod/utils/waypoint/WaypointManager.kt
@@ -145,29 +145,31 @@ object WaypointManager {
             // Remove the shovel guess if a known burrow, or an arrow guess exists at the same block, or 3 blocks near it (contrary to the name, precise guess is less precise than arrow guess)
             shovelGuesses.forEach { shovelGuess ->
                 val shovelGuessBlock = shovelGuess.pos.roundLocationToBlock()
-                if (
-                    allStaticBurrowWaypoints.any {
-                        val waypointPos = it.pos
-                        val waypointBlock = waypointPos.roundLocationToBlock()
 
-                        waypointBlock == shovelGuessBlock || waypointBlock.distanceTo(shovelGuessBlock) <= 3
+                allStaticBurrowWaypoints.firstOrNull { staticBurrow ->
+                    val waypointBlock = staticBurrow.pos.roundLocationToBlock()
+
+                    waypointBlock == shovelGuessBlock || waypointBlock.distanceTo(shovelGuessBlock) <= 3
+                }?.let { staticBurrow ->
+                    if (shovelGuess.timesDug > staticBurrow.timesDug) {
+                        staticBurrow.timesDug = shovelGuess.timesDug
                     }
-                ) {
+
                     removeAllOfType("guess")
                 }
             }
 
-            // Remove the arrow guesses representing the same blocks as an already-known treasure/mob/start burrow
+            // Remove the arrow guesses representing the same blocks as an already-known treasure/mob/start burrow, and transfer its timesDug to the known burrow instead if the arrow guess was dug more times than the known burrow
             arrowGuesses.forEach { arrowGuess ->
                 val arrowGuessBlock = arrowGuess.pos.roundLocationToBlock()
-                if (
-                    knownBurrows.any {
-                        val waypointPos = it.pos
-                        val waypointBlock = waypointPos.roundLocationToBlock()
 
-                        waypointBlock == arrowGuessBlock
+                knownBurrows.firstOrNull { knownBurrow ->
+                    knownBurrow.pos.roundLocationToBlock() == arrowGuessBlock
+                }?.let { knownBurrow ->
+                    if (arrowGuess.timesDug > knownBurrow.timesDug) {
+                        knownBurrow.timesDug = arrowGuess.timesDug
                     }
-                ) {
+
                     removeWaypoint(arrowGuess)
                 }
             }

--- a/src/main/kotlin/net/sbo/mod/utils/waypoint/WaypointManager.kt
+++ b/src/main/kotlin/net/sbo/mod/utils/waypoint/WaypointManager.kt
@@ -1,34 +1,33 @@
 package net.sbo.mod.utils.waypoint
 
-import net.sbo.mod.diana.guesses.PreciseGuessBurrow
+import net.fabricmc.fabric.api.client.rendering.v1.world.WorldRenderContext
+import net.fabricmc.fabric.api.client.rendering.v1.world.WorldRenderEvents
 import net.minecraft.client.multiplayer.ClientLevel
 import net.minecraft.core.BlockPos
 import net.sbo.mod.SBOKotlin
+import net.sbo.mod.diana.guesses.PreciseGuessBurrow
 import net.sbo.mod.settings.categories.Customization
-import net.sbo.mod.utils.render.WaypointRenderer
 import net.sbo.mod.settings.categories.Diana
 import net.sbo.mod.settings.categories.General.HideOwnWaypoints
 import net.sbo.mod.settings.categories.General.hideOwnWaypoints
 import net.sbo.mod.settings.categories.General.patcherWaypoints
-import net.sbo.mod.utils.chat.Chat
 import net.sbo.mod.utils.Helper
 import net.sbo.mod.utils.Helper.checkDiana
 import net.sbo.mod.utils.Helper.sleep
 import net.sbo.mod.utils.Player
 import net.sbo.mod.utils.SoundHandler.playCustomSound
+import net.sbo.mod.utils.chat.Chat
 import net.sbo.mod.utils.events.Register
 import net.sbo.mod.utils.events.annotations.SboEvent
 import net.sbo.mod.utils.events.impl.game.WorldChangeEvent
+import net.sbo.mod.utils.game.World
 import net.sbo.mod.utils.math.SboVec
+import net.sbo.mod.utils.render.WaypointRenderer
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.CopyOnWriteArrayList
 import kotlin.math.roundToInt
-import net.fabricmc.fabric.api.client.rendering.v1.world.WorldRenderContext
-import net.fabricmc.fabric.api.client.rendering.v1.world.WorldRenderEvents
-import net.sbo.mod.utils.game.World
 
 object WaypointManager {
-    var guessWp: Waypoint? = null
     private val waypoints = ConcurrentHashMap<String, CopyOnWriteArrayList<Waypoint>>()
     var closestWaypoint: Pair<Waypoint?, Double> = null to 1000.0
     val rareMobs: List<String> = listOf(
@@ -42,10 +41,6 @@ object WaypointManager {
     )
 
     fun init() {
-        if (guessWp == null) {
-            guessWp = Waypoint("Guess", 100.0, 100.0, 100.0, type = "guess")
-        }
-
         Register.command("sbosendping") { args ->
             val playerPos = Player.getLastPosition()
             if (args.isNotEmpty()) {
@@ -121,51 +116,29 @@ object WaypointManager {
             val knownBurrows = getWaypointsOfType("burrow")
             val shovelGuesses = getWaypointsOfType("guess")
             val arrowGuesses = getWaypointsOfType("arrow")
+            val rareMobWaypoints = getWaypointsOfType("rareMob")
 
             val posP = SboVec(playerPos.x, playerPos.y, playerPos.z).roundLocationToBlock()
 
-            val allGuesses = shovelGuesses + arrowGuesses
-            val allWaypoints = shovelGuesses + arrowGuesses + knownBurrows
+            val allWaypoints = knownBurrows + shovelGuesses + arrowGuesses + rareMobWaypoints
 
             // These do not change location when using the shovel
-            val allStaticWaypoints = arrowGuesses + knownBurrows
+            val allStaticBurrowWaypoints = knownBurrows + arrowGuesses
 
-            // Remove all waypoints that are 3 blocks or less close to player, under the world (y < 60) or at the exact same position as player.
-            val guessesToRemove = allGuesses
-                .filter { waypoint ->
-                    waypoint.distanceToPlayer() < 3.0 ||
-                            waypoint.pos.y < 60 ||
-                            (waypoint.pos.x == posP.x && waypoint.pos.z == posP.z)
-                }
+            // Remove all waypoints that are under the world (y < 60)
+            val guessesToRemove = allWaypoints.filter { waypoint -> waypoint.pos.y < 60 }
 
             val rareWp = getWaypointsOfType("rareMob")
 
-            // Remove rare mob waypoints that are 3 blocks or less to player
-            if (Diana.removeRareMobwaypoint) {
-                val rareMobsToRemove = rareWp
-                    .filter { waypoint -> waypoint.distanceToPlayer() < 3.0 }
-                    .toList()
-                rareMobsToRemove.forEach { waypoint -> removeWaypoint(waypoint) }
-            }
-
             guessesToRemove.forEach { waypoint ->
                 removeWaypoint(waypoint)
-            }
-
-            // Remove the shovel guess if an arrow guess exist at the same block
-            guessWp?.let { wp ->
-                val guessBlock = wp.pos.roundLocationToBlock()
-                if (wp.distanceToPlayer() < Diana.removeGuessDistance || arrowGuesses.any { it.pos.roundLocationToBlock() == guessBlock }) {
-                    removeAllOfType("guess")
-                    guessWp = null
-                }
             }
 
             // Remove the shovel guess if a known burrow, or an arrow guess exists at the same block, or 3 blocks near it (contrary to the name, precise guess is less precise than arrow guess)
             shovelGuesses.forEach { shovelGuess ->
                 val shovelGuessBlock = shovelGuess.pos.roundLocationToBlock()
                 if (
-                    allStaticWaypoints.any {
+                    allStaticBurrowWaypoints.any {
                         val waypointPos = it.pos
                         val waypointBlock = waypointPos.roundLocationToBlock()
 
@@ -173,7 +146,6 @@ object WaypointManager {
                     }
                 ) {
                     removeAllOfType("guess")
-                    guessWp = null
                 }
             }
 
@@ -204,11 +176,6 @@ object WaypointManager {
                 waypoint.isClosest = waypoint == bestGuessWp
                 waypoint.format(rareWp)
             }
-
-            val shouldLegacyHaveLine = bestGuessWp != null && bestGuessWp.type == "guess" && !bestGuessWp.hidden
-
-            guessWp?.isClosest = shouldLegacyHaveLine
-            guessWp?.format(rareWp)
         }
 
         WorldRenderEvents.BEFORE_TRANSLUCENT.register(WaypointRenderer)
@@ -216,7 +183,6 @@ object WaypointManager {
 
     @SboEvent
     fun onWorldChange(event: WorldChangeEvent) {
-        guessWp?.hide()
         removeAllOfType("world")
         removeAllOfType("guess")
         if (!Diana.dontClearArrowGuess) removeAllOfType("arrow")
@@ -248,7 +214,6 @@ object WaypointManager {
         this.forEachWaypoint { waypoint ->
             waypoint.render(context)
         }
-        this.guessWp?.render(context)
     }
 
     /**
@@ -269,6 +234,20 @@ object WaypointManager {
             closestWaypoint = null to 1000.0
         }
         waypoints[waypoint.type.lowercase()]?.remove(waypoint)
+    }
+
+    /**
+     * Gets a waypoint at a specific position and type, or null if it does not exist.
+     * @param pos The position of the waypoint to get.
+     * @param type The type of the waypoint to get.
+     */
+    fun getWaypointAt(pos: SboVec, type: String): Waypoint? {
+        val list = waypoints[type.lowercase()]
+        val waypoint = list?.find { it.pos.roundLocationToBlock() == pos.roundLocationToBlock() }
+        if (waypoint != null) {
+            return waypoint
+        }
+        return null
     }
 
     /**
@@ -313,17 +292,10 @@ object WaypointManager {
         if (pos == null) return
 
         removeAllOfType("guess")
-        addWaypoint(Waypoint("Guess", pos.x, pos.y, pos.z, type = "guess"))
 
-        if (guessWp == null) {
-            guessWp = Waypoint("Guess", 100.0, 100.0, 100.0, type = "guess")
-        }
-        guessWp?.apply {
-            val position = pos
-            this.pos = position
-
-            val (exists, wp) = waypointExists("burrow", position)
-            this.hidden = exists && wp != null && wp.distanceToPlayer() < 60
+        if (!waypointExists("burrow", pos).first) {
+            val waypoint = Waypoint("Guess", pos.x, pos.y, pos.z, type = "guess")
+            addWaypoint(waypoint)
         }
     }
 
@@ -383,16 +355,6 @@ object WaypointManager {
         return getAllGuessesAndBurrows()
             .filter { !it.hidden }
             .minByOrNull { it.distanceToPlayer() }
-    }
-
-    /**
-     * Gets the closest waypoint of a specific type to a given position.
-     * @param pos The position to find the closest waypoint to.
-     * @param type The type of waypoint to search for.
-     * @return The closest waypoint of the specified type, or null if none are found.
-     */
-    fun getClosestWaypoint(pos: SboVec, type: String): Pair<Waypoint, Double>? {
-        return getClosestWaypointFrom(pos, getWaypointsOfType(type))
     }
 
     private fun getClosestWaypointFrom(pos: SboVec): Pair<Waypoint, Double>? {

--- a/src/main/kotlin/net/sbo/mod/utils/waypoint/WaypointManager.kt
+++ b/src/main/kotlin/net/sbo/mod/utils/waypoint/WaypointManager.kt
@@ -6,13 +6,13 @@ import net.minecraft.client.multiplayer.ClientLevel
 import net.minecraft.core.BlockPos
 import net.sbo.mod.SBOKotlin
 import net.sbo.mod.diana.guesses.PreciseGuessBurrow
+import net.sbo.mod.diana.guesses.ArrowGuessBurrow
 import net.sbo.mod.settings.categories.Customization
 import net.sbo.mod.settings.categories.Diana
 import net.sbo.mod.settings.categories.General.HideOwnWaypoints
 import net.sbo.mod.settings.categories.General.hideOwnWaypoints
 import net.sbo.mod.settings.categories.General.patcherWaypoints
 import net.sbo.mod.utils.Helper
-import net.sbo.mod.utils.Helper.checkDiana
 import net.sbo.mod.utils.Helper.sleep
 import net.sbo.mod.utils.Player
 import net.sbo.mod.utils.SoundHandler.playCustomSound
@@ -25,6 +25,7 @@ import net.sbo.mod.utils.math.SboVec
 import net.sbo.mod.utils.render.WaypointRenderer
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.CopyOnWriteArrayList
+import java.time.Duration
 import kotlin.math.roundToInt
 
 object WaypointManager {
@@ -65,7 +66,7 @@ object WaypointManager {
             val mob = trailing.replace("|", "").trim().lowercase()
             val playername = Player.getName() ?: ""
             if (!channel.contains("Guild")) {
-                if ((!trailing.startsWith(" ") || rareMobs.contains(mob) || Diana.allWaypointsAreInqs) && Diana.receiveRareMob && checkDiana()) {
+                if ((!trailing.startsWith(" ") || rareMobs.contains(mob) || Diana.allWaypointsAreInqs) && Diana.receiveRareMob) {
                     val mobType: Diana.ReceiveList = when (mob) {
                         "minos inquisitor", "inquisitor", "inq" -> Diana.ReceiveList.INQ
                         "king minos", "king" -> Diana.ReceiveList.KING
@@ -142,6 +143,26 @@ object WaypointManager {
                 removeWaypoint(waypoint)
             }
 
+            // Remove shovel guesses pointing to invalid burrow locations
+            shovelGuesses.forEach { shovelGuess ->
+                if (!ArrowGuessBurrow.isBlockValid(shovelGuess.pos)) {
+                    removeWaypoint(shovelGuess)
+                }
+            }
+
+            // Remove arrow guesses pointing to invalid burrow locations after being existing for over 10 seconds (During 10 seconds period, we hide them instead to give time for moveToNext to do its job)
+            arrowGuesses.forEach { arrowGuess ->
+                if (!ArrowGuessBurrow.isBlockValid(arrowGuess.pos)) {
+                    if (arrowGuess.isOlderThan(Duration.ofSeconds(10))) {
+                        removeWaypoint(arrowGuess)
+                    } else {
+                        arrowGuess.inaccurateArrow = true
+                    }
+                } else {
+                    arrowGuess.inaccurateArrow = false
+                }
+            }
+
             // Remove the shovel guess if a known burrow, or an arrow guess exists at the same block, or 3 blocks near it (contrary to the name, precise guess is less precise than arrow guess)
             shovelGuesses.forEach { shovelGuess ->
                 val shovelGuessBlock = shovelGuess.pos.roundLocationToBlock()
@@ -151,25 +172,34 @@ object WaypointManager {
 
                     waypointBlock == shovelGuessBlock || waypointBlock.distanceTo(shovelGuessBlock) <= 3
                 }?.let { staticBurrow ->
-                    if (shovelGuess.timesDug > staticBurrow.timesDug) {
-                        staticBurrow.timesDug = shovelGuess.timesDug
-                    }
-
-                    removeAllOfType("guess")
+                    staticBurrow.carryOverState(shovelGuess)
+                    removeWaypoint(shovelGuess)
                 }
             }
 
-            // Remove the arrow guesses representing the same blocks as an already-known treasure/mob/start burrow, and transfer its timesDug to the known burrow instead if the arrow guess was dug more times than the known burrow
+            // Remove duplicate shovel guesses that are within 30 blocks, or 60 if in an unloaded chunk, of each other
+            shovelGuesses.forEachIndexed { index, shovelGuess ->
+                val shovelGuessBlock = shovelGuess.pos.roundLocationToBlock()
+
+                shovelGuesses.drop(index + 1).firstOrNull { otherGuess ->
+                    shovelGuessBlock.distanceTo(otherGuess.pos.roundLocationToBlock()) <= (if (ArrowGuessBurrow.isBlockValid(shovelGuess.pos) || ArrowGuessBurrow.isBlockValid(otherGuess.pos)) 30 else 60)
+                }?.let { otherGuess ->
+                    val keep = if (shovelGuess.hasStrongerStateThan(otherGuess)) shovelGuess else otherGuess
+                    val remove = if (keep === shovelGuess) otherGuess else shovelGuess
+
+                    keep.carryOverState(remove)
+                    removeWaypoint(remove)
+                }
+            }
+
+            // Remove the arrow guesses representing the same blocks as an already-known treasure/mob/start burrow, and transfer its state to the known burrow instead if the arrow guess was dug more times than the known burrow
             arrowGuesses.forEach { arrowGuess ->
                 val arrowGuessBlock = arrowGuess.pos.roundLocationToBlock()
 
                 knownBurrows.firstOrNull { knownBurrow ->
                     knownBurrow.pos.roundLocationToBlock() == arrowGuessBlock
                 }?.let { knownBurrow ->
-                    if (arrowGuess.timesDug > knownBurrow.timesDug) {
-                        knownBurrow.timesDug = arrowGuess.timesDug
-                    }
-
+                    knownBurrow.carryOverState(arrowGuess)
                     removeWaypoint(arrowGuess)
                 }
             }
@@ -186,13 +216,6 @@ object WaypointManager {
         WorldRenderEvents.BEFORE_TRANSLUCENT.register(WaypointRenderer)
     }
 
-    @SboEvent
-    fun onWorldChange(event: WorldChangeEvent) {
-        removeAllOfType("world")
-        removeAllOfType("guess")
-        if (!Diana.dontClearArrowGuess) removeAllOfType("arrow")
-    }
-
     fun addRareMobWaypoint(player: String, pos: SboVec, mobName: String, playername: String) {
         when (mobName) {
             "minos inquisitor", "inquisitor" -> if (hideOwnWaypoints.contains(HideOwnWaypoints.INQ) && player.contains(playername)) return
@@ -200,11 +223,12 @@ object WaypointManager {
             "manticore" -> if (hideOwnWaypoints.contains(HideOwnWaypoints.MANTICORE) && player.contains(playername)) return
             "sphinx" -> if (hideOwnWaypoints.contains(HideOwnWaypoints.SPHINX) && player.contains(playername)) return
         }
-        addWaypoint(Waypoint(player, pos.x, pos.y, pos.z, ttl = 45, type = "rareMob") )
+        addWaypoint(Waypoint(player, pos.x, pos.y, pos.z, ttl = 45, type = "rareMob"))
     }
 
     fun removeNearbyRareMobWaypoints() {
         removeWithinDistance("rareMob", 30)
+        removeWithinDistance("world", 30)
     }
 
     /**
@@ -295,8 +319,6 @@ object WaypointManager {
      */
     fun updateGuess(pos: SboVec?) {
         if (pos == null) return
-
-        removeAllOfType("guess")
 
         if (!waypointExists("burrow", pos).first) {
             val waypoint = Waypoint("Guess", pos.x, pos.y, pos.z, type = "guess")
@@ -430,7 +452,7 @@ object WaypointManager {
         if (Diana.ignoreYLevel) playerDistance = pos.distanceToIgnoringY(Player.getLastPosition())
 
         val condition1 = playerDistance > (closestDistance + Diana.warpDiff + (closestWarpPoint?.extraBlocks ?: 0))
-        val condition2 = condition1 && (closestWaypoint.second > 60 || getWaypointsOfType("rareMob").isNotEmpty())
+        val condition2 = condition1 && (closestWaypoint.second > 60 || getWaypointsOfType("rareMob").isNotEmpty() || getWaypointsOfType("world").isNotEmpty())
 
         val condition = if (Diana.dontWarpIfBurrowClose) condition2 else condition1
 
@@ -448,15 +470,15 @@ object WaypointManager {
 
     fun warpToInq() {
         val newestInq = getWaypointsOfType("rareMob").maxByOrNull { it.creation }
-        if (newestInq == null) return
-
-        val warp = getClosestWarp(newestInq.pos) ?: return
+        val newestWorldInq = getWaypointsOfType("world").maxByOrNull { it.creation }
+        val pos = newestInq?.pos ?: newestWorldInq?.pos ?: return
+        val warp = getClosestWarp(pos) ?: return
 
         executeWarpCommand(warp)
     }
 
     fun warpBoth() {
-        if (getWaypointsOfType("rareMob").isEmpty()) {
+        if (getWaypointsOfType("rareMob").isEmpty() && getWaypointsOfType("world").isEmpty()) {
             warpToGuess()
         } else {
             warpToInq()

--- a/src/main/kotlin/net/sbo/mod/utils/waypoint/WaypointManager.kt
+++ b/src/main/kotlin/net/sbo/mod/utils/waypoint/WaypointManager.kt
@@ -397,7 +397,7 @@ object WaypointManager {
         var secondClosestDistance = Double.MAX_VALUE
 
         for ((name, warp) in warps) {
-            val distance = if (Diana.ignoreYLevel && warp.ignoreYLevel) pos.distanceToIgnoringY(warp.pos) else pos.distanceTo(warp.pos)
+            val distance = if (Diana.ignoreYLevel) pos.distanceToIgnoringY(warp.pos) else pos.distanceTo(warp.pos)
 
             if (distance < closestDistance) {
                 secondClosestWarp = closestWarp
@@ -420,7 +420,7 @@ object WaypointManager {
             closestDistance = secondClosestDistance
         }
 
-        if (Diana.ignoreYLevel && closestWarpPoint?.ignoreYLevel == true) playerDistance = pos.distanceToIgnoringY(Player.getLastPosition())
+        if (Diana.ignoreYLevel) playerDistance = pos.distanceToIgnoringY(Player.getLastPosition())
 
         val condition1 = playerDistance > (closestDistance + Diana.warpDiff)
         val condition2 = condition1 && (closestWaypoint.second > 60 || getWaypointsOfType("rareMob").isNotEmpty())


### PR DESCRIPTION
- Fixed typos in comments and code, including renaming of onChatMessageCancable --> onChatMessageCancelable.
- Added NonNull annotations to Java code (JSpecify standard).
- Fixed a warning in SBOKotlin.kt about orElse returning Nullable String? whereas we are assigning it to a String by asserting (!!) The return-type of orElse in Java is Nullable, but since we were passing a non-null String and Java inter-op in Kotlin does not treat nullability annotations as strict as Kotlin's non-nullable types, it was just a warning instead of an error. Still good to fix it by enforcing non-nullability.
- Optimized imports.
- Fixed sphinxSinceFood being referenced inside the sphinxSinceLsFood branch of the code in Diana Tracker.
- Fixed if (realCount != -1) being always false due to realCount + 1 before the check.
- Fixed .replace("Manti-core", "MANTI_CORE") not working due to calling .uppercase beforehand, the correct replace target must be uppercase e.g MANTI-CORE.
- Removed all unused methods and turned unused properties to constructor parameters by removing the "val" keyword. The removed methods might be useful in future, but they unnecessarily count to jar size and ktolin compilation speed. Git history is always available to find these methods implementations again to re-add if needed, so remove them.
- Revamp the refreshBurrows logic and add timesDug counter to Waypoints This implements a smart removal feature and removes the promixity (< 3 block to player) removals, along with a new option to show times dug on the burrow text like [1/2].
- Renamed a few options variable names: dianaBurrowGuess --> spadeGuess, dianaBurrowDetect --> closeBurrowDetection
- Fixed weird spacing in the [EXCLUDED] text when Exclude Coins from Profit option is enabled
- Added Waypoint Opacity, Waypoint Text Opacity, Show Distance Cutoff and Show Times Dug options
- Explained a few options better in description, moved title timing options down, removed "Remove Guess When Close" and "Remove Rare Mob Waypoint when near" options The promixiy-based removals are gone, we have smarter removals now.
- Fixed burrows/hr showing as zero after startup before timer has been started at least once
- Removed the legacy guessWp variable, we already addWaypoint a waypoint with type "guess" when using spade shovel guess.