### PR TITLE
Fix Use Spade showing more often than necessary

### DIFF
--- a/src/main/kotlin/net/sbo/mod/diana/guesses/ArrowGuessBurrow.kt
+++ b/src/main/kotlin/net/sbo/mod/diana/guesses/ArrowGuessBurrow.kt
@@ -247,8 +247,10 @@ object ArrowGuessBurrow {
             allGuesses.add(GuessEntry(withinRange))
         }
 
-        if (Diana.showTitleWhenInaccurate) {
-            if (withinRange.size > 1) {
+        val withinRangeFirst = withinRange.getOrNull(0)
+
+        if (Diana.showTitleWhenFailure) {
+            if (withinRangeFirst == null) {
                 if (!spadeTitleShown) BurrowDetector.requestSpade()
                 spadeTitleShown = true
             } else {
@@ -256,7 +258,7 @@ object ArrowGuessBurrow {
             }
         }
 
-        return withinRange.getOrNull(0)
+        return withinRangeFirst
     }
 
     private fun checkMoveGuess() {

--- a/src/main/kotlin/net/sbo/mod/settings/categories/Diana.kt
+++ b/src/main/kotlin/net/sbo/mod/settings/categories/Diana.kt
@@ -87,9 +87,9 @@ object Diana : CategoryKt("Diana") {
         this.description = Literal("Shows a beacon beam for waypoints going to the sky if enabled.")
     }
 
-    var showTitleWhenInaccurate by boolean(false) {
-        this.name = Literal("Show Title When Inaccurate")
-        this.description = Literal("Shows a title to guess normally when the arrow guess is inaccurate")
+    var showTitleWhenFailure by boolean(false) {
+        this.name = Literal("Show Title When Failure")
+        this.description = Literal("Shows a title to guess normally when the arrow guess fails to solve the burrow")
     }
 
     var showTitleWhenChainEnd by boolean(false) {


### PR DESCRIPTION
There is no need to use spade if arrow guess did not return null, it usually returns a precise enough location that is less than 3 blocks to the correct block, and using the spade more often causes more trouble than it solves, since precise guess contrary to the name is less precise than arrow guess.

Renamed the option to "Show Use Spade on Failure" instead to match the new behavior of showing when solver returns null, instead of more than 1 result.