### PR TITLE
Cleanup unused RenderLayers and RenderPipelines

### DIFF
--- a/src/main/kotlin/net/sbo/mod/compat/IrisCompatibility.kt
+++ b/src/main/kotlin/net/sbo/mod/compat/IrisCompatibility.kt
@@ -5,17 +5,11 @@ import net.irisshaders.iris.api.v0.IrisProgram
 import net.sbo.mod.utils.render.SboRenderPipelines
 
 object IrisCompatibility {
-
     fun init() {
         IrisApi.getInstance().apply {
-            assignPipeline(SboRenderPipelines.FILLED_BOX_THROUGH_WALLS, IrisProgram.BASIC)
-            assignPipeline(SboRenderPipelines.LINES, IrisProgram.LINES)
             assignPipeline(SboRenderPipelines.LINES_THROUGH_WALLS, IrisProgram.LINES)
-            assignPipeline(SboRenderPipelines.BEACON_BEAM_OPAQUE, IrisProgram.BEACON_BEAM)
             assignPipeline(SboRenderPipelines.BEACON_BEAM_OPAQUE_THROUGH_WALLS, IrisProgram.BEACON_BEAM)
-            assignPipeline(SboRenderPipelines.BEACON_BEAM_TRANSLUCENT, IrisProgram.BEACON_BEAM)
             assignPipeline(SboRenderPipelines.BEACON_BEAM_TRANSLUCENT_THROUGH_WALLS, IrisProgram.BEACON_BEAM)
         }
     }
-
 }

