### PR TITLE
Bump mod version to 0.4.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -42,7 +42,7 @@ dgt.loom.loader.use=false
 # Mod properties
 mod.name=SBO
 mod.id=sbo
-mod.version=0.3.0-beta
+mod.version=0.4.0
 mod.group=net.sbo.mod
 mod.description=SBO is the ultimate diana mod for diana nons! FPS friendly, and packed with QOL features!
 


### PR DESCRIPTION
Bumps mod version from 0.3.0-beta to 0.4.0.

As planned in the previous release that the next release would remove the long overdue -beta suffix, this removes it.

Recommended release notes (Will post the raw version in a comment):

# SBO 0.4.0 for Minecraft 26.1.2 and 1.21.11
Note: The work on Minecraft 26.2 support is planned for next release, this is a regular maintenance release for Minecraft versions 26.1.2 and 1.21.11 only.

# Guess & Burrow changes
- Renamed non-working focused color to closest guess color and overhauled how the mod detects closest waypoint for drawing a line or warping purposes. This should improve your burrows/hour rates. Summary of changes is that previously, using shovel manually would override and set that as the closest warp, and the mod would never consider already known treasure/mob burrows for picking closest warp before; now it will. We've also changed the closest waypoint and warp detection logic to update the closest waypoint and warp every tick, instead of every 5 ticks (250 ms --> 50 ms) for better responsiveness.

The closest guess color will be set to purple by default, but is customizable. Please test and give feedback whether or not these changes improves your rates!

We've also made it so the mod can keep track of multiple Spade guesses when you use your shovel.

# Smart removal
Burrow and guess waypoints are now removed smarter; instead of the old removal when near or when clicking with shovel, we keep track of how many times you dug the burrows and remove based on that. We also now infer the type from chat message, to speedily update burrow type when you dug it, instead of relying on particles to appear.

The Rare Mob waypoints are also removed smarter when a rare mob dies.

We've also made it so the waypoints are not removed when changing worlds. If you see any bugs or want to get rid of all waypoints, use /sboclearburrows.

# Dynamic Opacity & Times Dug display
The block higlight of the waypoints the mod adds now have dynamic opacity ranging from fully opaque to 20% transparent when you get close to them, making for a better fresh look. We've also added a [0/2] counter for burrows that goes up as you dig the burrows. These settings are default enabled but can be disabled per preference.

A new Show Distance & Times Dug Cutoff setting related to this feature also exist, set to 50 blocks by default, this makes it so when you are >50 blocks away, the regular distance text like [130m] shows, while you are <50 blocks close instead the Times Dug information (like [0/2]) shows.

# Warp Title
We've added a Warp Title option that shows a title when a warp to a burrow is available, disabled by default for now but might be enabled by default after some tweaks in a future release. Please give feedback!

# Cocooning changes
- Chat based cocoon detection; the mod will now use the chat message to detect cocooned mobs instead of the legacy egg sac player head texture scanner. The new method is more reliable, avoiding false positives for example when cocooning a regular mob right after killing an inquisitor, but will only trigger for yourself and not others.
- The Cocoon! party announce message was also changed to include name of the mob extracted from the chat message; e.g., "Cocooned a Minos Inquisitor!". The same is true for the title which now will show the mob name as the subtitle.
- Fixed cocooned mobs not counting towards trackers and achievements (such as the b2b drop achievements) but only if you cocoon your own mobs. If someone else cocoons your mob sadly it won't be added to the tracker still.
- Enabled cocoon title and cocoon announce to party by default since it is reliable and includes name of the mob now.

# Automatic Session-tracker resetting
- Added an option to reset your Session-tracker automatically on game close. This does not affect Event or the Total trackers and is disabled by default to prevent resetting on upgrade. (Thanks cOnfusi0n1 for the implementation)

# More missing Diana V2 stuff added
- Added Myth the Fish to the Diana Loot HUD. In previous versions, Myth the Fish tracking was fixed, meaning it would track how many you dropped, but it wouldn't show it in the HUD. Now it should.
- Added Myth the Fish to the Past Events GUI similarly, in both per-event and Total overviews.
- Added missing Diana V2 mobs to the Past Events GUI: Sphinxes, Sphinxes (LS), Harpies, Cretan Bulls and Stranded Nymphs and their percentages compared to the total mobs spawned.
- Added Highest Magic Find for Shimmering Wools and Brain Foods to the !mf Party Command and the Magic Find Overlay/HUD.

# Strengthening against rare resets
- The data saving logic was updated to use blocking save when quitting game so that the game waits for the data save to finish before quitting, which avoids the game closing before save is fully complete, causing data resetting rarely.
- The data saving logic was updated to write to a temporary file first and then replace the original file with the temporary file only after the (temporary) file was fully written to successfully to avoid rarely corrupting your data and causing it to reset on e.g., electricity loss during a save. Atomic move is used if available to perform the in-place replace.

