### PR TITLE
Bump version to 0.4.1

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -42,7 +42,7 @@ dgt.loom.loader.use=false
 # Mod properties
 mod.name=SBO
 mod.id=sbo
-mod.version=0.4.0
+mod.version=0.4.1
 mod.group=net.sbo.mod
 mod.description=SBO is the ultimate diana mod for diana nons! FPS friendly, and packed with QOL features!
 


### PR DESCRIPTION
Bumps mod version to 0.4.1.

Recommended release notes:

---

# SBO 0.4.1 for Minecraft 26.1.2 and 1.21.11

# Note on Minecraft 26.2 support
This release only supports Minecraft 26.1.2 and 1.21.11. Minecraft 26.2 support is planned for a future release, please be patient.

# Note on solver accuracy
You should set your Render Distance to at least 10 and preferably have a mod like Hold That Chunk V2 or Bobby with Dynamic World Management ON for solver to work with better accuracy, as we can't check blocks in unloaded chunks. If you see a wrong Guess far away, getting near it might cause it to be removed since we check for the grass block when the chunk the guess is in gets loaded, and otherwise can only remove wrong guesses based on if the X Y Z radius is outside the hub bounds from opposite ends' highest/lowest points (conservative value to not remove any guess that might be on a valid block).

As always, remember to type /sboclearburrows if there is any guess or burrow waypoint that is stuck and won't go away (This will clear all current waypoints and guesses; so try going close and digging first to see if it goes away).

Please report any issues you encounter in our Discord server!

# Loot announce enhancements
- Added Loot Announce (Client-side message + Title + Party Announce) for Braided Griffin Feather drops.
- Added LS clarification and LS amount along with explicit total mention for Lootshare Loot Announce - e.g., will show like `[SBO] RARE DROP! Chimera (+566 ✯ Magic Find) (LS) Total #5 LS #1 (+41.3m coins)` in the party chat. This change does not affect you if you use custom messages, but we would recommend using the standard messages, as some features like price profit and ls clarifier/ls amount parameters are not yet added to the custom message.

# Bug fixes
- Fixed Shovel guesses sometimes showing very high Y coordinate guesses and persisting.
- Fixed Shovel guesses sometimes showing Guesses that are on very far islands than Hub; they will now be cleaned up automatically. Note that it might still sometimes show a Guess on other island's close parts to valid locations, such as Spider's Den if a burrow is near the back of portal to the spider's den. The Spade Guess is overall less accurate than Arrow Guess and so we only recommend using spade/shovel at the start or if the mod tells you to from the "Show Title When Chain End" and "Show Title When Failure" options. If you still get bugged waypoints you can type /sboclearburrows to reset them. Alternatively, you can dig the block of the guess with shovel which will remove the waypoint from the Hypixel feedback sound and particle when digging a grass block that doesn't have a burrow. We are aware that sometimes you can see a moving arrow guess waypoint for a short time and are working to resolve that as well in the future.
- Fixed Mob/Treasure burrow waypoints still being added even if Close Burrow Detection is turned off due to a forgotten config check on the new chat-based burrow type inference that runs if the particle detection doesn't work.
- Fixed Lootshare Chimera to Lootshare Inquisitor ratio always showing as 0.00% in the !lschim party command.
- Fixed Party Commands causing "Woah slow down, you're doing that too fast!" error when using the commands yourself for some people.
- Fixed Crown Of Greed party announce rarely triggering two times.
- Fixed Crown of Greed party announce showing amount one less than actual and starting from zero instead of one.
- Fixed "Show Title When Inaccurate" requesting you to use spade more often than necessary, renamed it to "Show Title When Failure", it will now only show if arrow guess fails; previously shown if more than 2 candidate blocks (The first block is accurate enough most of the time).
- Fixed game crashing when launching on Lunar Client due to a PauseMenuScreen mixin failure. Note that while we try best-effort support, we do not actually test our stuff in Lunar Client and only fix issues as they are reported by users; so you might have all sorts of issues.

# Misc
- Tweaked a few messages such as "Tracking lootshare mob: [Lv. 120] Empyrean Minos Inquisitor 0/80M" into "Registered Lootshare Minos Inquisitor!" and "Tracking cocooned mob: Minos Inquisitor" into "Registered cocooned mob: Minos Inquisitor" to avoid confusion with what "tracking" means to the end user, and reducing visual clutter from the display name of the mob including it's HP at death, causing confusion with the 0/80M part.
- Removed [WIP] prefix from Repeateable Achievements option since it was default enabled for a few releases anyways and seemed to work fine with no reported bugs.
- Added missing credits to the Credits screen (SidOfThe7Cs for Arrow guess).
- Merged "Burrow Line" and "Guess Line" optios to a single option "Guess & Burrow Line", this the feature that draws line to the closest burrow. You'd rarely want to disable one of them but keep the other enabled, so there is no point having seperate options. We are trying to reduce option clutter in the mod to make new user experience better (less confusion on configuring the mod).
- Removed the "Warp Delay" setting, as it wasn't widely used to warrant a setting and only worked for spade guessing, and was complicating warp keybind handling.

# Technical changes
- Updated Gradle build tool to 9.6.0 from 9.5.1.
- Updated checkout action from v6 to v7.
- Updated bundled UniversalCraft and Elementa from versions 494 and 743 to versions 505 and 745.
- Updated bundled ResourcefulConfig for 1.21.11 from version 3.11.2 to 3.11.3.
- Cleaned up unused custom RenderLayers and RenderPipelines from the mod and the Iris compatibility layer.
- Improved thread-safety of setting the tryWarp variable.
- Improved performance slightly by using precompiled Regexes and converting List to Set for contains lookups.
- Refactored keybind handling slightly to use System.nanoTime() to not depend on system time for last key press detection and trigger if time is exactly equal to the last press cooldown as well in addition to more.
- Refactored processBlockInteraction in DianaEvents to deduplicate code.