### PR TITLE
Fix crown of greed party announcing bugs

### DIFF
--- a/src/main/kotlin/net/sbo/mod/diana/DianaTracker.kt
+++ b/src/main/kotlin/net/sbo/mod/diana/DianaTracker.kt
@@ -119,17 +119,19 @@ object DianaTracker {
 
     fun trackWithPickuplog(item: Item) {
         sleep (1000) {
-            if (Helper.getSecondsPassed(item.creation) > 5) return@sleep
-//            if (!dianaMobDiedRecently(3)) return@sleep
-            when (item.itemId) {
-                "HILT_OF_REVELATIONS" -> onRareDropFromMob("Hilt Of Revelations", rare = false,
-                    trackLootshare = false,
-                    magicFind = 0
-                )
-                "CROWN_OF_GREED" -> onRareDropFromMob("Crown Of Greed", rare = true,
-                    trackLootshare = false,
-                    magicFind = 0
-                )
+            mc.execute {
+                if (Helper.getSecondsPassed(item.creation) > 5) return@sleep
+    //            if (!dianaMobDiedRecently(3)) return@sleep
+                when (item.itemId) {
+                    "HILT_OF_REVELATIONS" -> onRareDropFromMob("Hilt Of Revelations", rare = false,
+                        trackLootshare = false,
+                        magicFind = 0
+                    )
+                    "CROWN_OF_GREED" -> onRareDropFromMob("Crown Of Greed", rare = true,
+                        trackLootshare = false,
+                        magicFind = 0
+                    )
+                }
             }
         }
     }
@@ -696,7 +698,7 @@ object DianaTracker {
 
             if (isCoG) {
                 // CoG is no longer a treasure and instead dropped by Minos King; worth announcing
-                announceLootToParty("Crown of Greed", "Crown of Greed$mfPrefix", amount = dianaTrackerMayor.items.CROWN_OF_GREED)
+                announceLootToParty("Crown of Greed", "Crown of Greed$mfPrefix", amount = dianaTrackerMayor.items.CROWN_OF_GREED + 1) // we didn't call trackItem yet, so add + 1
             }
         }
 

--- a/src/main/kotlin/net/sbo/mod/diana/DianaTracker.kt
+++ b/src/main/kotlin/net/sbo/mod/diana/DianaTracker.kt
@@ -1,5 +1,6 @@
 package net.sbo.mod.diana
 
+import net.sbo.mod.SBOKotlin.mc
 import net.sbo.mod.diana.achievements.AchievementManager
 import net.sbo.mod.diana.achievements.AchievementManager.trackMagicFind
 import net.sbo.mod.diana.achievements.AchievementManager.unlockAchievement
@@ -120,8 +121,8 @@ object DianaTracker {
     fun trackWithPickuplog(item: Item) {
         sleep (1000) {
             mc.execute {
-                if (Helper.getSecondsPassed(item.creation) > 5) return@sleep
-    //            if (!dianaMobDiedRecently(3)) return@sleep
+                if (Helper.getSecondsPassed(item.creation) > 5) return@execute
+    //            if (!dianaMobDiedRecently(3)) return@execute
                 when (item.itemId) {
                     "HILT_OF_REVELATIONS" -> onRareDropFromMob("Hilt Of Revelations", rare = false,
                         trackLootshare = false,


### PR DESCRIPTION
- Wrap code after sleep(1000) that runs in a separate thread in trackWithPickuplog with a mc.execute to force main thread so that isItemOnCooldown.getOrPut can't return stale result due to race condition. This prevents the party announce from ever triggering 2 times from a single crown of greed drop (was a rare bug that happened once during 6-hour jerry diana).

- Fix crown of greed count in the party loot announce showing 1 less than actual and starting from 0