### PR TITLE
Various enhancements

### DIFF
--- a/src/main/kotlin/net/sbo/mod/compat/IrisCompatibility.kt
+++ b/src/main/kotlin/net/sbo/mod/compat/IrisCompatibility.kt
@@ -7,7 +7,6 @@ import net.sbo.mod.utils.render.SboRenderPipelines
 object IrisCompatibility {
     fun init() {
         IrisApi.getInstance().apply {
-            assignPipeline(SboRenderPipelines.LINES_THROUGH_WALLS, IrisProgram.LINES)
             assignPipeline(SboRenderPipelines.BEACON_BEAM_OPAQUE_THROUGH_WALLS, IrisProgram.BEACON_BEAM)
             assignPipeline(SboRenderPipelines.BEACON_BEAM_TRANSLUCENT_THROUGH_WALLS, IrisProgram.BEACON_BEAM)
         }

--- a/src/main/kotlin/net/sbo/mod/diana/guesses/ArrowGuessBurrow.kt
+++ b/src/main/kotlin/net/sbo/mod/diana/guesses/ArrowGuessBurrow.kt
@@ -82,7 +82,9 @@ object ArrowGuessBurrow {
 
     private var lastBlockClicked: SboVec? = null
 
-    private val allGuesses = CopyOnWriteArrayList<GuessEntry>()
+    val recentClickedBlocks = TimeLimitedSet<SboVec>(3.seconds)
+
+    val allGuesses = CopyOnWriteArrayList<GuessEntry>()
 
     @SboEvent
     fun onReceiveParticle(event: PacketReceiveEvent) {
@@ -306,8 +308,13 @@ object ArrowGuessBurrow {
     }
 
     internal fun isBlockTrulyValid(pos: SboVec): Boolean {
-        val isGround = pos.getBlockAt() == Blocks.GRASS_BLOCK
+        val block = pos.getBlockAt()
+        val isGrass = pos.getBlockAt() == Blocks.GRASS_BLOCK
+        val isAir = pos.getBlockAt() == Blocks.AIR
+        val isGround = isGrass || (isAir && recentClickedBlocks.contains(pos))
+
         val isValidBlockAbove = pos.up().getBlockAt() in allowedBlocksAboveGround
+
         return isGround && isValidBlockAbove
     }
 

--- a/src/main/kotlin/net/sbo/mod/diana/guesses/GuessEntry.kt
+++ b/src/main/kotlin/net/sbo/mod/diana/guesses/GuessEntry.kt
@@ -12,12 +12,6 @@ class GuessEntry(val guesses: List<SboVec>) {
 
     fun contains(vec: SboVec): Boolean = guesses.contains(vec)
 
-    fun removeGuesses() {
-        guesses.forEach {
-            WaypointManager.removeArrowGuess(it)
-        }
-    }
-
     fun moveToNext(): Boolean {
         val current = getCurrent()
         val currentWaypoint = WaypointManager.getWaypointAt(current, "arrow")

--- a/src/main/kotlin/net/sbo/mod/diana/guesses/PreciseGuessBurrow.kt
+++ b/src/main/kotlin/net/sbo/mod/diana/guesses/PreciseGuessBurrow.kt
@@ -54,7 +54,7 @@ object PreciseGuessBurrow {
         val guessPosition = this.guessBurrowLocation() ?: return
         finalLocation = guessPosition.down(0.5).roundLocationToBlock()
         finalLocation = guessPosition.down(0.5).roundLocationToBlock()
-        WaypointManager.updateGuess(finalLocation)
+        WaypointManager.addShovelGuess(finalLocation)
         newBurrow = false
     }
 

--- a/src/main/kotlin/net/sbo/mod/guis/AchievementsGUI.kt
+++ b/src/main/kotlin/net/sbo/mod/guis/AchievementsGUI.kt
@@ -9,6 +9,7 @@ import gg.essential.elementa.constraints.*
 import gg.essential.elementa.dsl.*
 import gg.essential.universal.UKeyboard
 import net.minecraft.ChatFormatting
+import net.minecraft.network.chat.TextColor
 import net.sbo.mod.SBOKotlin.mc
 import net.sbo.mod.diana.achievements.Achievement
 import net.sbo.mod.diana.achievements.AchievementManager
@@ -325,8 +326,16 @@ class AchievementsGUI : WindowScreen(ElementaVersion.V10) {
             val posY = spacingY + (row * (achievementBoxHeight + spacingY))
             lastY = posY
             val borderColor = if (achievement.isUnlocked(true)) Color(0, 255, 0) else Color(255, 0, 0)
-            val achievementColor =  if (achievement.rarity != "Celestial") Color(
-                ChatFormatting.getByCode(achievement.color[1])?.color ?: 0xFFFFFF) else Color(0x7D00FF)
+            val achievementColor = if ("Celestial" != achievement.rarity) {
+                Color(
+                    ChatFormatting.getByCode(achievement.color[1])
+                        ?.let(TextColor::fromLegacyFormat)
+                        ?.getValue()
+                        ?: 0xFFFFFF
+                )
+            } else {
+                Color(0x7D00FF)
+            }
 
             val roundedOutline = UIRoundedRectangle(5f).constrain {
                 x = posX.pixels

--- a/src/main/kotlin/net/sbo/mod/overlays/DianaLoot.kt
+++ b/src/main/kotlin/net/sbo/mod/overlays/DianaLoot.kt
@@ -234,6 +234,7 @@ object DianaLoot : DirtyFlushableOverlay() {
 
         if (screenOpen) {
             lines.addAll(listOf(changeView, delimiter, changeSellType))
+            if (Diana.lootTracker == Diana.Tracker.SESSION) lines.add(resetSession)
         }
     }
 
@@ -286,7 +287,6 @@ object DianaLoot : DirtyFlushableOverlay() {
 
         stats.add(timerLine)
         if (type == Diana.Tracker.TOTAL) stats.add(OverlayTextLine("${YELLOW}Total Events: $AQUA$totalEvents"))
-        if (screenOpen && type == Diana.Tracker.SESSION) stats.add(resetSession)
 
         return stats
     }

--- a/src/main/kotlin/net/sbo/mod/partyfinder/PartyFinderManager.kt
+++ b/src/main/kotlin/net/sbo/mod/partyfinder/PartyFinderManager.kt
@@ -88,7 +88,7 @@ object PartyFinderManager {
             }
         }
 
-        Register.command("sboKey") { args ->
+        Register.command("sboKey", "sbokey") { args ->
             if (args.isEmpty()) {
                 Chat.chat("§6[SBO] §cPlease provide a key")
             } else if (args[0].startsWith("sbo").not()) {

--- a/src/main/kotlin/net/sbo/mod/settings/categories/Customization.kt
+++ b/src/main/kotlin/net/sbo/mod/settings/categories/Customization.kt
@@ -108,6 +108,11 @@ object Customization : CategoryKt("Customization") {
         this.description = Literal("Shows times dug on the waypoint text for known burrows.")
     }
 
+    var warpTitleAsSubtitle by boolean(false) {
+        this.name = Literal("Warp Title As Subtitle")
+        this.description = Literal("Shows the warp title as a subtitle instead of title, reducing its size on screen. This will also cause it to move down slightly.")
+    }
+
     init {
         separator {
             this.title = "Sounds"

--- a/src/main/kotlin/net/sbo/mod/utils/Helper.kt
+++ b/src/main/kotlin/net/sbo/mod/utils/Helper.kt
@@ -466,13 +466,9 @@ object Helper {
     fun checkDiana(): Boolean = Debug.itsAlwaysDiana || hasSpade && hasMythologicalRitualActive() && World.getWorld() == "Hub"
 
     fun showTitle(title: String?, subtitle: String?, fadeIn: Int, time: Int, fadeOut: Int) {
-        mc.gui.apply {
-            setTimes(fadeIn, time, fadeOut)
-            if (title != null)
-                setTitle(Component.nullToEmpty(title))
-            if (subtitle != null)
-                setSubtitle(Component.nullToEmpty(subtitle))
-        }
+        mc.gui.setTimes(fadeIn, time, fadeOut)
+        if (title != null) mc.gui.setTitle(Component.nullToEmpty(title))
+        if (subtitle != null) mc.gui.setSubtitle(Component.nullToEmpty(subtitle))
     }
 
     fun checkCustomDropMessage(dropName: String, magicFind: Int): Pair<Boolean, String> {

--- a/src/main/kotlin/net/sbo/mod/utils/chat/Chat.kt
+++ b/src/main/kotlin/net/sbo/mod/utils/chat/Chat.kt
@@ -45,24 +45,26 @@ object Chat {
         }
     }
 
+    private fun sendClientMessage(message: Component) {
+        mc.execute {
+            mc.gui.chat.addMessage(message)
+        }
+    }
+
     /**
      * Shows a local chat message only visible to the player.
      * @param string The message to display in the chat.
      */
-    fun chat(string: String) {
-        mc.execute {
-            mc.gui.chat.addMessage(Component.nullToEmpty(string))
-        }
+    fun chat(message: String) {
+        sendClientMessage(Component.nullToEmpty(message))
     }
 
     /**
      * Shows a local chat message only visible to the player.
      * @param text The message to display in the chat.
      */
-    fun chat(text: Component) {
-        mc.execute {
-            mc.gui.chat.addMessage(text)
-        }
+    fun chat(message: Component) {
+        sendClientMessage(message)
     }
 
     /**
@@ -97,9 +99,7 @@ object Chat {
                 .withHoverEvent(hoverEvent)
         )
 
-        mc.execute {
-            mc.gui.chat.addMessage(styledText)
-        }
+        sendClientMessage(styledText)
     }
 
     /**
@@ -125,9 +125,7 @@ object Chat {
                 .withHoverEvent(hoverEvent)
         )
 
-        mc.execute {
-            mc.gui.chat.addMessage(styledText)
-        }
+        sendClientMessage(styledText)
     }
 
     /**
@@ -144,9 +142,7 @@ object Chat {
             combinedText.append(component)
         }
 
-        mc.execute {
-            mc.gui.chat.addMessage(combinedText)
-        }
+        sendClientMessage(combinedText)
     }
 
     /**

--- a/src/main/kotlin/net/sbo/mod/utils/collection/TimeLimitedCache.kt
+++ b/src/main/kotlin/net/sbo/mod/utils/collection/TimeLimitedCache.kt
@@ -4,6 +4,7 @@ import com.google.common.cache.Cache
 import com.google.common.cache.RemovalCause
 import java.util.concurrent.TimeUnit
 import kotlin.time.Duration
+import kotlin.time.toJavaDuration
 
 /**
  * A cache map that automatically removes entries after a specified duration since their last write.
@@ -21,7 +22,7 @@ class TimeLimitedCache<K : Any, V : Any>(
 ) : CacheMap<K, V>() {
 
     override val cache: Cache<K, V> = buildCache {
-        expireAfterWrite(expireAfterWrite.inWholeNanoseconds, TimeUnit.NANOSECONDS)
+        expireAfterWrite(expireAfterWrite.toJavaDuration())
         setRemovalListener(removalListener)
     }
 }

--- a/src/main/kotlin/net/sbo/mod/utils/events/DianaEvents.kt
+++ b/src/main/kotlin/net/sbo/mod/utils/events/DianaEvents.kt
@@ -2,6 +2,7 @@ package net.sbo.mod.utils.events
 
 import net.minecraft.network.protocol.game.ServerboundPlayerActionPacket
 import net.sbo.mod.SBOKotlin
+import net.sbo.mod.diana.guesses.ArrowGuessBurrow
 import net.sbo.mod.diana.burrows.BurrowDetector
 import net.sbo.mod.utils.events.annotations.SboEvent
 import net.sbo.mod.utils.events.impl.diana.BurrowDugEvent
@@ -29,7 +30,10 @@ object DianaEvents {
         if (World.getWorld() != "Hub") return
         if (packet.action != ServerboundPlayerActionPacket.Action.START_DESTROY_BLOCK) return
 
-        processBlockInteraction(packet.pos.toSboVec())
+        val pos = packet.pos.toSboVec()
+
+        ArrowGuessBurrow.recentClickedBlocks.add(pos)
+        processBlockInteraction(pos)
     }
 
     @SboEvent

--- a/src/main/kotlin/net/sbo/mod/utils/math/SboVec.kt
+++ b/src/main/kotlin/net/sbo/mod/utils/math/SboVec.kt
@@ -15,19 +15,27 @@ import kotlin.math.sqrt
  * The credits to this class go fully to the SkyHanni Mod: https://github.com/hannibal002/SkyHanni/blob/beta/src/main/java/at/hannibal2/skyhanni/utils/LorenzVec.kt
  */
 data class SboVec(var x: Double, var y: Double, var z: Double) {
-
     fun distanceTo(other: SboVec): Double {
-        return sqrt((other.x - this.x).pow(2) + (other.y - this.y).pow(2) + (other.z - this.z).pow(2))
+        val dx = other.x - x
+        val dy = other.y - y
+        val dz = other.z - z
+
+        return sqrt(dx * dx + dy * dy + dz * dz)
     }
 
     fun distanceToIgnoringY(other: SboVec): Double {
         val dx = x - other.x
         val dz = z - other.z
+
         return sqrt(dx * dx + dz * dz)
     }
 
     fun distanceTo(x: Double, y: Double, z: Double): Double {
-        return sqrt((x - this.x).pow(2) + (y - this.y).pow(2) + (z - this.z).pow(2))
+        val dx = x - this.x
+        val dy = y - this.y
+        val dz = z - this.z
+
+        return sqrt(dx * dx + dy * dy + dz * dz)
     }
 
     operator fun plus(other: SboVec): SboVec {

--- a/src/main/kotlin/net/sbo/mod/utils/render/RenderUtils3D.kt
+++ b/src/main/kotlin/net/sbo/mod/utils/render/RenderUtils3D.kt
@@ -8,6 +8,7 @@ import net.minecraft.client.Camera
 import net.minecraft.client.gui.Font
 import net.minecraft.client.renderer.MultiBufferSource
 import net.minecraft.client.renderer.texture.OverlayTexture
+import net.minecraft.client.renderer.rendertype.RenderTypes
 import net.minecraft.gizmos.GizmoStyle
 import net.minecraft.gizmos.Gizmos
 import net.minecraft.util.ARGB
@@ -184,7 +185,7 @@ object RenderUtils3D {
             val ny = upVec.y.toFloat()
             val nz = upVec.z.toFloat()
 
-            val renderLayer = SboRenderLayers.LINES_THROUGH_WALLS
+            val renderLayer = RenderTypes.LINES
             val buffer = consumers.getBuffer(renderLayer)
             val matrixEntry = last()
 

--- a/src/main/kotlin/net/sbo/mod/utils/render/SboRenderLayers.kt
+++ b/src/main/kotlin/net/sbo/mod/utils/render/SboRenderLayers.kt
@@ -5,14 +5,6 @@ import net.minecraft.client.renderer.rendertype.RenderSetup
 import net.minecraft.client.renderer.rendertype.RenderType
 
 object SboRenderLayers {
-    @JvmField
-    val LINES_THROUGH_WALLS: RenderType = RenderType.create(
-        "sbo/lines_through_walls",
-        RenderSetup.builder(SboRenderPipelines.LINES_THROUGH_WALLS)
-            .sortOnUpload()
-            .createRenderSetup()
-    )
-
     val BEACON_BEAM_OPAQUE_THROUGH_WALLS: RenderType = RenderType.create(
         "sbo/beacon_beam_opaque_through_walls",
         RenderSetup.builder(SboRenderPipelines.BEACON_BEAM_OPAQUE_THROUGH_WALLS)

--- a/src/main/kotlin/net/sbo/mod/utils/render/SboRenderPipelines.kt
+++ b/src/main/kotlin/net/sbo/mod/utils/render/SboRenderPipelines.kt
@@ -12,20 +12,6 @@ import net.sbo.mod.SBOKotlin
 
 /** Add new pipelines to [net.sbo.mod.compat.IrisCompatibility] */
 object SboRenderPipelines {
-    val LINES_THROUGH_WALLS: RenderPipeline = RenderPipelines.register(
-        RenderPipeline.builder(RenderPipelines.LINES_SNIPPET)
-            .withLocation(SBOKotlin.id("pipeline/line_through_walls"))
-            .withShaderDefine("shad")
-            .withVertexFormat(DefaultVertexFormat.POSITION_COLOR_NORMAL_LINE_WIDTH, Mode.LINES)
-            .withCull(false)
-            //#if MC < 26.1
-            .withBlend(BlendFunction.TRANSLUCENT)
-            .withDepthWrite(false)
-            .withDepthTestFunction(DepthTestFunction.NO_DEPTH_TEST)
-            //#endif
-            .build()
-    )
-
     val BEACON_BEAM_OPAQUE_THROUGH_WALLS: RenderPipeline = RenderPipeline.builder(RenderPipelines.BEACON_BEAM_SNIPPET)
         .withLocation(SBOKotlin.id("beacon_beam_opaque_through_walls"))
         //#if MC < 26.1

--- a/src/main/kotlin/net/sbo/mod/utils/waypoint/Waypoint.kt
+++ b/src/main/kotlin/net/sbo/mod/utils/waypoint/Waypoint.kt
@@ -100,8 +100,15 @@ class Waypoint(
 
             val title = Diana.showTitleWhenWarpAvailable
             if (title && closest != null && World.getWorld() == "Hub" && Helper.hasSpade) {
-                 val warpName = closest.replaceFirstChar(Char::titlecase)
-                 Helper.showTitle("§bWarp §e$warpName$distanceText", "", 0, 1, 0) // 1 ticks because next tick this will be called again
+                val warpName = closest.replaceFirstChar(Char::titlecase)
+
+                val text = "§bWarp §e$warpName$distanceText"
+                val asSubtitle = Customization.warpTitleAsSubtitle
+
+                val title = if (asSubtitle) "" else text
+                val subtitle = if (asSubtitle) text else null
+
+                Helper.showTitle(title, subtitle, 0, 1, 0) // 1 ticks because next tick this will be called again
             }
         } else {
             this.formattedText = "${this.text}${this.distanceText}$timesDugText"

--- a/src/main/kotlin/net/sbo/mod/utils/waypoint/WaypointManager.kt
+++ b/src/main/kotlin/net/sbo/mod/utils/waypoint/WaypointManager.kt
@@ -337,7 +337,7 @@ object WaypointManager {
         if (pos == null) return
 
         if (!waypointExists("burrow", pos).first) {
-            val waypoint = Waypoint("Spade Guess", pos.x, pos.y, pos.z, type = "guess")
+            val waypoint = Waypoint("Guess", pos.x, pos.y, pos.z, type = "guess")
             addWaypoint(waypoint)
         }
     }

--- a/src/main/kotlin/net/sbo/mod/utils/waypoint/WaypointManager.kt
+++ b/src/main/kotlin/net/sbo/mod/utils/waypoint/WaypointManager.kt
@@ -337,7 +337,7 @@ object WaypointManager {
         if (pos == null) return
 
         if (!waypointExists("burrow", pos).first) {
-            val waypoint = Waypoint("Shovel Guess", pos.x, pos.y, pos.z, type = "guess")
+            val waypoint = Waypoint("Spade Guess", pos.x, pos.y, pos.z, type = "guess")
             addWaypoint(waypoint)
         }
     }

--- a/src/main/kotlin/net/sbo/mod/utils/waypoint/WaypointManager.kt
+++ b/src/main/kotlin/net/sbo/mod/utils/waypoint/WaypointManager.kt
@@ -78,33 +78,40 @@ object WaypointManager {
                     }
                     if (mobType !in Diana.ReceiveMobs) return@onChatMessage
 
-                    when (mob) { // todo: add custom sounds per mob
-                        "minos inquisitor", "inquisitor", "inq" -> {
-                            Helper.showTitle("§r§6§l<§b§l§kO§6§l> §b§lINQUISITOR! §6§l<§b§l§kO§6§l>", player, Diana.rareTitleFadeIn, Diana.rareTitleTime, Diana.rareTitleFadeOut)
+                    val mobDisplayName = when (mobType) {
+                        Diana.ReceiveList.INQ -> {
+                            Helper.showTitle("§r§6§l<§b§l§kO§6§l> §d§lINQUISITOR! §6§l<§b§l§kO§6§l>", player, Diana.rareTitleFadeIn, Diana.rareTitleTime, Diana.rareTitleFadeOut)
                             playCustomSound(Customization.inqSound[0], Customization.inqVolume)
+                            "§dInquisitor"
                         }
-                        "king minos", "king" -> {
-                            Helper.showTitle("§r§6§l<§b§l§kO§6§l> §b§lKING MINOS! §6§l<§b§l§kO§6§l>", player, Diana.rareTitleFadeIn, Diana.rareTitleTime, Diana.rareTitleFadeOut)
+                        Diana.ReceiveList.KING -> {
+                            Helper.showTitle("§r§6§l<§b§l§kO§6§l> §6§lKING MINOS! §6§l<§b§l§kO§6§l>", player, Diana.rareTitleFadeIn, Diana.rareTitleTime, Diana.rareTitleFadeOut)
                             playCustomSound(Customization.kingSound[0], Customization.kingVolume)
+                            "§6King Minos"
                         }
-                        "manticore" -> {
-                            Helper.showTitle("§r§6§l<§b§l§kO§6§l> §b§lMANTICORE! §6§l<§b§l§kO§6§l>", player, Diana.rareTitleFadeIn, Diana.rareTitleTime, Diana.rareTitleFadeOut)
+                        Diana.ReceiveList.MANTICORE -> {
+                            Helper.showTitle("§r§6§l<§b§l§kO§6§l> §2§lMANTICORE! §6§l<§b§l§kO§6§l>", player, Diana.rareTitleFadeIn, Diana.rareTitleTime, Diana.rareTitleFadeOut)
                             playCustomSound(Customization.mantiSound[0], Customization.mantiVolume)
+                            "§2Manticore"
                         }
-                        "sphinx" -> {
-                            Helper.showTitle("§r§6§l<§b§l§kO§6§l> §b§lSPHINX! §6§l<§b§l§kO§6§l>", player, Diana.rareTitleFadeIn, Diana.rareTitleTime, Diana.rareTitleFadeOut)
+                        Diana.ReceiveList.SPHINX -> {
+                            Helper.showTitle("§r§6§l<§b§l§kO§6§l> §9§lSPHINX! §6§l<§b§l§kO§6§l>", player, Diana.rareTitleFadeIn, Diana.rareTitleTime, Diana.rareTitleFadeOut)
                             playCustomSound(Customization.sphinxSound[0], Customization.sphinxVolume)
+                            "§9Sphinx"
                         }
                         else -> {
-                            Helper.showTitle("§r§6§l<§b§l§kO§6§l> §b§lRARE MOB! §6§l<§b§l§kO§6§l>", player, Diana.rareTitleFadeIn, Diana.rareTitleTime, Diana.rareTitleFadeOut)
+                            Helper.showTitle("§r§6§l<§b§l§kO§6§l> §3§lRARE MOB! §6§l<§b§l§kO§6§l>", player, Diana.rareTitleFadeIn, Diana.rareTitleTime, Diana.rareTitleFadeOut)
                             playCustomSound(Customization.rareMobSound[0], Customization.rareMobVolume)
+                            "§3Rare Mob"
                         }
                     }
+
                     addRareMobWaypoint(
                         player,
                         SboVec(x.toDouble(), y.toDouble(), z.toDouble()),
-                        mob,
-                        playername
+                        mobType,
+                        playername,
+                        mobDisplayName
                     )
                 } else if (patcherWaypoints) {
                     if (hideOwnWaypoints.contains(HideOwnWaypoints.NORMAL) && player.contains(playername)) return@onChatMessage
@@ -137,7 +144,7 @@ object WaypointManager {
             // Remove all waypoints that are not in radius of typical burrow locations x y z
             this.forEachWaypoint { waypoint ->
                 val underWorld = waypoint.pos.y < 60
-                val aboveWorld = waypoint.pos.y > 100
+                val aboveWorld = waypoint.pos.y > 105
                 val outsideZ = waypoint.pos.z > 205
                 val outsideX = waypoint.pos.x > 175
                 val outsideNegativeZ = waypoint.pos.z < 0 && -waypoint.pos.z > 208
@@ -223,14 +230,16 @@ object WaypointManager {
         WorldRenderEvents.BEFORE_TRANSLUCENT.register(WaypointRenderer)
     }
 
-    fun addRareMobWaypoint(player: String, pos: SboVec, mobName: String, playername: String) {
-        when (mobName) {
-            "minos inquisitor", "inquisitor" -> if (hideOwnWaypoints.contains(HideOwnWaypoints.INQ) && player.contains(playername)) return
-            "king minos", "king" -> if (hideOwnWaypoints.contains(HideOwnWaypoints.KING) && player.contains(playername)) return
-            "manticore" -> if (hideOwnWaypoints.contains(HideOwnWaypoints.MANTICORE) && player.contains(playername)) return
-            "sphinx" -> if (hideOwnWaypoints.contains(HideOwnWaypoints.SPHINX) && player.contains(playername)) return
+    fun addRareMobWaypoint(player: String, pos: SboVec, mobType: Diana.ReceiveList, playername: String, mobDisplayName: String) {
+        when (mobType) {
+            Diana.ReceiveList.INQ -> if (hideOwnWaypoints.contains(HideOwnWaypoints.INQ) && player.contains(playername)) return
+            Diana.ReceiveList.KING -> if (hideOwnWaypoints.contains(HideOwnWaypoints.KING) && player.contains(playername)) return
+            Diana.ReceiveList.MANTICORE -> if (hideOwnWaypoints.contains(HideOwnWaypoints.MANTICORE) && player.contains(playername)) return
+            Diana.ReceiveList.SPHINX -> if (hideOwnWaypoints.contains(HideOwnWaypoints.SPHINX) && player.contains(playername)) return
+            else -> {}
         }
-        addWaypoint(Waypoint(player, pos.x, pos.y, pos.z, ttl = 45, type = "rareMob"))
+
+        addWaypoint(Waypoint(mobDisplayName + " §7($player§7)", pos.x, pos.y, pos.z, ttl = 45, type = "rareMob"))
     }
 
     fun removeNearbyRareMobWaypoints() {
@@ -321,14 +330,14 @@ object WaypointManager {
     }
 
     /**
-     * Updates the guess waypoint position.
-     * @param pos The new position for the guess waypoint.
+     * Adds a shovel guess waypoint.
+     * @param pos The position for the shovel guess waypoint.
      */
-    fun updateGuess(pos: SboVec?) {
+    fun addShovelGuess(pos: SboVec?) {
         if (pos == null) return
 
         if (!waypointExists("burrow", pos).first) {
-            val waypoint = Waypoint("Guess", pos.x, pos.y, pos.z, type = "guess")
+            val waypoint = Waypoint("Shovel Guess", pos.x, pos.y, pos.z, type = "guess")
             addWaypoint(waypoint)
         }
     }


### PR DESCRIPTION
- Better rare mob title with seperate color for each rare mob and waypoints that include mob's name and put player's name inside paranthesis after the rare mob name
- Rename updateGuess to addShovelGuess to better reflect the new behaviour of it
- Show "Shovel Guess" text instead of "Guess" for spade guesses to differenate them from Arrow Guesses, if users report inaccurate guesses we can then check if it was arrow or guess based on screenshot
- Add option to show warp title as subtitle instead, which looks smaller since some people said it was too big before (visual preference), also fixed warp title wiping any previous subtitle (Although we need to wipe the title to "" when using warpTitleAsSubtitle because apparently you cant show a subtitle without a title, so we show an empty title + the warp subtitle)
- Removed the custom LINES RenderLayer and RenderPipeline along with Iris compat register for it; vanilla RenderTypes.LINES now supports setLineWidth since 1.21.11, which was the reason we had a custom layer/pipeline in verious versions, to be able to modify the line width to 5 instead of 1
- Simplify SboVec distanceTo methods to not use pow
- Fix Guess waypoints being removed when you mine (destroy) the grass block fully with any shovel (incl. AOTV) this happened because isBlockValid returns false if the block guess is in is not a grass block and it won't be a grass block for a short time if you fully mine it client-side before server re-puts the block
- Replace to non-deprecated expireAfterWrite constructor in TimeLimitedCache
- Unify mc.execute and mc.gui.chat.addMessage to a single method
- Helper showTitle removed use of .apply (Useful for bloom replacement in 26.2 in the future)
- Added lowercase "sbokey" alias to /sboKey since some people were confused
- Move Reset Session button to come after Change View and Sell Order buttons on top instead of bottom (User request)
- Use TextColor since ChatFormatting#color seems to have disappeared in 26.2 in AchievementsGUI.kt for the achievementColor
- Remove unused GuessEntry#removeGuesses method
- Bump max Y level with grass block to 105 (remove higher than 105 a.k.a >=106) as Castle area has some grass blocks that can have valid burrows at Y=105