### PR TITLE
Fix weird guesses

### DIFF
--- a/src/main/kotlin/net/sbo/mod/diana/guesses/ArrowGuessBurrow.kt
+++ b/src/main/kotlin/net/sbo/mod/diana/guesses/ArrowGuessBurrow.kt
@@ -298,6 +298,7 @@ object ArrowGuessBurrow {
     }
 
     internal fun isBlockValid(pos: SboVec): Boolean {
+        if (!HUB_BOUNDS.isInside(pos)) return false 
         if (!pos.isInLoadedChunk()) return true
         return isBlockTrulyValid(pos)
     }

--- a/src/main/kotlin/net/sbo/mod/utils/waypoint/WaypointManager.kt
+++ b/src/main/kotlin/net/sbo/mod/utils/waypoint/WaypointManager.kt
@@ -134,8 +134,8 @@ object WaypointManager {
                 }
             }
 
-            // Remove all waypoints that are under the world (y < 60)
-            val guessesToRemove = allWaypoints.filter { waypoint -> waypoint.pos.y < 60 }
+            // Remove all waypoints that are under the world (y < 60) and above the world (y > 200)
+            val guessesToRemove = allWaypoints.filter { waypoint -> waypoint.pos.y < 60 || waypoint.pos.y >= 200 }
 
             val rareWp = getWaypointsOfType("rareMob")
 
@@ -153,7 +153,7 @@ object WaypointManager {
             // Remove arrow guesses pointing to invalid burrow locations after being existing for over 10 seconds (During 10 seconds period, we hide them instead to give time for moveToNext to do its job)
             arrowGuesses.forEach { arrowGuess ->
                 if (!ArrowGuessBurrow.isBlockValid(arrowGuess.pos)) {
-                    if (arrowGuess.isOlderThan(Duration.ofSeconds(10))) {
+                    if (arrowGuess.isOlderThan(Duration.ofSeconds(15))) {
                         removeWaypoint(arrowGuess)
                     } else {
                         arrowGuess.inaccurateArrow = true
@@ -170,7 +170,7 @@ object WaypointManager {
                 allStaticBurrowWaypoints.firstOrNull { staticBurrow ->
                     val waypointBlock = staticBurrow.pos.roundLocationToBlock()
 
-                    waypointBlock == shovelGuessBlock || waypointBlock.distanceTo(shovelGuessBlock) <= 3
+                    waypointBlock == shovelGuessBlock || waypointBlock.distanceTo(shovelGuessBlock) <= 4
                 }?.let { staticBurrow ->
                     staticBurrow.carryOverState(shovelGuess)
                     removeWaypoint(shovelGuess)
@@ -182,7 +182,7 @@ object WaypointManager {
                 val shovelGuessBlock = shovelGuess.pos.roundLocationToBlock()
 
                 shovelGuesses.drop(index + 1).firstOrNull { otherGuess ->
-                    shovelGuessBlock.distanceTo(otherGuess.pos.roundLocationToBlock()) <= (if (ArrowGuessBurrow.isBlockValid(shovelGuess.pos) || ArrowGuessBurrow.isBlockValid(otherGuess.pos)) 30 else 60)
+                    shovelGuessBlock.distanceTo(otherGuess.pos.roundLocationToBlock()) <= (if (ArrowGuessBurrow.isBlockValid(shovelGuess.pos) || ArrowGuessBurrow.isBlockValid(otherGuess.pos)) 30 else 70)
                 }?.let { otherGuess ->
                     val keep = if (shovelGuess.hasStrongerStateThan(otherGuess)) shovelGuess else otherGuess
                     val remove = if (keep === shovelGuess) otherGuess else shovelGuess

--- a/src/main/kotlin/net/sbo/mod/utils/waypoint/WaypointManager.kt
+++ b/src/main/kotlin/net/sbo/mod/utils/waypoint/WaypointManager.kt
@@ -130,7 +130,6 @@ object WaypointManager {
             this.forEachWaypoint { waypoint ->
                 if (waypoint.ttl > 0 && waypoint.creation + waypoint.ttl * 1000L < System.currentTimeMillis()) {
                     removeWaypoint(waypoint)
-                    return@forEachWaypoint
                 }
             }
 
@@ -182,7 +181,7 @@ object WaypointManager {
                 val shovelGuessBlock = shovelGuess.pos.roundLocationToBlock()
 
                 shovelGuesses.drop(index + 1).firstOrNull { otherGuess ->
-                    shovelGuessBlock.distanceTo(otherGuess.pos.roundLocationToBlock()) <= (if (ArrowGuessBurrow.isBlockValid(shovelGuess.pos) || ArrowGuessBurrow.isBlockValid(otherGuess.pos)) 30 else 70)
+                    shovelGuessBlock.distanceTo(otherGuess.pos.roundLocationToBlock()) <= (if (ArrowGuessBurrow.isBlockValid(shovelGuess.pos) || ArrowGuessBurrow.isBlockValid(otherGuess.pos)) 30 else 75)
                 }?.let { otherGuess ->
                     val keep = if (shovelGuess.hasStrongerStateThan(otherGuess)) shovelGuess else otherGuess
                     val remove = if (keep === shovelGuess) otherGuess else shovelGuess


### PR DESCRIPTION
- Check for HUB_BOUNDS in isBlockValid
- Remove any burrow above Y >= 200 (The top point of the mountain, conservative value still, might find a top-grass block Y level later)
- Slight adjustments; 10 seconds to 15 seconds hide time before removal for arrow guess, 4 block deduplication area for shovel near arrow/burrow waypoint, 70 block deduplication area for shovel guesses near each other that return false from isBlockValid

This reduces likelihood of false positive guesses and waypoints. Does not fully resolve yet (Occassionally you can see a moving arrow guess for a short time, and sometimes shovel guess is very inaccurate, even though we check isBlockValid, if its in an unloaded chunk it causes confusion for the user since isBlockValid returns true for unloaded chunks), but should be a much better experience now.