### PR TITLE
Fix Chim LS to Inquisitor LS ratio in party command

### DIFF
--- a/src/main/kotlin/net/sbo/mod/general/PartyCommands.kt
+++ b/src/main/kotlin/net/sbo/mod/general/PartyCommands.kt
@@ -106,7 +106,7 @@ object PartyCommands {
             fmt("Relics", dianaTrackerMayor.items.MINOS_RELIC, "MINOS_RELIC", "MINOS_CHAMPION")
         },
         PartyCommand(listOf("!chimls", "!chimerals", "!bookls", "!lschim", "!lsbook", "!lootsharechim", "!lschimera"), { settings.dianaPartyCommands }) {
-            fmt("Chimera LS", dianaTrackerMayor.items.CHIMERA_LS, "CHIMERALS", "MINOS_INQUISITOR_LS")
+            fmt("Chimera LS", dianaTrackerMayor.items.CHIMERA_LS, "CHIMERA_LS", "MINOS_INQUISITOR_LS")
         },
         PartyCommand(listOf("!core", "!manticore"), { settings.dianaPartyCommands }) {
             fmt("Cores", dianaTrackerMayor.items.MANTI_CORE, "MANTI_CORE", "MANTICORE")


### PR DESCRIPTION
Fixes !chimls LS book to inq ratio always showing as 0.00%.