### PR TITLE
Rename Inq Warp Key to Rare Mob Warp Key

### DIFF
--- a/src/main/kotlin/net/sbo/mod/utils/SboKeyBinds.kt
+++ b/src/main/kotlin/net/sbo/mod/utils/SboKeyBinds.kt
@@ -33,8 +33,8 @@ object SboKeyBinds {
         SBO_CATEGORY
     )
 
-    private val inqWarpKey: KeyMapping = KeyMapping(
-        "key.sbo-kotlin.inq_warp",
+    private val rareMobWarpKey: KeyMapping = KeyMapping(
+        "key.sbo-kotlin.rare_mob_warp",
         InputConstants.Type.KEYSYM,
         GLFW.GLFW_KEY_UNKNOWN,
         SBO_CATEGORY
@@ -63,7 +63,7 @@ object SboKeyBinds {
 
     fun register() {
         KeyBindingHelper.registerKeyBinding(guessWarpKey)
-        KeyBindingHelper.registerKeyBinding(inqWarpKey)
+        KeyBindingHelper.registerKeyBinding(rareMobWarpKey)
         KeyBindingHelper.registerKeyBinding(generalWarpKey)
         KeyBindingHelper.registerKeyBinding(sendCoordsKey)
         KeyBindingHelper.registerKeyBinding(sphinxSolverKey)
@@ -103,8 +103,8 @@ object SboKeyBinds {
                 WaypointManager.warpToGuess()
             }
 
-            handlePressAction(inqWarpKey) {
-                WaypointManager.warpToInq()
+            handlePressAction(rareMobWarpKey) {
+                WaypointManager.warpToRareMob()
             }
 
             handlePressAction(generalWarpKey) {

--- a/src/main/kotlin/net/sbo/mod/utils/waypoint/WaypointManager.kt
+++ b/src/main/kotlin/net/sbo/mod/utils/waypoint/WaypointManager.kt
@@ -849,10 +849,10 @@ object WaypointManager {
         getClosestWarp(bestGuess.pos)?.let { executeWarpCommand(it) } ?: return
     }
 
-    fun warpToInq() {
-        val newestInq = getWaypointsOfType("rareMob").maxByOrNull { it.creationNs }
-        val newestWorldInq = getWaypointsOfType("world").maxByOrNull { it.creationNs }
-        val pos = newestInq?.pos ?: newestWorldInq?.pos ?: return
+    fun warpToRareMob() {
+        val newestRareMob = getWaypointsOfType("rareMob").maxByOrNull { it.creationNs }
+        val newestWorldRareMob = getWaypointsOfType("world").maxByOrNull { it.creationNs }
+        val pos = newestRareMob?.pos ?: newestWorldRareMob?.pos ?: return
         val warp = getClosestWarp(pos) ?: return
 
         executeWarpCommand(warp)
@@ -862,7 +862,7 @@ object WaypointManager {
         if (getWaypointsOfType("rareMob").isEmpty() && getWaypointsOfType("world").isEmpty()) {
             warpToGuess()
         } else {
-            warpToInq()
+            warpToRareMob()
         }
     }
 

--- a/src/main/resources/assets/sbo/lang/en_us.json
+++ b/src/main/resources/assets/sbo/lang/en_us.json
@@ -2,8 +2,8 @@
   "key.category.sbo-kotlin.keybinds": "SBO - Keybinds",
 
   "key.sbo-kotlin.guess_warp": "Guess Warp Key",
-  "key.sbo-kotlin.inq_warp": "Inq Warp Key",
-  "key.sbo-kotlin.general_warp": "General warp Key",
+  "key.sbo-kotlin.rare_mob_warp": "Rare Mob Warp Key",
+  "key.sbo-kotlin.general_warp": "General Warp Key",
   "key.sbo-kotlin.send_coords": "Send Coordinates",
   "key.sbo-kotlin.sphinx_solver": "Sphinx Solver (!!UAYOR!!)"
 }


### PR DESCRIPTION
Renames the Inq Warp Key text in Controls menu of the game to Rare Mob Warp Key.

This also updates the name of related functions, variables and translation keys, in addition to the user-visible text being updated. While we could keep the old names in-code and only update user-visible text which would keep users configured key when updating the mod, it would cause unnecessary legacy naming in-code that would eventually have to be cleaned later anyways.

As said, this could cause users configured key (for this specific key) to be wiped, but is not a big deal as we can just note in the changelog. (next release will likely be a 0.5.0 instead of 0.4.4 anyways, as it has more bigger changes such as the custom sound revamp)

Also capitalizes the "W" in "General warp Key", making it "General Warp Key".