# New pause menu location
- We've moved the SBO button in the pause menu to actually fit in the vanilla Pause Menu instead of being on the side, so please check it out!

# Better loot announcer
- We've fixed loot announcer in chat option not working, and enhanced how the party loot announce works. It will now include coins profit now, and it should trigger for more drops such as Minos Relic, Crown of Greed, Daedalus Stick and Myth the Fish.

# Live update HUDs
- We've made it so the Diana Mobs and Diana Loot HUDs update every second. Previously, only your Playtime line was updated, making BPH value show inaccurate values and only update when you dig a burrow or open an inventory. Now your Burrows/hr value should update every second as well!

# Burrow waypoint cleanup
- The mod will now remove waypoints representing the same block. If spade guess represent the same block or 3 blocks near an Arrow Guess, it will be removed. If an arrow guess represents exactly the same block as an already known burrow (Treasure/Mob/Start) it will be removed. Additionally, if a spade guess represents an invalid block (non-grass) it will be removed as well.

# Experimental options
- Per user feedback, we have added new options to override behaviour of mod in some cases. Please note that these options might become default in the future after tweaking them, but are default disabled for this release.

- Always Assume LS: This makes it so that when a rare mob dies near 30 blocks or less of you, the mod counts it as loot share even if you do not get the LOOT SHARE! message. This might cause false positives, but the 30 block check should make it less enough to be worth in general, compared to only counting when getting the LOOT SHARE! message.

- Ignore Y Level: This makes it so the Y-distance is ignored when calculating closest warp and closest burrow, since some warps e.g., Castle and Wizard spawn you at a high Y-level, and Y distance is easier to travel.

- Bad Warp Distance: Currently only implemented for Crypt and Castle. When set to 0, this is disabled. When set to a distance, such as 100 blocks, and best warp is Crypt, but Castle is the second best warp and the Crypt warp is only 100 blocks closer than Castle, this makes the mod still prioritize Castle as the best warp.

# Bug fixes
- Fixed the /sboresetsession command to use the same code path as the "Reset Session" button in the Diana Loot HUD. It should now reset playtime and other session data correctly.
- Fixed the /sbopastevents GUI overflowing after the addition of new items such as Mythological Dyes, Shimmering Wools and Manti-cores.
- Fixed burrow and guess waypoints rendering outside of The Hub, such as in Crimson Isle. The waypoints are not removed so they will re-appear when you join Hub back, they are just hidden in other islands now.
- Fixed warp keys not working at start of event when lots of users are sending requests to the Mayor API causing rate-limits by removing the need to have Diana active for the keys to work. The condition was instead changed to be in the Hub island and have a spade in inventory. This makes it also work in Alpha Hypixel Network additionally, since the Mayor API check only passed normally if Diana was mayor in the main server before.
- Fixed minotaurs since stick being referenced as minos since stick in the Diana Stats overlay.
- Fixed empty magic find text on rare drop party announce when using the default custom rare drop messages. This might not work if you use a different format in your custom messages.
- Fixed a possible ConcurrentModificationException when using Rare Mob Higlight.
- Fixed JSON deserialization errors related to unknown keys; the JSON deserialization code paths will now ignore unknown keys for forward-compatibility with backend changes.
- Fixed minor issues in several game utility classes.
- Fixed keybinds such as warp and send coords not working if a conflicting key was set.
- Fixed hover text on HUD lines not working since MC 1.21.8 (only worked on 1.21.5, the original version hover logic was coded for), you should now be able to see LS odds and amounts on combined loot trackers when you over over them, and four-eyed fish coins when you hover over the coins line in the loot tracker again.
- Fixed the Max Carnival achievement unlocking with perks at 1 tier before the max and renamed it to "Max Diana Carnival" to make the intent clearer.
- Fixed changing treasure/mob burrow colors not updating color of the already existing waypoints for them.
- Fixed burrows/hr not showing at startup for about 36 seconds or when it was zero.
- Fixed an Arrow guess and a known-Burrow guess waypoint being displayed for the same block if you get close enough to detect it as Treasure/Mob/Start burrow then go 60 blocks far from it.
- Fixed inactive time compensation not working as expected and lowering your burrows/hour from being AFK each time it is paused.
- Fixed Loot Tracker and Loot Announce features not working in the Alpha Hypixel Network.
- Fixed the SPR (Shelmet/Plushie/Remedies) sound option not doing anything, and renamed it to Misc Drop Sound and made it work on Crown Of Greed, Washed-Up Souvenir, Cretan Urn, Hilt of Revelations as well in addition to Dwarf Turtle Shelmet, Crochet Tiger Plushie and Antique Remedies drops.
- Fixed Sphinxes Since LS Brain Food chat message instead showing Sphinxes Since regular Brain Food.
- Fixed the mob not removing the Mob burrow waypoint when you die to a mob.
- Fixed warping to rare mob waypoints received from other mods not working in some cases.

