### PR TITLE
Remove warp delay setting

### DIFF
--- a/src/main/kotlin/net/sbo/mod/settings/categories/Diana.kt
+++ b/src/main/kotlin/net/sbo/mod/settings/categories/Diana.kt
@@ -137,13 +137,6 @@ object Diana : CategoryKt("Diana") {
         this.description = Literal("Blocks at which good warps are prioritized over bad ones (Currently only Castle and Crypt). For example, if you set it to 100, when the Crypt warp is the closest warp to a burrow, and the Castle is second closest, with Crypt warp being only 100 blocks or less closer than Castle, Castle will be preferred over Crypt warp for accessibility, as it can be faster to AOTV out of castle to reach the burrow whereas Crypt is longer to get out. (0 to disable)")
     }
 
-    var warpDelay by int(0) {
-        this.range = 0..1000
-        this.slider = true
-        this.name = Literal("Warp Delay (<X>ms)")
-        this.description = Literal("The delay bevor you can warp after guessing with spade. (0 to disable)")
-    }
-
     init {
         separator {
             this.title = "Diana Tracker"

--- a/src/main/kotlin/net/sbo/mod/utils/SboKeyBinds.kt
+++ b/src/main/kotlin/net/sbo/mod/utils/SboKeyBinds.kt
@@ -9,9 +9,14 @@ import net.sbo.mod.SBOKotlin
 import net.sbo.mod.utils.chat.Chat
 import net.sbo.mod.utils.waypoint.WaypointManager
 import org.lwjgl.glfw.GLFW
+import java.util.concurrent.TimeUnit
 
 object SboKeyBinds {
-    private data class KeyPressState(var isHeldDown: Boolean = false, var lastActivation: Long = 0)
+    private data class KeyPressState(
+        var isHeldDown: Boolean = false,
+        var lastActivationNanos: Long = 0L
+    )
+
     private val keyStates = mutableMapOf<String, KeyPressState>()
     private val SBO_CATEGORY = KeyMapping.Category(SBOKotlin.id(owner = "sbo-kotlin", path = "keybinds"))
 
@@ -59,14 +64,23 @@ object SboKeyBinds {
         handlePressAction(keyBinding, 0L, action)
     }
 
-    private fun handlePressAction(keyBinding: KeyMapping, cooldownMillis: Long, action: () -> Unit) {
+    private fun handlePressAction(
+        keyBinding: KeyMapping,
+        cooldownMillis: Long,
+        action: () -> Unit
+    ) {
         val state = keyStates.getOrPut(keyBinding.name) { KeyPressState() }
 
         if (keyBinding.isDown) {
-            val currentTime = System.currentTimeMillis()
-            if (!state.isHeldDown && currentTime - state.lastActivation > cooldownMillis) {
+            val currentTimeNanos = System.nanoTime()
+
+            if (
+                !state.isHeldDown &&
+                currentTimeNanos - state.lastActivationNanos >=
+                TimeUnit.MILLISECONDS.toNanos(cooldownMillis)
+            ) {
                 action()
-                state.lastActivation = currentTime
+                state.lastActivationNanos = currentTimeNanos
                 state.isHeldDown = true
             }
         } else {

--- a/src/main/kotlin/net/sbo/mod/utils/waypoint/WaypointManager.kt
+++ b/src/main/kotlin/net/sbo/mod/utils/waypoint/WaypointManager.kt
@@ -488,7 +488,6 @@ object WaypointManager {
     var tryWarp: Boolean = false
     fun executeWarpCommand(warp: String) {
         if (World.getWorld() != "Hub" || !Helper.hasSpade) return
-        if (Diana.warpDelay > 0 && System.currentTimeMillis() - PreciseGuessBurrow.lastGuessTime < Diana.warpDelay) return
         if (warp.isNotEmpty() && !tryWarp) {
             tryWarp = true
             Chat.command("warp $warp")

--- a/src/main/kotlin/net/sbo/mod/utils/waypoint/WaypointManager.kt
+++ b/src/main/kotlin/net/sbo/mod/utils/waypoint/WaypointManager.kt
@@ -461,7 +461,6 @@ object WaypointManager {
 
     fun warpToGuess() {
         val bestGuess = getBestGuess() ?: return
-        if (bestGuess.hidden) return
         getClosestWarp(bestGuess.pos)?.let {
             executeWarpCommand(it)
         } ?:

--- a/src/main/kotlin/net/sbo/mod/utils/waypoint/WaypointManager.kt
+++ b/src/main/kotlin/net/sbo/mod/utils/waypoint/WaypointManager.kt
@@ -5,6 +5,7 @@ import net.fabricmc.fabric.api.client.rendering.v1.world.WorldRenderEvents
 import net.minecraft.client.multiplayer.ClientLevel
 import net.minecraft.core.BlockPos
 import net.sbo.mod.SBOKotlin
+import net.sbo.mod.SBOKotlin.mc
 import net.sbo.mod.diana.guesses.PreciseGuessBurrow
 import net.sbo.mod.diana.guesses.ArrowGuessBurrow
 import net.sbo.mod.settings.categories.Customization
@@ -461,10 +462,7 @@ object WaypointManager {
 
     fun warpToGuess() {
         val bestGuess = getBestGuess() ?: return
-        getClosestWarp(bestGuess.pos)?.let {
-            executeWarpCommand(it)
-        } ?:
-        return
+        getClosestWarp(bestGuess.pos)?.let { executeWarpCommand(it) } ?: return
     }
 
     fun warpToInq() {
@@ -485,13 +483,16 @@ object WaypointManager {
     }
 
     var tryWarp: Boolean = false
+
     fun executeWarpCommand(warp: String) {
         if (World.getWorld() != "Hub" || !Helper.hasSpade) return
         if (warp.isNotEmpty() && !tryWarp) {
             tryWarp = true
             Chat.command("warp $warp")
             sleep(500) {
-                tryWarp = false
+                mc.execute {
+                    tryWarp = false
+                }
             }
         }
     }


### PR DESCRIPTION
Some users are still having problems with Warp Keys not working after the consumeClick to isDown change. I have no idea, but let's reduce possibility of failure here by avoiding 1 more condition; the warp delay setting checks from last spade use, which most people do not need to use spade except at start or rarely when running out of burrows due to arrow guess existing, so this might be a possible failure case for the warp keys not working. Even if its not the reason, we do need to reduce the option clutter in the mod to avoid confusion of new users anyways, so this should be a positive change.