### PR TITLE
Bump send delay to 250ms

### DIFF
--- a/src/main/kotlin/net/sbo/mod/general/PartyCommands.kt
+++ b/src/main/kotlin/net/sbo/mod/general/PartyCommands.kt
@@ -14,6 +14,7 @@ import net.sbo.mod.utils.Helper.removeFormatting
 import net.sbo.mod.utils.Player
 import net.sbo.mod.utils.SboTimerManager
 import net.sbo.mod.utils.chat.Chat
+import net.sbo.mod.utils.chat.ChatMessageQueue
 import net.sbo.mod.utils.data.SboDataObject.dianaTrackerMayor
 import net.sbo.mod.utils.data.SboDataObject.sboData
 import net.sbo.mod.utils.events.Register
@@ -256,5 +257,8 @@ object PartyCommands {
     }
 
     private fun sendCommand(cmd: String) = Chat.command(cmd)
-    private fun sendResponse(msg: String) = Chat.pc(msg)
+    private fun sendResponse(msg: String) {
+        ChatMessageQueue.onCommandOrMessageSent() // always force the 250ms delay just in case for now since some users report hypixel blocks sometimes
+        Chat.pc(msg)
+    }
 }

--- a/src/main/kotlin/net/sbo/mod/utils/chat/ChatMessageQueue.kt
+++ b/src/main/kotlin/net/sbo/mod/utils/chat/ChatMessageQueue.kt
@@ -9,7 +9,7 @@ import net.sbo.mod.utils.events.impl.game.SentCommandEvent
 import net.sbo.mod.utils.events.impl.game.SentMessageEvent
 
 object ChatMessageQueue {
-    private const val DELAY_NANOS = 200_000_000L
+    private const val DELAY_NANOS = 250_000_000L
     private val queue = ObjectArrayFIFOQueue<String>(1)
 
     private var lastSentAt = 0L
@@ -37,6 +37,7 @@ object ChatMessageQueue {
     }
 
     fun send(player: LocalPlayer, message: String) {
+        onCommandOrMessageSent() // should be called by mixin, but just in case it doesn't for some reason
         player.connection.sendChat(message)
     }
 


### PR DESCRIPTION
Some users reported having issues when running self-party commands after the ChatMessageQueue refactor.

Most likely explanation is that previously Thread.sleep on Virtual Thread was sleeping more than 200ms. The JavaDoc of Thread.sleep says that the given millis parameter is the minimum amount of sleep time, and the actual sleep time can be higher (but not less). Let's bump the delay to 250ms. Reportedly did not fix the issue for one user, but it might be that they failed to properly override actions version, since Prism Launcher is sometimes weird and prefers Modrinth version over manually added actions jar. Worst case we come back and revert the commit or try alternative fix if the issue persists after next Modrinth release.