# Accessibility updates
- Added a button to open the past events menu to the settings.
- Added a assume muted option, which sends all messages that were supposed to be sent in party chat to client chat instead, will show only for yourself. This avoids the giant text that pops up when mod tries to send party messages that shows your mute, remaining time, server rules, etc., and will show you your party command output when someone else uses it (e.g., if someone else uses !profit in a party with you, you will get a client-side message with the profit data that you can share in an external platform).

# Customization
- Added title timing options for rare mob titles. (Thanks cOnfusi0n1 for the implementation)
- Added AFK pause time option to configure after how much time trackers pause in seconds.
- Added an option to enable showing an use spade title when a burrow chain ends and there's no other guess or burrows to go to.
- Added an option to disable the beacon beam going to the sky for waypoints and guesses.
- Added an option (NPC Price Overrides) to make several frequently NPC-sold items (Cretan Urn, Dwarf Turtle Shelmet, Antique Remedies, Washed Up Souvenir, Crochet Tiger Plushie, Hilt of Revelations) always take the NPC price in Diana Profit calculator even if AH price is higher.
- Added an option (Exclude Coins from Profit) to exclude coins gained from Profit tracker, useful if using a non-1B crown since the coins are consumed in reality.
- Added Rare Mob and Other Waypoint Color settings

# Config renames
We've renamed a few options to avoid confusion:
 Guess Color --> Other Guess Color
 Diana Burrow Guess --> Spade Guess
 Diana Burrow Detect --> Close Burrow Detection

# Default config tweaks
NOTE: These changes will not affect you (except the new AFK pause time option default of 60 seconds) if you are upgrading from a previous release (please review and enable anything you might want yourself from the below list), as your settings are not overridden with the new defaults unless you delete your configs or if you are a new SBO user.

- Enabled tps command by default.
- Enabled party finder auto requeue by default.
- Enabled no shuriken overlay by default.
- Enabled rare loot title and party announcer by default.
- Enabled Diana Loot HUD by default.
- The newly added AFK pause time option is now set to 60 seconds by default, rather than the hardcoded 1.5 minutes it was before the option was added.

# Performance
- Improved performance of overlays further by only updating if changed.
- Improved performance of the playtime tracking code.
- Improved performance of item metadata lookups such as skyblock ID, uuid, timestamp, display name and lore lines.

# Removed
- Removed "Remove Rare Mob Beam Distance". If you were relying on this to disable beacon beams by setting it to a too high option, use instead the new toggle "Show Beacon Beam" to disable beacon beams completely. The option was only supposed to work on beams for rare mobs, but was working on all beams, and is removed to reduce confusion since there's now a separate toggle.
- Removed "Dont Clear Arrow Guess on World Change", since waypoints are now never cleared on world change.

# Cleanup
- Removed Minecraft 1.21.10 support as Hypixel dropped support.
- Removed all unused code in the project to reduce tech debt.

# Misc
- Added !version party command that shows your SBO and Minecraft version.
- Added drop amount to the default rare drop party announce messages. Also removed unnecessary delayed sending for most mobs and drops.
- The sound handling for custom resourcepack sounds should be more user friendly now. There's also a new /sbots command to test sounds.
- Strengthened against the "You are doing this too fast!" errors whenever the mod tries to send a party chat message in your behalf.
- All waypoints and guesses created by mod now have an expiration time of 30 minutes, Hypixel itself seems to change a burrow's location after 30 minutes of no interaction with it, so this aligns with that.
- Added an outdated SBO version toast if a mod update is available and the user is running a known outdated version; hopefully this reduces the amount of people running old versions with bugs we already fixed.
- Added error logging when no AH or BZ price data is available for any item (no internet connection). If at least 1 price information is available (e.g 1 previous API request succeeded) this error won't be shown to you but still logged to latest.log. Previously, no error at all was logged or shown in chat.
- Added a feedback message when the mod registers a lootshare mob.
- Removed the ! from end of drop names in Loot Announcer to match the Hypixel format.

# Technical changes
- The 26.1 version now targets 26.1.2 as the baseline instead of 26.1.
- The required Fabric Loader, Fabric API and Fabric Language Kotlin versions are updated. You might need to update your mods and loader.
- The version constraint of the mod for 1.21.11 was changed to an exact match while 26.1.2 onward uses allow-patch-level updates (~) now so that your game will not crash when you try to use a wrong jar but rather fail with a nice Fabric Loader GUI that you have the wrong version.
- Refactored Party Commands to clean up its code. All party commands should work same as before as this an in-code only change, please report any bugs.
- The event system of the mod now supports event priorities and an unregister callback.
- Performed general code cleanup to improve performance, fix correctness issues, and remove unnecessary code constructs.
- The allowed blocks above ground constant used in Arrow Guess is updated for the new hub. This might result in better solver guess results.
- Refactored Mayor detection utilities along with Item utilities.