### PR TITLE
Try fix crash on 1.21.11 plus HTTP changes

### DIFF
--- a/src/main/kotlin/net/sbo/mod/diana/burrows/BurrowDetector.kt
+++ b/src/main/kotlin/net/sbo/mod/diana/burrows/BurrowDetector.kt
@@ -117,6 +117,8 @@ object BurrowDetector {
     }
 
     fun requestSpade(reason: String) {
+        if (World.getWorld() != "Hub") return
+
         val color = if (reason == "failure") "c" else "e"
         Helper.showTitle("§${color}Use Spade!", "", 0, 60, 0)
         Chat.chat("§6[SBO] §${color}Use spade!")

--- a/src/main/kotlin/net/sbo/mod/diana/guesses/ArrowGuessBurrow.kt
+++ b/src/main/kotlin/net/sbo/mod/diana/guesses/ArrowGuessBurrow.kt
@@ -123,6 +123,8 @@ object ArrowGuessBurrow {
     @SboEvent
     fun onReceiveParticle(event: PacketReceiveEvent) {
         if (!Diana.arrowGuess) return
+        if (World.getWorld() != "Hub") return
+
         val packet = event.packet as? ClientboundLevelParticlesPacket ?: return
         if (!packet.isRelevant()) return
 

--- a/src/main/kotlin/net/sbo/mod/utils/http/Http.kt
+++ b/src/main/kotlin/net/sbo/mod/utils/http/Http.kt
@@ -36,7 +36,6 @@ object Http {
     private val CLIENT: HttpClient = HttpClient.newBuilder()
         .executor(EXECUTOR)
         .connectTimeout(Duration.ofMillis(CONNECT_TIMEOUT))
-        .version(HTTP_3_OR_2)
         .followRedirects(HttpClient.Redirect.NORMAL)
         .build()
 
@@ -48,6 +47,12 @@ object Http {
         }
     }
 
+    private val HTTP2_ONLY = setOf(
+        // Unfortunately, the backend does not yet support HTTP/3 it seems and JDK's HTTP/3 implementation seems to not correctly fallback into HTTP/2 with it. Bazaar and Election API of Hypixel successfully make use of it, though, so we should keep it for these.
+        "skyblockoverhaul.com",
+        "api.skyblockoverhaul.com"
+    )
+
     /**
      * Sends an asynchronous HTTP GET request.
      *
@@ -57,8 +62,12 @@ object Http {
     fun sendGetRequest(urlString: String): HttpRequestHandle {
         val handle = HttpRequestHandle()
 
+        val uri = URI.create(urlString)
+        val httpVersion = if (uri.host in HTTP2_ONLY) HttpClient.Version.HTTP_2 else HTTP_3_OR_2
+
         val request = HttpRequest.newBuilder()
-            .uri(URI.create(urlString))
+            .version(httpVersion)
+            .uri(uri)
             .timeout(Duration.ofMillis(REQUEST_TIMEOUT))
             .header("User-Agent", USER_AGENT)
             .GET()

--- a/src/main/kotlin/net/sbo/mod/utils/http/Http.kt
+++ b/src/main/kotlin/net/sbo/mod/utils/http/Http.kt
@@ -25,18 +25,28 @@ object Http {
     private val EXECUTOR: ExecutorService = Executors.newFixedThreadPool(
         Runtime.getRuntime().availableProcessors() * 2,
         ThreadFactory { runnable ->
-            Thread(runnable, "SBO HTTP").apply {
+            Thread(runnable, "SBO Http Request Thread").apply {
                 isDaemon = true
             }
         }
     )
 
+    private val HTTP_3_OR_2: HttpClient.Version = http3WithFallback()
+
     private val CLIENT: HttpClient = HttpClient.newBuilder()
         .executor(EXECUTOR)
         .connectTimeout(Duration.ofMillis(CONNECT_TIMEOUT))
-        .version(HttpClient.Version.HTTP_2)
+        .version(HTTP_3_OR_2)
         .followRedirects(HttpClient.Redirect.NORMAL)
         .build()
+
+    private fun http3WithFallback(): HttpClient.Version {
+        try {
+            return HttpClient.Version.valueOf("HTTP_3") // Available since Java 26 (JEP 517: HTTP/3 for the HTTP Client API)
+        } catch (ignored: IllegalArgumentException) {
+            return HttpClient.Version.HTTP_2 // Fallback to baseline of HTTP/2
+        }
+    }
 
     /**
      * Sends an asynchronous HTTP GET request.
@@ -46,12 +56,6 @@ object Http {
      */
     fun sendGetRequest(urlString: String): HttpRequestHandle {
         val handle = HttpRequestHandle()
-
-        val httpVersion = try {
-            HttpClient.Version.valueOf("HTTP_3") // Available since Java 26
-        } catch (ignored: IllegalArgumentException) {
-            HttpClient.Version.HTTP_2 // Fallback to baseline of HTTP/2
-        }
 
         val request = HttpRequest.newBuilder()
             .uri(URI.create(urlString))

--- a/src/main/kotlin/net/sbo/mod/utils/waypoint/Waypoint.kt
+++ b/src/main/kotlin/net/sbo/mod/utils/waypoint/Waypoint.kt
@@ -14,7 +14,7 @@ import kotlin.math.roundToInt
 import kotlin.math.sqrt
 
 private const val MIN_OPACITY = 0.2f
-private const val MAX_OPACITY = 0.99f
+private const val MAX_OPACITY = 1.0f
 private const val FADE_START_DISTANCE = 4.5
 private const val FADE_END_DISTANCE = 100.0
 
@@ -48,7 +48,7 @@ class Waypoint(
     var isClosest = false
     var timesDug = 0
     var userInteractedWith = false
-    private var dynamicOpacity = 0.99f
+    private var dynamicOpacity = 1.0f
     var inaccurateArrow = false
 
     fun hasStrongerStateThan(other: Waypoint): Boolean =
@@ -179,7 +179,7 @@ class Waypoint(
         inqWaypoints: List<Waypoint>
     ) {
         this.distanceRaw = distanceToPlayer()
-        this.dynamicOpacity = if (Customization.dynamicWaypointOpacity) updateDynamicOpacity() else (Customization.waypointOpacity / 100.0).toFloat().coerceIn(0f, 0.99f)
+        this.dynamicOpacity = if (Customization.dynamicWaypointOpacity) updateDynamicOpacity() else (Customization.waypointOpacity / 100.0).toFloat().coerceIn(0.2f, 1.0f)
 
         val dist = distanceRaw.roundToInt()
 

--- a/src/main/resources/sbo.classtweaker
+++ b/src/main/resources/sbo.classtweaker
@@ -1,1 +1,5 @@
 classTweaker v2 named
+accessible	method	net/minecraft/client/renderer/rendertype/RenderType create (Ljava/lang/String;Lnet/minecraft/client/renderer/rendertype/RenderSetup;)Lnet/minecraft/client/renderer/rendertype/RenderType;
+accessible  field   net/minecraft/client/gui/Gui titleTime I
+accessible  field   net/minecraft/client/gui/Gui title Lnet/minecraft/network/chat/Component;
+accessible  field   net/minecraft/client/gui/Gui subtitle Lnet/minecraft/network/chat/Component;


### PR DESCRIPTION
Http 3 variable was dead code cause i forgot to actually pass it to the HttpClient. Also changed thread name to be better.

Also tries to fix a crash on 1.21.11 due to access widener not applying. If it doesnt work still, most likely a gradle cache issue?