### PR TITLE
Other small tweaks

### DIFF
--- a/src/main/kotlin/net/sbo/mod/diana/achievements/AchievementManager.kt
+++ b/src/main/kotlin/net/sbo/mod/diana/achievements/AchievementManager.kt
@@ -348,6 +348,8 @@ object AchievementManager {
         }
     }
 
+    val COA_MF_PATTERN = Pattern.compile("\\+([0-9]*\\.?[0-9]+)✯ Magic Find ✿")
+
     fun trackCOA() {
         val helmet = mc.player?.inventory?.getItem(39) ?: ItemStack.EMPTY
         val lookup = ItemLookup(helmet)
@@ -357,9 +359,7 @@ object AchievementManager {
 
         val mf = lookup.loreList
             .map { it.removeFormatting() }
-            .getValueFromLine(
-                Pattern.compile("\\+([0-9]*\\.?[0-9]+)✯ Magic Find ✿")
-            )
+            .getValueFromLine(COA_MF_PATTERN)
             .toDouble()
 
         when (mf) {

--- a/src/main/kotlin/net/sbo/mod/diana/guesses/ArrowGuessBurrow.kt
+++ b/src/main/kotlin/net/sbo/mod/diana/guesses/ArrowGuessBurrow.kt
@@ -265,7 +265,7 @@ object ArrowGuessBurrow {
         if (allGuesses.isEmpty()) return
         val player = SBOKotlin.mc.player ?: return
         val hasSpade = InventoryUtils.isItemHeld("SPADE", 1.seconds)
-        val burrowLocations = BurrowDetector.burrows.values.map { it.waypoint?.pos ?: SboVec(0.0, 0.0, 0.0) }
+        val burrowLocations = BurrowDetector.burrows.values.asSequence().map { it.waypoint?.pos ?: SboVec.ZERO }.toHashSet()
         val playerPos = player.position().toSboVec()
 
         for (guess in allGuesses) {

--- a/src/main/kotlin/net/sbo/mod/utils/waypoint/Waypoint.kt
+++ b/src/main/kotlin/net/sbo/mod/utils/waypoint/Waypoint.kt
@@ -35,13 +35,13 @@ class Waypoint(
     val x: Double,
     val y: Double,
     val z: Double,
-    val ttl: Int = 1800,
+    val ttl: Long = 1800,
     val type: String = "normal",
     var line: Boolean = false
 ) {
     var pos: SboVec = SboVec(this.x, this.y, this.z)
     var hidden: Boolean = false
-    val creation: Long = System.currentTimeMillis()
+    val creationNs: Long = System.nanoTime()
     var formatted: Boolean = false
     var distanceRaw: Double = 0.0
     var distanceText: String = ""
@@ -212,7 +212,7 @@ class Waypoint(
     }
 
     fun isOlderThan(duration: Duration): Boolean {
-        return System.currentTimeMillis() - this.creation > duration.toMillis()
+        return this.creationNs + duration.toNanos() < System.nanoTime()
     }
 
     fun render(context: WorldRenderContext) {

--- a/src/main/kotlin/net/sbo/mod/utils/waypoint/WaypointManager.kt
+++ b/src/main/kotlin/net/sbo/mod/utils/waypoint/WaypointManager.kt
@@ -27,6 +27,7 @@ import net.sbo.mod.utils.render.WaypointRenderer
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.CopyOnWriteArrayList
 import java.time.Duration
+import java.util.concurrent.TimeUnit
 import kotlin.math.roundToInt
 
 object WaypointManager {
@@ -118,29 +119,33 @@ object WaypointManager {
             val knownBurrows = getWaypointsOfType("burrow")
             val shovelGuesses = getWaypointsOfType("guess")
             val arrowGuesses = getWaypointsOfType("arrow")
-            val rareMobWaypoints = getWaypointsOfType("rareMob")
 
             val posP = SboVec(playerPos.x, playerPos.y, playerPos.z).roundLocationToBlock()
-
-            val allWaypoints = knownBurrows + shovelGuesses + arrowGuesses + rareMobWaypoints
 
             // These do not change location when using the shovel
             val allStaticBurrowWaypoints = knownBurrows + arrowGuesses
 
             // Remove all TTL expired waypoints
+            val currentTime = System.nanoTime()
+
             this.forEachWaypoint { waypoint ->
-                if (waypoint.ttl > 0 && waypoint.creation + waypoint.ttl * 1000L < System.currentTimeMillis()) {
+                if (waypoint.ttl > 0L && currentTime - waypoint.creationNs > TimeUnit.SECONDS.toNanos(waypoint.ttl)) {
                     removeWaypoint(waypoint)
                 }
             }
 
-            // Remove all waypoints that are under the world (y < 60) and above the world (y > 200)
-            val guessesToRemove = allWaypoints.filter { waypoint -> waypoint.pos.y < 60 || waypoint.pos.y >= 200 }
+            // Remove all waypoints that are not in radius of typical burrow locations x y z
+            this.forEachWaypoint { waypoint ->
+                val underWorld = waypoint.pos.y < 60
+                val aboveWorld = waypoint.pos.y > 100
+                val outsideZ = waypoint.pos.z > 205
+                val outsideX = waypoint.pos.x > 175
+                val outsideNegativeZ = waypoint.pos.z < 0 && -waypoint.pos.z > 208
+                val outsideNegativeX = waypoint.pos.x < 0 && -waypoint.pos.x > 283
 
-            val rareWp = getWaypointsOfType("rareMob")
-
-            guessesToRemove.forEach { waypoint ->
-                removeWaypoint(waypoint)
+                if (underWorld || aboveWorld || outsideZ || outsideX || outsideNegativeZ || outsideNegativeX) {
+                    removeWaypoint(waypoint)
+                }
             }
 
             // Remove shovel guesses pointing to invalid burrow locations
@@ -163,21 +168,21 @@ object WaypointManager {
                 }
             }
 
-            // Remove the shovel guess if a known burrow, or an arrow guess exists at the same block, or 3 blocks near it (contrary to the name, precise guess is less precise than arrow guess)
+            // Remove the shovel guess if a known burrow, or an arrow guess exists at the same block, or 30 blocks near it (contrary to the name, precise guess is less precise than arrow guess)
             shovelGuesses.forEach { shovelGuess ->
                 val shovelGuessBlock = shovelGuess.pos.roundLocationToBlock()
 
                 allStaticBurrowWaypoints.firstOrNull { staticBurrow ->
                     val waypointBlock = staticBurrow.pos.roundLocationToBlock()
 
-                    waypointBlock == shovelGuessBlock || waypointBlock.distanceTo(shovelGuessBlock) <= 4
+                    waypointBlock == shovelGuessBlock || waypointBlock.distanceTo(shovelGuessBlock) <= 30
                 }?.let { staticBurrow ->
                     staticBurrow.carryOverState(shovelGuess)
                     removeWaypoint(shovelGuess)
                 }
             }
 
-            // Remove duplicate shovel guesses that are within 30 blocks, or 60 if in an unloaded chunk, of each other
+            // Remove duplicate shovel guesses that are within 30 blocks, or 75 if in an unloaded chunk, of each other
             shovelGuesses.forEachIndexed { index, shovelGuess ->
                 val shovelGuessBlock = shovelGuess.pos.roundLocationToBlock()
 
@@ -206,6 +211,8 @@ object WaypointManager {
 
             closestWaypoint = getClosestWaypointFrom(playerPos) ?: (null to 1000.0)
             val bestGuessWp = getBestGuess()
+
+            val rareWp = getWaypointsOfType("rareMob")
 
             this.forEachWaypoint { waypoint ->
                 waypoint.isClosest = waypoint == bestGuessWp
@@ -405,10 +412,11 @@ object WaypointManager {
     fun getClosestWarp(pos: SboVec): String? {
         var warps = hubWarps.filter { it.value.unlocked }.mapValues { it.value }
         for (warp in Diana.allowedWarps) {
-            if (additionalHubWarps.containsKey(warp.name.lowercase())) {
-                val additionalWarp = additionalHubWarps[warp.name.lowercase()]
+            val warpName = warp.name.lowercase()
+            if (additionalHubWarps.containsKey(warpName)) {
+                val additionalWarp = additionalHubWarps[warpName]
                 if (additionalWarp != null && additionalWarp.unlocked) {
-                    warps = warps + (warp.name.lowercase() to additionalWarp)
+                    warps = warps + (warpName to additionalWarp)
                 }
             }
         }
@@ -465,8 +473,8 @@ object WaypointManager {
     }
 
     fun warpToInq() {
-        val newestInq = getWaypointsOfType("rareMob").maxByOrNull { it.creation }
-        val newestWorldInq = getWaypointsOfType("world").maxByOrNull { it.creation }
+        val newestInq = getWaypointsOfType("rareMob").maxByOrNull { it.creationNs }
+        val newestWorldInq = getWaypointsOfType("world").maxByOrNull { it.creationNs }
         val pos = newestInq?.pos ?: newestWorldInq?.pos ?: return
         val warp = getClosestWarp(pos) ?: return
 


### PR DESCRIPTION
- Use cached Pattern in AchievementManager for CoA Magic Find pattern
- Use Set instead of List (.filter results in List) before .contains check inside loop in ArrowGuessBurrow#checkMoveGuess and use SboVec.ZERO instead of allocating a new each time
- Convert ttl parameter to Long and use nanoTime for better accuracy, faster time query from clocksource and avoiding overflows
- Deduplicate warp.name.lowercase() calls by saving to a local variable inside getClosestWarp
- Move rareWp variable down just before its used
- Fix comment still referencing 60 instead of 75
- Bump from 4 blocks to 30 blocks for removing shovel waypoints near arrow guess or known burrow waypoints (Shovel guess sometimes results in a Guess near them, but still imprecise and far)
- Remove allWaypoints and use existing forEachWaypoint, remove unused rareMobWaypoints local variables
- Add basic X Y Z radius checks to remove inaccurate waypoints, highest grass block in new hub seems to be below y 100, and same for x/z, tested on Alpha