### PR TITLE
Bump version to 0.4.2

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -42,7 +42,7 @@ dgt.loom.loader.use=false
 # Mod properties
 mod.name=SBO
 mod.id=sbo
-mod.version=0.4.1
+mod.version=0.4.2
 mod.group=net.sbo.mod
 mod.description=SBO is the ultimate diana mod for diana nons! FPS friendly, and packed with QOL features!
 


### PR DESCRIPTION
# SBO 0.4.2 for Minecraft 26.1.2 and 1.21.11

# Note on Minecraft 26.2 support
This release only supports Minecraft 26.1.2 and 1.21.11. Minecraft 26.2 support is planned for a future release, please be patient. To clarify, Hypixel's suggestion to upgrade to 26.2 only appears when joining with 1.21.11 or 1.21.10, and 26.1.2 will be supported for at least 3 months from now on since it won't be dropped till 26.3 releases.

# Better rare mob titles & waypoints
The rare mob title on screen has been enhanced to show different colors for different mobs; pink for inquisitor, gold for king, dark green for manticore, light blue for sphinx and cyan for unknown (previously, all showed as aqua color).

Enhanced the waypoint text for rare mob waypoints to include the name of the mob, and put playername to inside paranthesis instead:

Old: Aqua colored "[MVP+] playername" only, even if the chat message the waypoint was created from included name of the rare mob
New: Pink colored "Inquisitor " (or Gold colored King/Dark Green colored Manticore/Light Blue colored Sphinx depending on spawned mob), then gray colored "(", then regular display name of the player e.g., "[MVP+] playername", then gray colored ")"

# Warp Title As Subtitle option
Added new option ("Warp Title As Subtitle") that uses subtitle instead of title for showing Warp Title; will make it look smaller and a bit more down than center/crosshair position. Useful if you do not like the big warp title.

# Hide LS Stats option & Toggle-able Diana Stat lines
Added new option ("Hide LS Stats") that hides the Lootshare parts of the Diana Stats overlay (The one that shows stats like "Inquisitor since Chim: 10 [LS: 45]", where the bracket LS line is hidden if the new option is enabled). This is useful if you are playing Solo and want to reduce visual clutter.

The Diana Stats overlay now also supports toggling specific lines on and off (just like the Diana Loot overlay) if you want to e.g for example hide Sphinx since Brain Food line, if you don't care about that and only care about Inquisitor/King stats for example.

# Shovel-guess classification
Shovel-originating guesses will show the text as "Shovel Guess", while arrow guesses continue to use short form "Guess". In case of a guess pointing to an invalid location, please note its type when reporting a bug.

# Bug fixes
- Fixed destroying the grass block for a waypoint causing it to be removed, since the grass block is removed for a short time before it re-appears, mod previously would consider it an invalid guess and remove; should be fixed now.
- Fixed Warp Title not respecting Warp near to Rare Mob Waypoints, and Rare Mob Waypoints no longer having the (/warp <place>) text.

# Misc
- Add /sbokey alias to the /sboKey (case-sensitive) command to avoid confusion with users getting unknown command error when typing /sbokey.
- Moved Reset Session button from bottom of Diana Loot overlay to the top right after the Change View and Sell Order/Instasell lines.
- Bump max Y-level with a grass block representing possible valid burrow to Y=105 from Y=100 (meaning the mod will now only remove Y 106 and higher instead of 101 and higher), as there is some legitimate burrows above Y=100 up to 105 in the Castle area.
- /sboclearburrows now also clears all the internal state known about burrows in addition to all the user visible waypoints.

# Technical changes
- Simplified distance calculations to not use Math.pow.
- Use the non-deprecated Duration overload rather than long and TimeUnit overload for expireAfterWrite.
- Unified client-side send message code to a single method.
- Use TextColor instead of legacy ChatFormatting for achievement color.