--- a/src/main/kotlin/net/sbo/mod/utils/render/RenderUtils3D.kt
+++ b/src/main/kotlin/net/sbo/mod/utils/render/RenderUtils3D.kt
@@ -29,7 +29,6 @@ object RenderUtils3D {
         colorComponents: FloatArray,
         hexColor: Int,
         alpha: Float,
-        throughWalls: Boolean,
         drawLine: Boolean,
         lineWidth: Float,
         renderBeam: Boolean
@@ -37,8 +36,7 @@ object RenderUtils3D {
         drawFilledBox(
             pos,
             colorComponents,
-            alpha,
-            throughWalls
+            alpha
         )
 
         if (drawLine) {
@@ -47,7 +45,6 @@ object RenderUtils3D {
                 pos,
                 colorComponents,
                 lineWidth,
-                throughWalls,
                 alpha
             )
         }
@@ -56,10 +53,8 @@ object RenderUtils3D {
             renderBeaconBeam(
                 context,
                 pos,
-                colorComponents,
-                true
+                colorComponents
             )
-
         }
 
         if (text.isNotEmpty() && text != "§7") {
@@ -70,8 +65,7 @@ object RenderUtils3D {
                 text,
                 hexColor,
                 Customization.waypointTextShadow,
-                Customization.waypointTextScale/100.0,
-                throughWalls
+                Customization.waypointTextScale/100.0
             )
         }
     }
@@ -81,13 +75,11 @@ object RenderUtils3D {
      * @param pos The position in the world where the box should be drawn.
      * @param colorComponents The RGB color components as a FloatArray (0.0 to 1.0).
      * @param alpha The alpha value for transparency (0.0 to 1.0).
-     * @param throughWalls Whether the box should be drawn through walls.
      */
-    fun drawFilledBox(
+    private fun drawFilledBox(
         pos: SboVec,
         colorComponents: FloatArray,
         alpha: Float,
-        throughWalls: Boolean
     ) {
         val r = (colorComponents[0].coerceIn(0f, 1f) * 255).toInt()
         val g = (colorComponents[1].coerceIn(0f, 1f) * 255).toInt()
@@ -95,11 +87,7 @@ object RenderUtils3D {
         val a = (alpha.coerceIn(0f, 1f) * 255).toInt()
         val argbColor = (a shl 24) or (r shl 16) or (g shl 8) or b
         val bPos = pos.toBlockPos().immutable()
-        if (throughWalls) {
-            Gizmos.cuboid(AABB.encapsulatingFullBlocks(bPos, bPos), GizmoStyle.fill(argbColor)).setAlwaysOnTop()
-        } else {
-            Gizmos.cuboid(AABB.encapsulatingFullBlocks(bPos, bPos), GizmoStyle.fill(argbColor))
-        }
+        Gizmos.cuboid(AABB.encapsulatingFullBlocks(bPos, bPos), GizmoStyle.fill(argbColor)).setAlwaysOnTop()
     }
 
     /**
@@ -111,15 +99,14 @@ object RenderUtils3D {
      * @param shadow Whether to draw the text with a shadow.
      * @param scale The scale of the text.
      */
-    fun drawString(
+    private fun drawString(
         context: WorldRenderContext,
         pos: SboVec,
         yOffset: Double,
         text: String,
         color: Int,
         shadow: Boolean,
-        scale: Double,
-        throughWalls: Boolean
+        scale: Double
     ) {
         context.pushPop {
             val camera = context.getCamera()
@@ -144,7 +131,7 @@ object RenderUtils3D {
 
             val consumers = context.consumers()
 
-            val layerType = if (throughWalls) Font.DisplayMode.SEE_THROUGH else Font.DisplayMode.NORMAL
+            val layerType = Font.DisplayMode.SEE_THROUGH
 
             textRenderer.drawInBatch(
                 text,
@@ -167,15 +154,13 @@ object RenderUtils3D {
      * @param target The target position in the world.
      * @param color The RGB color of the line as a FloatArray (0.0 to 1.0).
      * @param lineWidth The width of the line.
-     * @param throughWalls Whether the line should be drawn through walls.
      * @param alpha The alpha value for transparency (0.0 to 1.0).
      */
-    fun drawLineFromCursor(
+    private fun drawLineFromCursor(
         context: WorldRenderContext,
         target: SboVec,
         color: FloatArray,
         lineWidth: Float,
-        throughWalls: Boolean,
         alpha: Float = 0.5f
     ) {
         context.pushPop {
@@ -199,7 +184,7 @@ object RenderUtils3D {
             val ny = upVec.y.toFloat()
             val nz = upVec.z.toFloat()
 
-            val renderLayer = if (throughWalls) SboRenderLayers.LINES_THROUGH_WALLS else SboRenderLayers.LINES
+            val renderLayer = SboRenderLayers.LINES_THROUGH_WALLS
             val buffer = consumers.getBuffer(renderLayer)
             val matrixEntry = last()
 
@@ -221,11 +206,10 @@ object RenderUtils3D {
      * @param colorComponents The RGB color components as a FloatArray (0.0 to
      * @param phase Whether the beam should render through walls.
      */
-    fun renderBeaconBeam(
+    private fun renderBeaconBeam(
         ctx: WorldRenderContext,
         vec: SboVec,
-        colorComponents: FloatArray,
-        phase: Boolean = false
+        colorComponents: FloatArray
     ) {
         val player = mc.player ?: return
         if (vec.center().distanceTo(player.x, player.y, player.z) < 8) return
@@ -243,8 +227,7 @@ object RenderUtils3D {
                 consumers,
                 partialTicks,
                 world.gameTime,
-                Color(beamColor[0], beamColor[1], beamColor[2]).rgb,
-                phase
+                Color(beamColor[0], beamColor[1], beamColor[2]).rgb
             )
         }
     }
@@ -253,11 +236,10 @@ object RenderUtils3D {
         vertices: MultiBufferSource,
         partialTicks: Float,
         worldTime: Long,
-        color: Int,
-        phase: Boolean = false
+        color: Int
     ) {
-        val opaqueLayer = if (phase) SboRenderLayers.BEACON_BEAM_OPAQUE_THROUGH_WALLS else SboRenderLayers.BEACON_BEAM_OPAQUE
-        val translucentLayer = if (phase) SboRenderLayers.BEACON_BEAM_TRANSLUCENT_THROUGH_WALLS else SboRenderLayers.BEACON_BEAM_TRANSLUCENT
+        val opaqueLayer = SboRenderLayers.BEACON_BEAM_OPAQUE_THROUGH_WALLS
+        val translucentLayer = SboRenderLayers.BEACON_BEAM_TRANSLUCENT_THROUGH_WALLS
         val heightScale = 1f
         val height = 320
         val innerRadius = 0.2f

--- a/src/main/kotlin/net/sbo/mod/utils/render/SboRenderLayers.kt
+++ b/src/main/kotlin/net/sbo/mod/utils/render/SboRenderLayers.kt
@@ -6,14 +6,6 @@ import net.minecraft.client.renderer.rendertype.RenderType
 
 object SboRenderLayers {
     @JvmField
-    val LINES: RenderType = RenderType.create(
-        "sbo/lines",
-        RenderSetup.builder(SboRenderPipelines.LINES)
-            .sortOnUpload()
-            .createRenderSetup()
-    )
-
-    @JvmField
     val LINES_THROUGH_WALLS: RenderType = RenderType.create(
         "sbo/lines_through_walls",
         RenderSetup.builder(SboRenderPipelines.LINES_THROUGH_WALLS)
@@ -21,25 +13,10 @@ object SboRenderLayers {
             .createRenderSetup()
     )
 
-    val BEACON_BEAM_OPAQUE: RenderType = RenderType.create(
-        "sbo/beacon_beam_opaque",
-        RenderSetup.builder(SboRenderPipelines.BEACON_BEAM_OPAQUE)
-            .withTexture("Sampler0", BeaconRenderer.BEAM_LOCATION)
-            .createRenderSetup()
-    )
-
     val BEACON_BEAM_OPAQUE_THROUGH_WALLS: RenderType = RenderType.create(
         "sbo/beacon_beam_opaque_through_walls",
         RenderSetup.builder(SboRenderPipelines.BEACON_BEAM_OPAQUE_THROUGH_WALLS)
             .withTexture("Sampler0", BeaconRenderer.BEAM_LOCATION)
-            .createRenderSetup()
-    )
-
-    val BEACON_BEAM_TRANSLUCENT: RenderType = RenderType.create(
-        "sbo/beacon_beam_translucent",
-        RenderSetup.builder(SboRenderPipelines.BEACON_BEAM_TRANSLUCENT)
-            .withTexture("Sampler0", BeaconRenderer.BEAM_LOCATION)
-            .sortOnUpload()
             .createRenderSetup()
     )
 

--- a/src/main/kotlin/net/sbo/mod/utils/render/SboRenderPipelines.kt
+++ b/src/main/kotlin/net/sbo/mod/utils/render/SboRenderPipelines.kt
@@ -12,29 +12,6 @@ import net.sbo.mod.SBOKotlin
 
 /** Add new pipelines to [net.sbo.mod.compat.IrisCompatibility] */
 object SboRenderPipelines {
-    val FILLED_BOX_THROUGH_WALLS: RenderPipeline = RenderPipelines.register(
-        RenderPipeline.builder(RenderPipelines.DEBUG_FILLED_SNIPPET)
-            .withLocation(SBOKotlin.id("pipeline/debug_filled_box_through_walls"))
-            .withVertexFormat(DefaultVertexFormat.POSITION_COLOR, Mode.TRIANGLE_STRIP)
-            //#if MC < 26.1
-            .withDepthTestFunction(DepthTestFunction.NO_DEPTH_TEST)
-            //#endif
-            .build()
-    )
-
-    val LINES: RenderPipeline = RenderPipelines.register(
-        RenderPipeline.builder(RenderPipelines.LINES_SNIPPET)
-            .withLocation(SBOKotlin.id("pipeline/line_strip"))
-            .withVertexFormat(DefaultVertexFormat.POSITION_COLOR_NORMAL_LINE_WIDTH, Mode.LINES)
-            .withCull(false)
-            //#if MC < 26.1
-            .withBlend(BlendFunction.TRANSLUCENT)
-            .withDepthWrite(true)
-            .withDepthTestFunction(DepthTestFunction.LEQUAL_DEPTH_TEST)
-            //#endif
-            .build()
-    )
-
     val LINES_THROUGH_WALLS: RenderPipeline = RenderPipelines.register(
         RenderPipeline.builder(RenderPipelines.LINES_SNIPPET)
             .withLocation(SBOKotlin.id("pipeline/line_through_walls"))
@@ -49,23 +26,11 @@ object SboRenderPipelines {
             .build()
     )
 
-    val BEACON_BEAM_OPAQUE: RenderPipeline = RenderPipeline.builder(RenderPipelines.BEACON_BEAM_SNIPPET)
-        .withLocation(SBOKotlin.id("beacon_beam_opaque"))
-        .build()
-
     val BEACON_BEAM_OPAQUE_THROUGH_WALLS: RenderPipeline = RenderPipeline.builder(RenderPipelines.BEACON_BEAM_SNIPPET)
         .withLocation(SBOKotlin.id("beacon_beam_opaque_through_walls"))
         //#if MC < 26.1
         .withDepthWrite(false)
         .withDepthTestFunction(DepthTestFunction.NO_DEPTH_TEST)
-        //#endif
-        .build()
-
-    val BEACON_BEAM_TRANSLUCENT: RenderPipeline = RenderPipeline.builder(RenderPipelines.BEACON_BEAM_SNIPPET)
-        .withLocation(SBOKotlin.id("beacon_beam_translucent"))
-        //#if MC < 26.1
-        .withDepthWrite(false)
-        .withBlend(BlendFunction.TRANSLUCENT)
         //#endif
         .build()
 

--- a/src/main/kotlin/net/sbo/mod/utils/waypoint/Waypoint.kt
+++ b/src/main/kotlin/net/sbo/mod/utils/waypoint/Waypoint.kt
@@ -231,7 +231,6 @@ class Waypoint(
             rgbAndHex.rgb,
             applyAlpha(rgbAndHex.hex, waypointTextOpacity),
             waypointOpacity,
-            true,
             this.line,
             Diana.dianaLineWidth.toFloat(),
             Diana.showBeaconBeam


### PR DESCRIPTION
This makes upgrading to new Minecraft versions simpler since we need to maintain less custom RenderLayers and RenderPipelines.

The "throughWalls" and "phase" parameters passed were effectively always true, since they were all called from renderWaypoint, and Waypoint.kt always passed the throughWalls parameter as true, so the non-through walls variants of the render layers and pipelines were effectively dead code and unnecessary maintenance burden. Marked functions not called outside the class and only inside renderWaypoint as private as well.

The FILLED_BOX_THROUGH_WALLS was entirely unused except inside IrisCompatibility.kt, preventing IDE from reporting it as unused, but I have also cleaned that up here.