### PR TITLE
Fix missing config check for known burrow from chat

### DIFF
--- a/src/main/kotlin/net/sbo/mod/diana/burrows/BurrowDetector.kt
+++ b/src/main/kotlin/net/sbo/mod/diana/burrows/BurrowDetector.kt
@@ -130,6 +130,8 @@ object BurrowDetector {
         source: String = "particle",
         carriedTimesDug: Int? = null
     ) {
+        if (!Diana.closeBurrowDetection) return
+
         val posString = "${pos.x.toInt()} ${pos.y.toInt()} ${pos.z.toInt()}"
 
         if (burrowsHistory.contains(posString)) return


### PR DESCRIPTION
If "Close Burrow Detection" is false, we should not try to infer type from chat message and add a waypoint.