### PR TITLE
Use simpler cocoon and ls messages

### DIFF
--- a/src/main/kotlin/net/sbo/mod/diana/DianaTracker.kt
+++ b/src/main/kotlin/net/sbo/mod/diana/DianaTracker.kt
@@ -178,7 +178,7 @@ object DianaTracker {
 
     fun onMobSpawn(mob: String, fromCocoon: Boolean = false) {
         lastSpawnedMob = mob
-        if (fromCocoon) Chat.chat("§6[SBO] §eTracking cocooned mob: $mob")
+        if (fromCocoon) Chat.chat("§6[SBO] §eRegistered cocooned mob: $mob")
         when (mob) {
             "King Minos" -> {
                 DianaMobDetect.onRareSpawn(mob)

--- a/src/main/kotlin/net/sbo/mod/utils/Helper.kt
+++ b/src/main/kotlin/net/sbo/mod/utils/Helper.kt
@@ -67,7 +67,7 @@ object Helper {
     }
 
     private fun notifyUserOfLs(mob: String) {
-        Chat.chat("§6[SBO] §eTracking lootshare mob: $mob")
+        Chat.chat("§6[SBO] §eRegistered Lootshare $mob!")
     }
 
     fun init() {
@@ -119,7 +119,7 @@ object Helper {
                 if (lsOverride) onLootShare() // makes the getSecondsPassed condition below always pass
                 if (getSecondsPassed(lastLootShare) < 2 && !hasTrackedInq) {
                     hasTrackedInq = true
-                    notifyUserOfLs(name)
+                    notifyUserOfLs("Minos Inquisitor")
                     DianaTracker.trackItem("MINOS_INQUISITOR_LS", 1)
                     sleep(2000) {
                         hasTrackedInq = false
@@ -132,7 +132,7 @@ object Helper {
                 if (lsOverride) onLootShare() // makes the getSecondsPassed condition below always pass
                 if (getSecondsPassed(lastLootShare) < 2 && !hasTrackedKing) {
                     hasTrackedKing = true
-                    notifyUserOfLs(name)
+                    notifyUserOfLs("King Minos")
                     DianaTracker.trackItem("KING_MINOS_LS", 1)
                     sleep(2000) {
                         hasTrackedKing = false
@@ -144,7 +144,7 @@ object Helper {
                 removeNearbyRareMobWaypoints()
                 if (getSecondsPassed(lastLootShare) < 2 && !hasTrackedSphinx) {
                     hasTrackedSphinx = true
-                    notifyUserOfLs(name)
+                    notifyUserOfLs("Sphinx")
                     DianaTracker.trackItem("SPHINX_LS", 1)
                     sleep(2000) {
                         hasTrackedSphinx = false
@@ -157,7 +157,7 @@ object Helper {
                 if (lsOverride) onLootShare() // makes the getSecondsPassed condition below always pass
                 if (getSecondsPassed(lastLootShare) < 2 && !hasTrackedManti) {
                     hasTrackedManti = true
-                    notifyUserOfLs(name)
+                    notifyUserOfLs("Manticore")
                     DianaTracker.trackItem("MANTICORE_LS", 1)
                     sleep(2000) {
                         hasTrackedManti = false


### PR DESCRIPTION
- Tracking --> Registered to avoid confusion.
- Use display name instead of full display name of mob at death (previously would show like [Lv. 120] Exalted Minos Inquisitor 0/80M) for LS confirmation message