### PR TITLE
Bump version to 0.4.3

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -42,7 +42,7 @@ dgt.loom.loader.use=false
 # Mod properties
 mod.name=SBO
 mod.id=sbo
-mod.version=0.4.2
+mod.version=0.4.3
 mod.group=net.sbo.mod
 mod.description=SBO is the ultimate diana mod for Hypixel Skyblock! FPS friendly, and packed with QOL features!
 


### PR DESCRIPTION
# SBO 0.4.3 for Minecraft 26.1.2 and 1.21.11

# Note on Minecraft 26.2 support
This release only supports Minecraft 26.1.2 and 1.21.11. Minecraft 26.2 support is planned for a future release, please be patient. To clarify, Hypixel's suggestion to upgrade to 26.2 only appears when joining with 1.21.11 or 1.21.10, and 26.1.2 will be supported for at least 3 months from now on since it won't be dropped till 26.3 releases.

# Toggle-able Pause Menu button
We have added an option to disable the Pause Menu button SBO adds, in case you don't like it.

# Sphinx Keybind
NOTE: This feature is UAYOR (use at your own risk) as answering without chat open can be considered an unfair advantage over other players, but it does not do multiple things with one keypress because internally, we do not open the chat for you nor click to the message for you - we just run the command that would have normally ran if you have opened the chat and clicked on the answer directly, which is a single action.

We have added a new keybind to the vanilla Controls menu - when set to a button, it will answer the sphinx question without needing to open the chat and leftclick. If you set this key to leftclick (ignore the conflict warning), you can most likely answer the question and go straight to damaging the Sphinx as fast possible to avoid any time loss.

# Hide LS Stats enhanced
Hide LS Stats option is enhanced to now also hide LS stats in the Diana Mobs Overlay, not just Diana Stats Overlay.

# More fixes for missing Diana-V2 stuff
Added highest Manticore and Fateful Stinger Magic Find to the Magic Find Overlay and the !mf Party Command. We have also added the previously missing Minos Relic here, along with now tracking your highest Magic Find for Minos Relic (magic find from past drops are not tracked due to internal tracker being newly added). The internal tracker for Minos Relic was missing as before Diana-V2, Minos Relic drops used to not contain Magic Find in the chat message.

# Burrow-found sound
We have changed the default value of the "Burrow Found Sound" option in Customization settings to "notification", and made it only play when detecting burrows from particles when close. This should make you notice better if the mod finds a new burrow behind you.

The internal ID of the option was changed so that the upgrading users also get the new default. You may get a prompt in chat that you need to enable the SBO Custom Sounds Data Pack resourcepack when a new treasure or mob burrow is discovered, as now the custom sounds are actually used by the out of box configuration, instead of being completely optional and upto the user. This is intended.

The extraction code was also fixed so that the built-in sounds are now correctly extracted from the jar onto the config/sounds directory and then to the resourcepacks/SBO Custom Sounds Data Pack/assets/sbo/sound directory.

# Experimental features
Added "Ongoing Chains Display" - displays amount of chains you have started (from the chat message) and the amount of known burrow + arrow guess waypoints visible added by the mod. If these numbers do not match, it might mean that the mod has a bug causing a chain to not have a waypoint, or to have an additional waypoint not cleaned up without a chain started. This display will also show additional data if internal state of the mod is corrupt.

Note that, the amounts of chains you have started does NOT save to disk, so it will be inherently wrong if you restart your game after starting some burrows and not finishing them (unless 30 minutes passes, at which server resets your burrows). If you are concerned with this, use the Diana NPC clear burrows feature for now; as this feature is currently experimental, no in-code fix for this is available, but is planned for next release.

With the 6 block distance and internal state fixes, Arrow Guess sometimes wiping a chain should be fully fixed - but ongoing chains display can still help you notice if it ever happens again.

# Alpha-preparation bug fixes
- Fixed disconnect when digging a burrow on Alpha due to Hypixel Skyblock Resourcepack changing the Mythological Mob icon in lore lines of CoA and the mod failing to find the correct line.
- Fixed features that depend on diana mob detection such as HP Overlay or No Shuriken Overlay not working in the Alpha Network due to Hypixel Skyblock Resourcepack changing the Mythological Mob icon.
- Fixed Mythological Dye drops not counting due to not matching Regex.

# Other bug fixes
- Fixed crash if your achievements data was previously corrupted (It should not corrupt in decently new versions since we have fixed all the data save corruption issues, but if it was previously corrupted in an old version and you have just upgraded, it could cause a crash previously, which is now fixed)
- Fixed a ConcurrentModificationException crash when burrow found sound plays due to particle detection of the burrow happening on another thread (off-thread sound play).
- Fixed Arrow Guess being removed instead of moved to the next internal subguess when digging an invalid Arrow Guess with your shovel.
- Fixed Arrow Guess not running the solver to find the next burrow in the chain if you dig a burrow then run away very fast due to a condition of being 6 blocks close to the arrow particles.
- Fixed guesses still being removed if you use an Efficiency 5 spade to dig them with high ping or lower server TPS due to grass block re-appearing later than intended by bumping the maximum time grass block could be missing to 4 seconds from 3 seconds. This is still client-side time but we plan to make it server-tick based in the future along with the spade held time counter (if you held spade for longer than 1s and are near 30 blocks of an arrow guess we try to move the arrow guess to the next internal subguess or remove if it runs out of subguesses, but the 1second time is client-side time).
- Fixed internal state of Arrow Guesses and Known Burrows not being properly cleaned up and causing inaccurate removals after long gameplay sessions. This should also reduce memory usage slightly after long gameplay sessions as less data is tracked (only the active waypoints and chains, with stale ones from past burrows cleaned up properly now).
- Fixed Waypoint text not showing for Rare Mobs if there are multiple Rare Mob waypoints and it is not the newest one.
- Fixed Warp title overriding other titles such as the Use Spade or Rare Mob spawn titles. In the future, these will be turned to overlays so that their scale or position can be changed freely and overriding would be a non-issue; for now this should work though.
- Fixed duplicate misc drop sound being played for Hilt of Revelations drops.

# Misc
- The Use Spade title will now show red if it was shown due to Arrow Guess failing and yellow if it was due to a chain ending; there is also now a chat message in addition to the title.
- There is now a message in chat when your playtime timer pauses due to inactivity.
- The /sboc and /sbocheck commands are enhanced to work without passing any arguments, which will check your own requirements.
- The Rare Mob waypoints will now be removed when a rare mob dies close to a rare mob waypoint, even if you were far away from the mob. Previously, it only removed if you were close to the rare mob and the waypoint.
- There is now a chat message when playing a custom sound fails due to it not being loaded correctly.
- All references inside mod that reference the SBO-Kotlin GitHub repository were updated to reference SBO instead, as the repository is now renamed to just SBO instead of SBO-Kotlin. The old (archived) ChatTriggers JavaScript module is now named SBO-CT in GitHub.
- There is now a chat message for Hilt of Revelations rare drops, since Hypixel does not send one.

# Removed
The "Icon Scale" option in the Party Finder settings has been removed as it did not work and was completely unreferenced inside the code, other than the user visible option, to avoid confusion.

# Optimized
- Optimized a duplicate formattedString() call in Diana Mob Detection.

# Technical changes
- Bumped up interval of updating item prices from 5 minutes to 10 minutes to lessen the backend overhead since a lot of people are active due to the Raffle event.
- Changed HTTP request API from old HttpURLConnection to the new Java 11+ HttpClient API, allowing taking advantage of HTTP/2 (and HTTP/3 if available), with a dedicated thread pool to send requests and have longer timeouts (if the client timeout is lower than server timeout, previously it could timeout early while server was still preparing the response).
- The AH item price fetch errors now only be notified in chat for the first error only to prevent spam every 5 minutes. The color is changed from dark red to light red as well to be less scary.
- Added up to 5 times retry when saving data atomically as antiviruses and search indexing could be blocking the atomic move.
- Added direct write fallback if atomic move keeps failing.
- Most time-based code that compares current time to a previous snapshot of time (for e.g., cooldowns or time took calculations) now uses System.nanoTime() instead of System.currentTimeMillis() since it is more precise, faster and monotonic (always going up), whereas currentTimeMillis could even jump backwards due to clock synchronization (NTP).
- Updated Gradle build tool to 9.6.1 from 9.6.0.
- Updated Fabric Loom to 1.17.3 from 1.17.2; moved the version number to libs.versions.toml for a single source of the version to fix Dependabot pull requests failing in GitHub actions. Also made Dependabot target the development branch (Diana-V2) instead of main.
- Performed general code cleanup to remove unused imports, unused functions and variables, unnecessary paranthesis and privatize functions only used inside the declaring class.
- Enhanced mod metadata to add indiviual author URLs, remove unnecessary trailing slashes in URLs, fix SPDX license identifier, and add GitHub Releases & Modrinth links to the mod menu links sections, along with making them use translated text from Mod Menu (relevant for languages that use different characters or RTL instead of LTR text such as Chinese, Korean or Arabic). The mod escription is also updated to replace "the ultimate diana mod for diana nons" with "the ultimate diana mod for Hypixel Skyblock"