### PR TITLE
More enhancements

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -30,6 +30,7 @@ loom {
 
     runs.configureEach {
         generateRunConfig.set(true)
+        preferGradleTask = true
     }
 }
 

--- a/src/main/kotlin/net/sbo/mod/SBOKotlin.kt
+++ b/src/main/kotlin/net/sbo/mod/SBOKotlin.kt
@@ -146,11 +146,9 @@ object SBOKotlin : ClientModInitializer {
 			}
 		}
 
-        //#if MC < 26.1
-		//$$ if (FabricLoader.getInstance().isModLoaded("iris")) {
-		//$$ 	IrisCompatibility.init()
-		//$$ }
-		//#endif
+		if (FabricLoader.getInstance().isModLoaded("iris")) {
+		    IrisCompatibility.init()
+		}
 
 		logger.info("SBO-Kotlin initialized successfully!")
 	}

--- a/src/main/kotlin/net/sbo/mod/compat/IrisCompatibility.kt
+++ b/src/main/kotlin/net/sbo/mod/compat/IrisCompatibility.kt
@@ -5,12 +5,14 @@ import net.irisshaders.iris.api.v0.IrisProgram
 import net.sbo.mod.utils.render.SboRenderPipelines
 
 object IrisCompatibility {
-    //#if MC < 26.1
     fun init() {
         IrisApi.getInstance().apply {
+            assignPipeline(SboRenderPipelines.LINES_THROUGH_WALLS, IrisProgram.LINES)
+
+            //#if MC < 26.1
             assignPipeline(SboRenderPipelines.BEACON_BEAM_OPAQUE_THROUGH_WALLS, IrisProgram.BEACON_BEAM)
             assignPipeline(SboRenderPipelines.BEACON_BEAM_TRANSLUCENT_THROUGH_WALLS, IrisProgram.BEACON_BEAM)
+            //#endif
         }
     }
-    //#endif
 }

--- a/src/main/kotlin/net/sbo/mod/diana/DianaMobDetect.kt
+++ b/src/main/kotlin/net/sbo/mod/diana/DianaMobDetect.kt
@@ -43,7 +43,7 @@ object DianaMobDetect {
     private val mobHpOverlay: Overlay = Overlay(name = "mythosMobHp", x = 10f, y = 10f, exampleView = OverlayExamples.mythosMobHpExample).setCondition { Diana.mythosMobHp }
     private val noShurikenOverlay: Overlay = Overlay(name = "noShuriken", x = 10f, y = 10f, scale = 3f, exampleView = OverlayExamples.dianaStarlessMobExample).setCondition { Diana.noShurikenOverlay }
 
-    private val kingHitsRegex = """.*?(\d+)\s+hits.*""".toRegex()
+    private val kingHitsRegex = """.*?(\d+)\s+Hits.*""".toRegex()
 
     internal enum class RareDianaMob(val display: String) {
         INQ("Minos Inquisitor"),
@@ -58,7 +58,7 @@ object DianaMobDetect {
 
     private fun findKingHits(name: String): MatchResult? {
         if (World.getWorld() != "Hub") return null
-        if (!name.contains("hits")) return null
+        if (!name.contains("Hits")) return null
         return kingHitsRegex.find(name)
     }
 
@@ -200,7 +200,7 @@ object DianaMobDetect {
         if (name.isEmpty() || name == "Armor Stand") return null
 
         parseKingHits(name)?.let {
-            return OverlayTextLine("§6King Minos §7- §5$it hits")
+            return OverlayTextLine("§6King Minos §7- §5$it Hits")
         }
 
         if (!hasMythoMobTypeChar(name)) return null

--- a/src/main/kotlin/net/sbo/mod/diana/DianaMobDetect.kt
+++ b/src/main/kotlin/net/sbo/mod/diana/DianaMobDetect.kt
@@ -9,6 +9,7 @@ import net.sbo.mod.utils.Helper.removeFormatting
 import net.sbo.mod.utils.Helper.showTitle
 import net.sbo.mod.utils.Helper.sleep
 import net.sbo.mod.utils.SoundHandler.playCustomSound
+import net.sbo.mod.utils.game.World
 import net.sbo.mod.utils.chat.Chat
 import net.sbo.mod.utils.chat.ChatUtils.formattedString
 import net.sbo.mod.utils.data.SboDataObject
@@ -42,6 +43,8 @@ object DianaMobDetect {
     private val mobHpOverlay: Overlay = Overlay(name = "mythosMobHp", x = 10f, y = 10f, exampleView = OverlayExamples.mythosMobHpExample).setCondition { Diana.mythosMobHp }
     private val noShurikenOverlay: Overlay = Overlay(name = "noShuriken", x = 10f, y = 10f, scale = 3f, exampleView = OverlayExamples.dianaStarlessMobExample).setCondition { Diana.noShurikenOverlay }
 
+    private val kingHitsRegex = """.*?(\d+)\s+hits.*""".toRegex()
+
     internal enum class RareDianaMob(val display: String) {
         INQ("Minos Inquisitor"),
         KING("King Minos"),
@@ -52,6 +55,18 @@ object DianaMobDetect {
             fun fromName(name: String): RareDianaMob? = entries.firstOrNull { name.contains(it.display, ignoreCase = true) }
         }
     }
+
+    private fun findKingHits(name: String): MatchResult? {
+        if (World.getWorld() != "Hub") return null
+        if (!name.contains("hits")) return null
+        return kingHitsRegex.find(name)
+    }
+
+    private fun isKingHitPhase(name: String) =
+        findKingHits(name) != null
+
+    private fun parseKingHits(name: String) =
+        findKingHits(name)?.groupValues?.getOrNull(1)?.toIntOrNull()
 
     private fun parseHealthFromName(name: String): Double? =
         healthRegex.find(name)?.groupValues?.get(1)?.let { raw ->
@@ -123,7 +138,7 @@ object DianaMobDetect {
                 }
 
                 val name = entity.customName?.formattedString() ?: entity.name.formattedString()
-                if (hasMythoMobTypeChar(name)) {
+                if (hasMythoMobTypeChar(name) || isKingHitPhase(name)) {
                     tracked[id] = entity
                     unconfirmedIterator.remove()
                 }
@@ -183,6 +198,11 @@ object DianaMobDetect {
 
     private fun checkDianaMob(entity: ArmorStand, name: String, id: Int) : OverlayTextLine? {
         if (name.isEmpty() || name == "Armor Stand") return null
+
+        parseKingHits(name)?.let {
+            return OverlayTextLine("§6King Minos §7- §5$it hits")
+        }
+
         if (!hasMythoMobTypeChar(name)) return null
 
         val health = parseHealthFromName(name)

--- a/src/main/kotlin/net/sbo/mod/diana/DianaTracker.kt
+++ b/src/main/kotlin/net/sbo/mod/diana/DianaTracker.kt
@@ -876,6 +876,7 @@ object DianaTracker {
 
     private fun resetMayorTracker(check: Boolean = false) {
         if (!check) {
+            if (dianaTrackerMayor.year == 0) dianaTrackerMayor.year = Mayor.mayorElectedYear
             pastDianaEventsData.events += dianaTrackerMayor.snapshot()
             SboDataObject.save("PastDianaEventsData")
         }

--- a/src/main/kotlin/net/sbo/mod/diana/DianaTracker.kt
+++ b/src/main/kotlin/net/sbo/mod/diana/DianaTracker.kt
@@ -7,6 +7,7 @@ import net.sbo.mod.overlays.DianaLoot
 import net.sbo.mod.overlays.DianaMobs
 import net.sbo.mod.overlays.DianaStats
 import net.sbo.mod.overlays.MagicFind
+import net.sbo.mod.settings.categories.Debug
 import net.sbo.mod.settings.categories.Diana
 import net.sbo.mod.settings.categories.QOL
 import net.sbo.mod.utils.Helper
@@ -123,8 +124,14 @@ object DianaTracker {
     }
 
     fun trackWithPickuplog(item: Item) {
-        if (Helper.getSecondsPassed(item.creation) > 5) return
-//            if (!dianaMobDiedRecently(3)) return
+        val createdAt = item.creation
+        val secondsPassedSinceCreation = Helper.getSecondsPassed(createdAt)
+
+        if (secondsPassedSinceCreation > 6) {
+            if (Debug.debugMessages) Chat.chat("debug: not tracking item with creation older than 6 seconds. secondsPassedSinceCreation=$secondsPassedSinceCreation,createdAt=$createdAt")
+            return
+        }
+
         trackWithPickuplog(item.itemId)
     }
 

--- a/src/main/kotlin/net/sbo/mod/diana/DianaTracker.kt
+++ b/src/main/kotlin/net/sbo/mod/diana/DianaTracker.kt
@@ -46,6 +46,7 @@ object DianaTracker {
     private var allowScavTracking: Boolean = true
 
     var lastSpawnedMob: String? = null
+    var lastSpawnedMobTime: Long = 0L
 
     fun init() {
         Register.command("sboresetsession") {
@@ -124,7 +125,7 @@ object DianaTracker {
 
     private fun trackWithPickuplog(itemId: String) {
         when (itemId) {
-            "HILT_OF_REVELATIONS" -> onRareDrop("Hilt Of Revelations", showMessageOrTitle = true,
+            "HILT_OF_REVELATIONS" -> onRareDrop("Hilt Of Revelations", showMessageOrTitle = Diana.hiltDropMessage,
                 trackLootshare = false,
                 magicFind = 0,
                 actuallyRare = false // makes it show the chat message but not the title
@@ -181,6 +182,7 @@ object DianaTracker {
 
     private fun onMobSpawn(mob: String, fromCocoon: Boolean = false) {
         lastSpawnedMob = mob
+        lastSpawnedMobTime = System.nanoTime()
         //if (fromCocoon) Chat.chat("§6[SBO] §eRegistered cocooned mob: $mob")
         when (mob) {
             "King Minos" -> {

--- a/src/main/kotlin/net/sbo/mod/diana/RareMobHighlight.kt
+++ b/src/main/kotlin/net/sbo/mod/diana/RareMobHighlight.kt
@@ -5,6 +5,7 @@ import net.minecraft.world.entity.player.Player
 import net.sbo.mod.SBOKotlin.mc
 import net.sbo.mod.diana.DianaMobDetect.RareDianaMob
 import net.sbo.mod.settings.categories.Diana
+import net.sbo.mod.settings.categories.Customization
 import net.sbo.mod.utils.accessors.isSboGlowing
 import net.sbo.mod.utils.accessors.setSboGlowColor
 import net.sbo.mod.utils.events.Register
@@ -22,7 +23,7 @@ import java.util.concurrent.ConcurrentHashMap
  * and settings, and updates their glow state accordingly.
  */
 object RareMobHighlight {
-    private val rareMobs = ConcurrentHashMap.newKeySet<Player>()
+    private val rareMobs = ConcurrentHashMap<Player, RareDianaMob>()
 
     fun init() {
         Register.onTick(4) {
@@ -36,8 +37,8 @@ object RareMobHighlight {
         if (event.entity is Player) {
             if (!Diana.HighlightRareMobs) return
             if (event.entity.uuid.version() == 4) return
-            if (RareDianaMob.entries.any { event.entity.name.string.contains(it.display, ignoreCase = true) }) {
-                rareMobs.add(event.entity)
+            RareDianaMob.fromName(event.entity.name.string)?.let {
+                rareMobs[event.entity] = it
             }
         }
     }
@@ -46,18 +47,17 @@ object RareMobHighlight {
     fun onEntityUnload(event: EntityUnloadEvent) {
         if (event.entity is Player) {
             if (!Diana.HighlightRareMobs) return
-            if (rareMobs.contains(event.entity)) {
+            if (rareMobs.remove(event.entity) != null) {
                 event.entity.isSboGlowing = false
-                rareMobs.remove(event.entity)
             }
         }
     }
 
     private fun ClientLevel.checkMobGlow() {
         val player = mc.player
-        val iterator = rareMobs.iterator()
+        val iterator = rareMobs.entries.iterator()
         while (iterator.hasNext()) {
-            val mob = iterator.next()
+            val (mob, type) = iterator.next()
 
             if (!mob.isAlive || mob.level() != this) {
                 mob.isSboGlowing = false
@@ -68,7 +68,14 @@ object RareMobHighlight {
             val hasLineOfSight = player != null && player.hasLineOfSight(mob)
             if (Diana.HighlightRareMobs && hasLineOfSight && !mob.isInvisible) {
                 mob.isSboGlowing = true
-                mob.setSboGlowColor(Color(Diana.HighlightColor))
+                val color = when (type) {
+                    RareDianaMob.KING -> Customization.KingMinosGlowColor
+                    RareDianaMob.INQ -> Customization.MinosInquisitorGlowColor
+                    RareDianaMob.MANTI -> Customization.ManticoreGlowColor
+                    RareDianaMob.SPHINX -> Customization.SphinxGlowColor
+                }
+
+                mob.setSboGlowColor(Color(color))
             } else {
                 mob.isSboGlowing = false
             }

--- a/src/main/kotlin/net/sbo/mod/diana/burrows/BurrowDetector.kt
+++ b/src/main/kotlin/net/sbo/mod/diana/burrows/BurrowDetector.kt
@@ -32,6 +32,8 @@ object BurrowDetector {
 
     private val chainExpirations = ArrayDeque<Long>()
 
+    var pendingUseSpadeTitle: String? = null
+
     val chains: Int
         get() {
             purgeExpiredChains()
@@ -131,6 +133,12 @@ object BurrowDetector {
                 burrowType = parseTypeFromChatMsg(message.string)
             )
         }
+
+        Register.onTick(1) {
+            pendingUseSpadeTitle?.let {
+                Helper.showTitle(it, "", 0, 1, 0)
+            }
+        }
     }
 
     private fun chainFinish() {
@@ -169,7 +177,8 @@ object BurrowDetector {
         if (World.getWorld() != "Hub") return
 
         val color = if (reason == "failure") "c" else "e"
-        Helper.showTitle("§${color}Use Spade!", "", 0, 60, 0)
+
+        pendingUseSpadeTitle = "§${color}Use Spade!"
         Chat.chat("§6[SBO] §${color}Use spade!")
     }
 

--- a/src/main/kotlin/net/sbo/mod/diana/guesses/ArrowGuessBurrow.kt
+++ b/src/main/kotlin/net/sbo/mod/diana/guesses/ArrowGuessBurrow.kt
@@ -209,18 +209,51 @@ object ArrowGuessBurrow {
         return RaycastUtils.Ray(adjustedBase, adjustedTip.minus(adjustedBase).normalize())
     }
 
-    private fun findline(): List<SboVec> {
-        for (location in locations) {
-            val line = mutableListOf<SboVec>()
-            val visited = mutableSetOf<SboVec>()
-            line.add(location)
-            visited.add(location)
+    private data class LineCandidate(
+        val points: List<SboVec>,
+        val score: Double,
+        val support: Int
+    )
 
-            if (extendLine(line, visited, locations, SHAFT_LENGTH, PARTICLE_DETECTION_TOLERANCE)) {
-                return line.toList()
+    private fun findline(): List<SboVec> {
+        val candidates = buildList {
+            for (start in locations) {
+                val line = mutableListOf<SboVec>()
+                val visited = mutableSetOf<SboVec>()
+                line.add(start)
+                visited.add(start)
+
+                if (extendLine(line, visited, locations, SHAFT_LENGTH, PARTICLE_DETECTION_TOLERANCE)) {
+                    add(LineCandidate(line.toList(), scoreLine(line.toList()), line.size))
+                }
             }
         }
-        return emptyList()
+
+        return candidates
+            .minWithOrNull(
+                compareBy<LineCandidate> { it.score }
+                    .thenByDescending { it.support }
+            )
+            ?.points
+            .orEmpty()
+    }
+
+    private fun scoreLine(line: List<SboVec>): Double {
+        if (line.size < 2) return Double.POSITIVE_INFINITY
+
+        val origin = line.first()
+        val direction = line.last().minus(origin).normalize()
+
+        return line.sumOf { point ->
+            val toPoint = point.minus(origin)
+            val projection = direction.dotProduct(toPoint)
+            val closest = origin.add(
+                direction.x * projection,
+                direction.y * projection,
+                direction.z * projection
+            )
+            point.distanceTo(closest)
+        }
     }
 
     private fun extendLine(
@@ -277,7 +310,6 @@ object ArrowGuessBurrow {
             ?.index
             ?: return null
 
-
         val candidates = mutableMapOf<SboVec, Pair<Double, Double>>()
 
         val endPointArray = endPoint.toDoubleArray()
@@ -297,12 +329,17 @@ object ArrowGuessBurrow {
 
             val scaledDistance = distanceToRay * 500000 / distanceFromOrigin
 
-            candidates[candidateBlock] = scaledDistance.roundTo(2) to distanceFromOrigin
+            candidates[candidateBlock] = scaledDistance to distanceFromOrigin
         }
         if (candidates.isEmpty()) return null
 
-        val minValue = candidates.values.minOf { it.first }
-        val possibilities = candidates.filterValues { it.first == minValue }
+        val best = candidates.entries.minWithOrNull(
+            compareBy<Map.Entry<SboVec, Pair<Double, Double>>> { it.value.first }
+                .thenBy { it.value.second }
+        ) ?: return null
+
+        val bestScore = best.value.first
+        val possibilities = candidates.filterValues { abs(it.first - bestScore) <= 1e-6 }
         val withinRange = possibilities.filterValues { it.second.toInt() in range }.map { it.key }
 
         val first = withinRange.firstOrNull()

--- a/src/main/kotlin/net/sbo/mod/diana/guesses/ArrowGuessBurrow.kt
+++ b/src/main/kotlin/net/sbo/mod/diana/guesses/ArrowGuessBurrow.kt
@@ -224,7 +224,8 @@ object ArrowGuessBurrow {
                 visited.add(start)
 
                 if (extendLine(line, visited, locations, SHAFT_LENGTH, PARTICLE_DETECTION_TOLERANCE)) {
-                    add(LineCandidate(line.toList(), scoreLine(line.toList()), line.size))
+                    val immutable = line.toList()
+                    add(LineCandidate(immutable, scoreLine(immutable), immutable.size))
                 }
             }
         }

--- a/src/main/kotlin/net/sbo/mod/diana/guesses/PreciseGuessBurrow.kt
+++ b/src/main/kotlin/net/sbo/mod/diana/guesses/PreciseGuessBurrow.kt
@@ -3,6 +3,7 @@ package net.sbo.mod.diana.guesses
 import net.minecraft.core.particles.ParticleTypes
 import net.minecraft.network.protocol.game.ClientboundLevelParticlesPacket
 import net.sbo.mod.SBOKotlin
+import net.sbo.mod.diana.burrows.BurrowDetector
 import net.sbo.mod.settings.categories.Diana
 import net.sbo.mod.utils.events.annotations.SboEvent
 import net.sbo.mod.utils.events.impl.game.PlayerInteractEvent
@@ -63,6 +64,7 @@ object PreciseGuessBurrow {
         val item = player?.mainHandItem
         if (item?.isEmpty == true) return
         if (item == null || "Spade" !in item.hoverName.string) return
+        BurrowDetector.pendingUseSpadeTitle = null
         if (System.nanoTime() - this.lastLavaParticle < TimeUnit.MILLISECONDS.toNanos(200L)) {
             event.isCanceled = true
             return

--- a/src/main/kotlin/net/sbo/mod/partyfinder/PartyPlayer.kt
+++ b/src/main/kotlin/net/sbo/mod/partyfinder/PartyPlayer.kt
@@ -1,6 +1,7 @@
 package net.sbo.mod.partyfinder
 
 import net.sbo.mod.SBOKotlin.API_URL
+import net.sbo.mod.SBOKotlin.logger
 import net.sbo.mod.diana.achievements.AchievementManager.trackWithCheckPlayer
 import net.sbo.mod.utils.Helper.sleep
 import net.sbo.mod.utils.Player
@@ -41,7 +42,7 @@ object PartyPlayer {
 
     fun load() {
         getPartyPlayerStats(forceRefresh = true) { stats ->
-            Chat.chat("§6[SBO] §aPlayer stats loaded: ${stats.name} (SB Level: ${stats.sbLvl})")
+            logger.info("§6[SBO] §aPlayer stats loaded: ${stats.name} (SB Level: ${stats.sbLvl})")
         }
     }
 

--- a/src/main/kotlin/net/sbo/mod/partyfinder/PartyPlayer.kt
+++ b/src/main/kotlin/net/sbo/mod/partyfinder/PartyPlayer.kt
@@ -42,7 +42,7 @@ object PartyPlayer {
 
     fun load() {
         getPartyPlayerStats(forceRefresh = true) { stats ->
-            logger.info("§6[SBO] §aPlayer stats loaded: ${stats.name} (SB Level: ${stats.sbLvl})")
+            logger.info("[SBO] Player stats loaded: ${stats.name} (SB Level: ${stats.sbLvl})")
         }
     }
 

--- a/src/main/kotlin/net/sbo/mod/settings/categories/Customization.kt
+++ b/src/main/kotlin/net/sbo/mod/settings/categories/Customization.kt
@@ -10,7 +10,7 @@ import java.io.File
 object Customization : CategoryKt("Customization") {
     init {
         separator {
-            this.title = "Waypoint Customization"
+            this.title = "Guess Color Customization"
         }
     }
 
@@ -18,14 +18,14 @@ object Customization : CategoryKt("Customization") {
         Color(0.6f, 0.2f, 0.8f).rgb) {
         this.name = Literal("Closest Guess Color")
         this.description = Literal("Pick a color for closest guess.")
-        this.allowAlpha = true
+        this.allowAlpha = false
     }
 
     var OtherGuessColor by color(
         Color(0.0f, 0.964f, 1.0f).rgb) {
         this.name = Literal("Other Guess Color")
         this.description = Literal("Pick a color for other guesses.")
-        this.allowAlpha = true
+        this.allowAlpha = false
     }
 
     var SubGuessColor by color(
@@ -33,49 +33,105 @@ object Customization : CategoryKt("Customization") {
     ) {
         this.name = Literal("Sub Guess Color")
         this.description = Literal("Color of inactive arrow guess locations. (only used if \"Show Arrow Sub Guesses\" enabled in Diana category)")
-        this.allowAlpha = true
+        this.allowAlpha = false
     }
 
     var OptimalOrderLineColor by color(
         Color(1.0f, 1.0f, 1.0f).rgb) {
         this.name = Literal("Optimal Order Line Color")
         this.description = Literal("Pick a color for optimal order line color. (line drawn between guesses in the optimal order to them, only used if \"Draw Optimal Order Lines\" enabled in Diana category)")
-        this.allowAlpha = true
+        this.allowAlpha = false
+    }
+
+    init {
+        separator {
+            this.title = "Burrow Color Customization"
+        }
     }
 
     var StartColor by color(
         Color(0.333f, 1.0f, 0.333f).rgb) {
         this.name = Literal("Start Burrow Color")
         this.description = Literal("Pick a color for start burrows.")
-        this.allowAlpha = true
+        this.allowAlpha = false
     }
 
     var MobColor by color(
         Color(1.0f, 0.333f, 0.333f).rgb) {
         this.name = Literal("Mob Burrow Color")
         this.description = Literal("Pick a color for mob burrows.")
-        this.allowAlpha = true
+        this.allowAlpha = false
     }
 
     var TreasureColor by color(
         Color(1f, 0.666f, 0.0f).rgb) {
         this.name = Literal("Treasure Burrow Color")
         this.description = Literal("Pick a color for treasure burrows.")
-        this.allowAlpha = true
+        this.allowAlpha = false
+    }
+
+    init {
+        separator {
+            this.title = "Waypoint Color Customization"
+        }
     }
 
     var RareMobColor by color(
         Color(1.0f, 0.84f, 0.0f).rgb) {
         this.name = Literal("Rare Mob Waypoint Color")
         this.description = Literal("Pick a color for rare mob waypoints.")
-        this.allowAlpha = true
+        this.allowAlpha = false
     }
 
     var OtherWaypointColor by color(
         Color(0.0f, 0.2f, 1.0f).rgb) {
         this.name = Literal("Other Waypoint Color")
         this.description = Literal("Pick a color for other waypoints, e.g., waypoints created from non-SBO player-sent coordinates. (Separate from rare mob color)")
+        this.allowAlpha = false
+    }
+
+    init {
+        separator {
+            this.title = "Glow Color Customization"
+        }
+    }
+
+    var KingMinosGlowColor by color(
+        Color(1.0f, 0.55f, 0.0f).rgb
+    ) {
+        this.name = Literal("King Minos Glow Color")
+        this.description = Literal("Glow color for King Minos.")
         this.allowAlpha = true
+    }
+
+    var MinosInquisitorGlowColor by color(
+        Color(1.0f, 0.35f, 0.75f).rgb
+    ) {
+        this.name = Literal("Minos Inquisitor Glow Color")
+        this.description = Literal("Glow color for Minos Inquisitor.")
+        this.allowAlpha = true
+    }
+
+    var ManticoreGlowColor by color(
+        Color(0.0f, 0.45f, 0.0f).rgb
+    ) {
+        this.name = Literal("Manticore Glow Color")
+        this.description = Literal("Glow color for Manticore.")
+        this.allowAlpha = true
+    }
+
+    var SphinxGlowColor by color(
+        Color(0.35f, 0.8f, 1.0f).rgb
+    ) {
+        this.name = Literal("Sphinx Glow Color")
+        this.description = Literal("Glow color for Sphinx.")
+        this.allowAlpha = true
+    }
+
+    init {
+        separator {
+            this.title = "Waypoint Customization"
+        }
     }
 
     var dynamicWaypointOpacity by boolean(true) {
@@ -93,12 +149,6 @@ object Customization : CategoryKt("Customization") {
         this.range = 0..100
         this.name = Literal("Waypoint Text Opacity")
         this.description = Literal("The opacity of the text on the rendered waypoints. 50 will make it 50% transparent, 100% fully opaque, 0% fully invisible, etc. (default 100)")
-    }
-
-    init {
-        separator {
-            this.title = "Waypoint Text Customization"
-        }
     }
 
     var waypointTextShadow by boolean(true) {
@@ -122,6 +172,12 @@ object Customization : CategoryKt("Customization") {
     var showTimesDug by boolean(true) {
         this.name = Literal("Show Times Dug")
         this.description = Literal("Shows times dug on the waypoint text for known burrows.")
+    }
+
+    init {
+        separator {
+            this.title = "Warp Title Customization"
+        }
     }
 
     var warpTitleAsSubtitle by boolean(false) {

--- a/src/main/kotlin/net/sbo/mod/settings/categories/Customization.kt
+++ b/src/main/kotlin/net/sbo/mod/settings/categories/Customization.kt
@@ -36,6 +36,13 @@ object Customization : CategoryKt("Customization") {
         this.allowAlpha = true
     }
 
+    var OptimalOrderLineColor by color(
+        Color(1.0f, 1.0f, 1.0f).rgb) {
+        this.name = Literal("Optimal Order Line Color")
+        this.description = Literal("Pick a color for optimal order line color. (line drawn between guesses in the optimal order to them, only used if \"Draw Optimal Order Lines\" enabled in Diana category)")
+        this.allowAlpha = true
+    }
+
     var StartColor by color(
         Color(0.333f, 1.0f, 0.333f).rgb) {
         this.name = Literal("Start Burrow Color")

--- a/src/main/kotlin/net/sbo/mod/settings/categories/Diana.kt
+++ b/src/main/kotlin/net/sbo/mod/settings/categories/Diana.kt
@@ -389,22 +389,22 @@ object Diana : CategoryKt("Diana") {
         }
     }
 
-    var rareTitleFadeIn by int(0) {
-        this.name = Literal("Rare Title Fade In")
+    var rareTitleFadeInTime by int(0) {
+        this.name = Literal("Rare Title Fade In Time")
         this.description = Literal("Fade-in (ticks) for rare mob titles. Enter 0 in all three settings to disable the titles.")
         this.range = 0..100
         this.slider = true
     }
 
-    var rareTitleTime by int(90) {
-        this.name = Literal("Rare Title Time")
+    var rareTitleStayTime by int(60) {
+        this.name = Literal("Rare Title Stay Time")
         this.description = Literal("Display time (ticks) for rare mob titles. Enter 0 in all three settings to disable the titles.")
         this.range = 0..100
         this.slider = true
     }
 
-    var rareTitleFadeOut by int(20) {
-        this.name = Literal("Rare Title Fade Out")
+    var rareTitleFadeOutTime by int(0) {
+        this.name = Literal("Rare Title Fade Out Time")
         this.description = Literal("Fade-out (ticks) for rare mob titles. Enter 0 in all three settings to disable the titles.")
         this.range = 0..100
         this.slider = true

--- a/src/main/kotlin/net/sbo/mod/settings/categories/Diana.kt
+++ b/src/main/kotlin/net/sbo/mod/settings/categories/Diana.kt
@@ -92,6 +92,11 @@ object Diana : CategoryKt("Diana") {
         this.description = Literal("Shows \"Possible\" text on sub guesses in addition to the block higlight. Might increase visual clutter in exchange of making subguesses more visible.")
     }
 
+    var drawOptimalOrderLines by boolean(false) {
+        this.name = Literal("Draw Optimal Order Lines")
+        this.description = Literal("Draws lines between burrows from closest to your current location to the farthest from current location (e.g., optimal order to do them in).")
+    }
+
     var showBeaconBeam by boolean(true) {
         this.name = Literal("Show Beacon Beam")
         this.description = Literal("Shows a beacon beam for waypoints going to the sky if enabled.")

--- a/src/main/kotlin/net/sbo/mod/settings/categories/Diana.kt
+++ b/src/main/kotlin/net/sbo/mod/settings/categories/Diana.kt
@@ -313,6 +313,11 @@ object Diana : CategoryKt("Diana") {
         this.description = Literal("Announces relic/shelmet/plushie/remedies in chat.")
     }
 
+    var hiltDropMessage by boolean(true) {
+        this.name = Literal("Hilt of Revelations Drop Message")
+        this.description = Literal("Sends rare drop message for Hilt of Revelations, since Hypixel does not send one.")
+    }
+
     var lootAnnouncerScreen by boolean(true) {
         this.name = Literal("Loot Screen Announcer")
         this.description = Literal("Announces chimera/stick/relic on screen.")
@@ -490,6 +495,20 @@ object Diana : CategoryKt("Diana") {
         this.description = Literal("Sends a text on King spawn 5 seconds after spawn, use {since} for mobs since mob, {chance} for mob chance.")
     }
 
+    init {
+        button {
+            title = "Send All Test Messages"
+            text = "Send Test"
+            description = "Sends all test messages for the Rare Mob spawn message."
+            onClick {
+                Chat.chat("Inq Message: " + Helper.getSpawnMessage(announceInqText[0], "inq"))
+                Chat.chat("Sphinx Message: " + Helper.getSpawnMessage(announceSphinxText[0], "sphinx"))
+                Chat.chat("Manti Message: " + Helper.getSpawnMessage(announceMantiText[0], "manti"))
+                Chat.chat("King Message: " + Helper.getSpawnMessage(announceKingText[0], "king"))
+            }
+        }
+    }
+
     var announceCocoon by boolean(true) {
         this.name = Literal("Send Message On Cocoon")
         this.description = Literal("Sends a message to party chat on cocoon.")
@@ -513,20 +532,6 @@ object Diana : CategoryKt("Diana") {
     var NoShurikenMobs by select(NoShurikenList.INQ, NoShurikenList.MANTICORE, NoShurikenList.KING, NoShurikenList.SPHINX) {
         this.name = Literal("Select which Mobs to Check")
         this.description = Literal("Select which mobs to check for shuriken.")
-    }
-
-    init {
-        button {
-            title = "Send All Test Messages"
-            text = "Send Test"
-            description = "Sends all test messages for the Rare Mob spawn message."
-            onClick {
-                Chat.chat("Inq Message: " + Helper.getSpawnMessage(announceInqText[0], "inq"))
-                Chat.chat("Sphinx Message: " + Helper.getSpawnMessage(announceSphinxText[0], "sphinx"))
-                Chat.chat("Manti Message: " + Helper.getSpawnMessage(announceMantiText[0], "manti"))
-                Chat.chat("King Message: " + Helper.getSpawnMessage(announceKingText[0], "king"))
-            }
-        }
     }
 
     init {

--- a/src/main/kotlin/net/sbo/mod/settings/categories/Diana.kt
+++ b/src/main/kotlin/net/sbo/mod/settings/categories/Diana.kt
@@ -473,13 +473,6 @@ object Diana : CategoryKt("Diana") {
         this.description = Literal("Highlights rare mobs (King, Manti, Sphinx, Inq) with a glowing effect.")
     }
 
-    var HighlightColor by color(
-        Color(0.0f, 0.964f, 1.0f).rgb) {
-        this.name = Literal("Highlight Color")
-        this.description = Literal("Color for the rare mob highlight effect.")
-        this.allowAlpha = true
-    }
-
     var announceInqText by strings("") {
         this.name = Literal("Send Text On Inq Spawn")
         this.description = Literal("Sends a text on Inq spawn 5 seconds after spawn, use {since} for mobs since mob, {chance} for mob chance.")

--- a/src/main/kotlin/net/sbo/mod/utils/Helper.kt
+++ b/src/main/kotlin/net/sbo/mod/utils/Helper.kt
@@ -32,6 +32,7 @@ import java.util.*
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
+import java.util.concurrent.CompletableFuture
 import java.util.regex.Pattern
 import kotlin.math.roundToInt
 import kotlin.math.roundToLong
@@ -114,8 +115,11 @@ object Helper {
             DianaTracker.trackChatRngDrop("Enchanted Book (Chimera 1) §b(+§b566 ✯ Magic Find)")
         }*/
 
-        sleep(50) {
-            updateItemPriceInfo()
+        // Workaround to not timeout on the first requests since there is lot of work being done that steals CPU time from our HTTP threads during game startup. Wait after at least 1 second of virtual thread carrier threads being available, and runAsync's ForkJoinPool task queue to become empty to be able to run our task.
+        sleep(1000) {
+            CompletableFuture.runAsync {
+                updateItemPriceInfo()
+            }
         }
     }
 

--- a/src/main/kotlin/net/sbo/mod/utils/SoundHandler.kt
+++ b/src/main/kotlin/net/sbo/mod/utils/SoundHandler.kt
@@ -53,6 +53,8 @@ object SoundHandler {
      * @param volume Volume level (0-1), combined with master volume
      */
     fun playCustomSound(sound: String, volume: Float) {
+        if (sound.isEmpty()) return
+
         // Combine per-sound volume (0-1) with global master volume
         val volumePercent = volume.coerceIn(0f, 1f) * Customization.masterVolume
 

--- a/src/main/kotlin/net/sbo/mod/utils/SoundHandler.kt
+++ b/src/main/kotlin/net/sbo/mod/utils/SoundHandler.kt
@@ -23,7 +23,10 @@ object SoundHandler {
 
     // Thread pool for audio processing - bounded and daemon threads
     private val AUDIO_EXECUTOR: ExecutorService = Executors.newSingleThreadExecutor { r ->
-        Thread(r, "sbo-audio-thread").apply { isDaemon = true }
+        Thread(r, "sbo-audio-thread").apply {
+            isDaemon = true
+            priority = Thread.NORM_PRIORITY + 1 // audio processing needs slightly more priority for less latency
+        }
     }
 
     /**

--- a/src/main/kotlin/net/sbo/mod/utils/game/Mayor.kt
+++ b/src/main/kotlin/net/sbo/mod/utils/game/Mayor.kt
@@ -4,70 +4,90 @@ import net.sbo.mod.SBOKotlin
 import net.sbo.mod.utils.data.MayorResponse
 import net.sbo.mod.utils.events.Register
 import net.sbo.mod.utils.http.Http
-import java.util.Calendar
-import java.util.Date
-import java.util.GregorianCalendar
+import java.util.*
 import kotlin.math.floor
-import kotlin.math.round
 
 object Mayor {
-    var dateMayorElected: Date? = null
-    var newMayorAtDate: Date? = null
+    private const val SKYBLOCK_EPOCH = 1560276000L
+    private const val SECONDS_PER_MINUTE = 0.8333333333333334
+    private const val SECONDS_PER_MONTH = 37200.0
+    private const val SECONDS_PER_DAY = 1200.0
+    private const val SECONDS_PER_HOUR = 50.0
+    private const val MONTHS_IN_YEAR = 12
+    private const val DAYS_IN_MONTH = 31
+    private const val ELECTION_DAY = 27
+    private const val ELECTION_MONTH = 3
+
+    private const val FALLBACK_MAYOR = "Diana"
+    private const val FALLBACK_PERK = "Mythological Ritual"
+
+    private var dateMayorElected: Date? = null
+    private var newMayorAtDate: Date? = null
     var mayor: String? = null
     var perks: MutableSet<String> = mutableSetOf()
-    var mayorApiError: Boolean = false
-    var apiLastUpdated: Long? = null
-    var minister: String? = null
+    private var mayorApiError: Boolean = false
+    private var apiLastUpdated: Long? = null
+    private var minister: String? = null
     var ministerPerk: String? = null
-    var skyblockDate: Date? = null
-    var skyblockDateString: String = ""
-    var refreshingMayor: Boolean = false
-    var newMayor: Boolean = false
-    var outDatedApi: Boolean = false
-    var sbYear: Int = 0
+    private var skyblockDate: Date? = null
+    private var skyblockDateString: String = ""
+    private var refreshingMayor: Boolean = false
+    private var newMayor: Boolean = false
+    private var outDatedApi: Boolean = false
+    private var sbYear: Int = 0
     var mayorElectedYear = 0
 
     fun init() {
         refreshMayorData()
-        Register.onTick(20 * 60) {
-            refreshMayorData()
-        }
+        Register.onTick(20 * 60) { refreshMayorData() }
     }
 
     private fun refreshMayorData() {
         skyblockDateString = calcSkyblockDate(System.currentTimeMillis())
-        if (skyblockDateString.isNotEmpty()) {
-            skyblockDate = convertStringToDate(skyblockDateString)
-            if (newMayorAtDate == null || newMayorAtDate!!.time < skyblockDate!!.time) {
-                newMayor = true
-                val calendar = Calendar.getInstance()
-                calendar.time = skyblockDate!!
-                val currentYear = calendar.get(Calendar.YEAR)
-                val compareDate = convertStringToDate("27.3.$currentYear")
-                if (compareDate.time > skyblockDate!!.time) {
-                    mayorElectedYear = currentYear - 1
-                    dateMayorElected = convertStringToDate("27.3.${currentYear - 1}")
-                    newMayorAtDate = convertStringToDate("27.3.$currentYear")
-                } else {
-                    mayorElectedYear = currentYear
-                    dateMayorElected = convertStringToDate("27.3.$currentYear")
-                    newMayorAtDate = convertStringToDate("27.3.${currentYear + 1}")
-                }
-            }
-            val calendar = Calendar.getInstance()
-            calendar.time = skyblockDate!!
-            sbYear = calendar.get(Calendar.YEAR)
-        }
+        if (skyblockDateString.isEmpty()) return
 
-        if (skyblockDate != null) {
-            if ((mayor === null || mayorApiError || newMayor || outDatedApi) && !refreshingMayor) {
-                getMayor()
-                newMayor = false
-            }
+        skyblockDate = convertStringToDate(skyblockDateString)
+        updateMayorElection()
+        updateSbYear()
+        fetchMayorIfNeeded()
+    }
+
+    private fun updateMayorElection() {
+        val newDate = newMayorAtDate ?: return
+        if (newDate.time >= (skyblockDate?.time ?: return)) return
+
+        newMayor = true
+        val currentYear = Calendar.getInstance().get(Calendar.YEAR)
+        val electionThisYear = date(ELECTION_DAY, ELECTION_MONTH, currentYear)
+
+        if (electionThisYear.time > skyblockDate!!.time) {
+            mayorElectedYear = currentYear - 1
+            dateMayorElected = date(ELECTION_DAY, ELECTION_MONTH, currentYear - 1)
+            newMayorAtDate = electionThisYear
+        } else {
+            mayorElectedYear = currentYear
+            dateMayorElected = electionThisYear
+            newMayorAtDate = date(ELECTION_DAY, ELECTION_MONTH, currentYear + 1)
         }
     }
 
-    internal fun getMayor() {
+    private fun updateSbYear() {
+        Calendar.getInstance().apply {
+            time = skyblockDate!!
+            sbYear = get(Calendar.YEAR)
+        }
+    }
+
+    private fun fetchMayorIfNeeded() {
+        if (skyblockDate == null) return
+        if (mayor != null && !mayorApiError && !newMayor && !outDatedApi) return
+        if (refreshingMayor) return
+
+        getMayor()
+        newMayor = false
+    }
+
+    private fun getMayor() {
         mayor = null
         perks.clear()
         refreshingMayor = true
@@ -75,99 +95,89 @@ object Mayor {
         Http.sendGetRequest("https://api.hypixel.net/resources/skyblock/election")
             .toJson<MayorResponse>(true) { response ->
                 refreshingMayor = false
-                if (response.success) {
-                    apiLastUpdated = response.lastUpdated
-                    mayor = response.mayor.name
-                    perks = response.mayor.perks.map { it.name }.toMutableSet()
-                    minister = response.mayor.minister?.name
-                    ministerPerk = response.mayor.minister?.perk?.name
-                    mayorApiError = false
-                    apiLastUpdated?.let { apiTimeStamp ->
-                        val apiDate = convertStringToDate(calcSkyblockDate(apiTimeStamp))
-                        if (dateMayorElected == null || apiDate.time >= dateMayorElected!!.time) {
-                            outDatedApi = false
-                        } else {
-                            outDatedApi = true
-                            mayor = "Diana"
-                            perks = mutableSetOf("Mythological Ritual")
-                        }
-                    }
-                } else {
-                    val errorMessage = response.error ?: "Unknown error"
-                    SBOKotlin.logger.error("API error: $errorMessage")
-                    mayorApiError = true
-                    mayor = "Diana"
-                    perks = mutableSetOf("Mythological Ritual")
+                if (!response.success) {
+                    handleApiError(response.error ?: "Unknown error")
+                    return@toJson
                 }
+                processMayorResponse(response)
             }
             .error { error ->
-                mayorApiError = true
-                mayor = "Diana"
-                perks = mutableSetOf("Mythological Ritual")
-                SBOKotlin.logger.error("Error getting mayor from API: ${error.message}")
-                refreshingMayor = false
+                handleApiError(error.message ?: "Request failed")
             }
     }
 
-    // ... (convertStringToDate und calcSkyblockDate bleiben unverändert)
+    private fun processMayorResponse(response: MayorResponse) {
+        apiLastUpdated = response.lastUpdated
+        mayor = response.mayor.name
+        perks = response.mayor.perks.map { it.name }.toMutableSet()
+        minister = response.mayor.minister?.name
+        ministerPerk = response.mayor.minister?.perk?.name
+        mayorApiError = false
+
+        checkApiFreshness()
+    }
+
+    private fun checkApiFreshness() {
+        val apiTimeStamp = apiLastUpdated ?: return
+        val apiDate = convertStringToDate(calcSkyblockDate(apiTimeStamp))
+        val electedDate = dateMayorElected
+
+        outDatedApi = electedDate != null && apiDate.time < electedDate.time
+        if (outDatedApi) applyFallback()
+    }
+
+    private fun handleApiError(message: String) {
+        mayorApiError = true
+        applyFallback()
+        SBOKotlin.logger.error("API error: $message")
+    }
+
+    private fun applyFallback() {
+        mayor = FALLBACK_MAYOR
+        perks = mutableSetOf(FALLBACK_PERK)
+    }
+
+    private fun date(day: Int, month: Int, year: Int): Date =
+        GregorianCalendar(year, month - 1, day).time
+
     private fun convertStringToDate(string: String): Date {
         val parts = string.split(".")
-        val day = parts[0].toInt()
-        val month = parts[1].toInt() - 1
-        val year = parts[2].toInt()
-        return GregorianCalendar(year, month, day).time
+        return date(parts[0].toInt(), parts[1].toInt(), parts[2].toInt())
     }
 
     private fun calcSkyblockDate(date: Long): String {
-        val monthsInYear = 12
-        val secondsPerMinute = 0.8333333333333334
-        val secondsPerMonth = 37200.0
-
         val unix = floor(date.toDouble() / 1000).toLong()
-        var secondsSinceLastLog = unix - 1560276000L
+        var secondsSinceEpoch = unix - SKYBLOCK_EPOCH
 
         var year = 1
         var month = 1
         var day = 1
         var hour = 6
-        var minute = 0
 
-        val secondsPerYear = secondsPerMonth * monthsInYear
-        val secondsPerDay = 1200.0
-        val secondsPerHour = 50.0
+        val secondsPerYear = SECONDS_PER_MONTH * MONTHS_IN_YEAR
 
-        val yearDiff = floor(secondsSinceLastLog / secondsPerYear).toInt()
-        secondsSinceLastLog -= yearDiff * secondsPerYear.toLong()
+        val yearDiff = floor(secondsSinceEpoch / secondsPerYear).toInt()
+        secondsSinceEpoch -= yearDiff * secondsPerYear.toLong()
         year += yearDiff
 
-        val monthDiff = floor(secondsSinceLastLog / secondsPerMonth).toInt() % 13
-        secondsSinceLastLog -= monthDiff * secondsPerMonth.toLong()
-        month = (month + monthDiff) % 13
-        if (month == 0) month = 13
+        val monthDiff = floor(secondsSinceEpoch / SECONDS_PER_MONTH).toInt() % 13
+        secondsSinceEpoch -= monthDiff * SECONDS_PER_MONTH.toLong()
+        month = (month + monthDiff).let { if (it == 0) 13 else it }
 
-        val dayDiff = floor(secondsSinceLastLog / secondsPerDay).toInt() % 32
-        secondsSinceLastLog -= dayDiff * secondsPerDay.toLong()
-        day = (day + dayDiff) % 32
-        if (day == 0) day = 32
+        val dayDiff = floor(secondsSinceEpoch / SECONDS_PER_DAY).toInt() % 32
+        secondsSinceEpoch -= dayDiff * SECONDS_PER_DAY.toLong()
+        day = (day + dayDiff).let { if (it == 0) DAYS_IN_MONTH else it }
 
-        val hourDiff = floor(secondsSinceLastLog / secondsPerHour).toInt() % 24
-        secondsSinceLastLog -= hourDiff * secondsPerHour.toLong()
+        val hourDiff = floor(secondsSinceEpoch / SECONDS_PER_HOUR).toInt() % 24
+        secondsSinceEpoch -= hourDiff * SECONDS_PER_HOUR.toLong()
         hour = (hour + hourDiff) % 24
 
         if (hour < 6) {
-            if (day < 31) {
-                day += 1
-            } else {
-                day = 1
-                month += 1
-            }
+            day = if (day < DAYS_IN_MONTH) day + 1 else 1
+            if (day == 1) month++
         }
 
-        val minuteDiff = floor(secondsSinceLastLog / secondsPerMinute).toInt() % 60
-        secondsSinceLastLog -= minuteDiff * secondsPerMinute.toLong()
-        minute = (minute + minuteDiff) % 60
-
-        minute = (round(minute / 5.0) * 5).toInt() % 60
+        floor(secondsSinceEpoch / SECONDS_PER_MINUTE).toInt() % 60
 
         return "$day.$month.$year"
     }

--- a/src/main/kotlin/net/sbo/mod/utils/game/Mayor.kt
+++ b/src/main/kotlin/net/sbo/mod/utils/game/Mayor.kt
@@ -4,90 +4,70 @@ import net.sbo.mod.SBOKotlin
 import net.sbo.mod.utils.data.MayorResponse
 import net.sbo.mod.utils.events.Register
 import net.sbo.mod.utils.http.Http
-import java.util.*
+import java.util.Calendar
+import java.util.Date
+import java.util.GregorianCalendar
 import kotlin.math.floor
+import kotlin.math.round
 
 object Mayor {
-    private const val SKYBLOCK_EPOCH = 1560276000L
-    private const val SECONDS_PER_MINUTE = 0.8333333333333334
-    private const val SECONDS_PER_MONTH = 37200.0
-    private const val SECONDS_PER_DAY = 1200.0
-    private const val SECONDS_PER_HOUR = 50.0
-    private const val MONTHS_IN_YEAR = 12
-    private const val DAYS_IN_MONTH = 31
-    private const val ELECTION_DAY = 27
-    private const val ELECTION_MONTH = 3
-
-    private const val FALLBACK_MAYOR = "Diana"
-    private const val FALLBACK_PERK = "Mythological Ritual"
-
-    private var dateMayorElected: Date? = null
-    private var newMayorAtDate: Date? = null
+    var dateMayorElected: Date? = null
+    var newMayorAtDate: Date? = null
     var mayor: String? = null
     var perks: MutableSet<String> = mutableSetOf()
-    private var mayorApiError: Boolean = false
-    private var apiLastUpdated: Long? = null
-    private var minister: String? = null
+    var mayorApiError: Boolean = false
+    var apiLastUpdated: Long? = null
+    var minister: String? = null
     var ministerPerk: String? = null
-    private var skyblockDate: Date? = null
-    private var skyblockDateString: String = ""
-    private var refreshingMayor: Boolean = false
-    private var newMayor: Boolean = false
-    private var outDatedApi: Boolean = false
-    private var sbYear: Int = 0
+    var skyblockDate: Date? = null
+    var skyblockDateString: String = ""
+    var refreshingMayor: Boolean = false
+    var newMayor: Boolean = false
+    var outDatedApi: Boolean = false
+    var sbYear: Int = 0
     var mayorElectedYear = 0
 
     fun init() {
         refreshMayorData()
-        Register.onTick(20 * 60) { refreshMayorData() }
+        Register.onTick(20 * 60) {
+            refreshMayorData()
+        }
     }
 
     private fun refreshMayorData() {
         skyblockDateString = calcSkyblockDate(System.currentTimeMillis())
-        if (skyblockDateString.isEmpty()) return
+        if (skyblockDateString.isNotEmpty()) {
+            skyblockDate = convertStringToDate(skyblockDateString)
+            if (newMayorAtDate == null || newMayorAtDate!!.time < skyblockDate!!.time) {
+                newMayor = true
+                val calendar = Calendar.getInstance()
+                calendar.time = skyblockDate!!
+                val currentYear = calendar.get(Calendar.YEAR)
+                val compareDate = convertStringToDate("27.3.$currentYear")
+                if (compareDate.time > skyblockDate!!.time) {
+                    mayorElectedYear = currentYear - 1
+                    dateMayorElected = convertStringToDate("27.3.${currentYear - 1}")
+                    newMayorAtDate = convertStringToDate("27.3.$currentYear")
+                } else {
+                    mayorElectedYear = currentYear
+                    dateMayorElected = convertStringToDate("27.3.$currentYear")
+                    newMayorAtDate = convertStringToDate("27.3.${currentYear + 1}")
+                }
+            }
+            val calendar = Calendar.getInstance()
+            calendar.time = skyblockDate!!
+            sbYear = calendar.get(Calendar.YEAR)
+        }
 
-        skyblockDate = convertStringToDate(skyblockDateString)
-        updateMayorElection()
-        updateSbYear()
-        fetchMayorIfNeeded()
-    }
-
-    private fun updateMayorElection() {
-        val newDate = newMayorAtDate ?: return
-        if (newDate.time >= (skyblockDate?.time ?: return)) return
-
-        newMayor = true
-        val currentYear = Calendar.getInstance().get(Calendar.YEAR)
-        val electionThisYear = date(ELECTION_DAY, ELECTION_MONTH, currentYear)
-
-        if (electionThisYear.time > skyblockDate!!.time) {
-            mayorElectedYear = currentYear - 1
-            dateMayorElected = date(ELECTION_DAY, ELECTION_MONTH, currentYear - 1)
-            newMayorAtDate = electionThisYear
-        } else {
-            mayorElectedYear = currentYear
-            dateMayorElected = electionThisYear
-            newMayorAtDate = date(ELECTION_DAY, ELECTION_MONTH, currentYear + 1)
+        if (skyblockDate != null) {
+            if ((mayor === null || mayorApiError || newMayor || outDatedApi) && !refreshingMayor) {
+                getMayor()
+                newMayor = false
+            }
         }
     }
 
-    private fun updateSbYear() {
-        Calendar.getInstance().apply {
-            time = skyblockDate!!
-            sbYear = get(Calendar.YEAR)
-        }
-    }
-
-    private fun fetchMayorIfNeeded() {
-        if (skyblockDate == null) return
-        if (mayor != null && !mayorApiError && !newMayor && !outDatedApi) return
-        if (refreshingMayor) return
-
-        getMayor()
-        newMayor = false
-    }
-
-    private fun getMayor() {
+    internal fun getMayor() {
         mayor = null
         perks.clear()
         refreshingMayor = true
@@ -95,89 +75,99 @@ object Mayor {
         Http.sendGetRequest("https://api.hypixel.net/resources/skyblock/election")
             .toJson<MayorResponse>(true) { response ->
                 refreshingMayor = false
-                if (!response.success) {
-                    handleApiError(response.error ?: "Unknown error")
-                    return@toJson
+                if (response.success) {
+                    apiLastUpdated = response.lastUpdated
+                    mayor = response.mayor.name
+                    perks = response.mayor.perks.map { it.name }.toMutableSet()
+                    minister = response.mayor.minister?.name
+                    ministerPerk = response.mayor.minister?.perk?.name
+                    mayorApiError = false
+                    apiLastUpdated?.let { apiTimeStamp ->
+                        val apiDate = convertStringToDate(calcSkyblockDate(apiTimeStamp))
+                        if (dateMayorElected == null || apiDate.time >= dateMayorElected!!.time) {
+                            outDatedApi = false
+                        } else {
+                            outDatedApi = true
+                            mayor = "Diana"
+                            perks = mutableSetOf("Mythological Ritual")
+                        }
+                    }
+                } else {
+                    val errorMessage = response.error ?: "Unknown error"
+                    SBOKotlin.logger.error("API error: $errorMessage")
+                    mayorApiError = true
+                    mayor = "Diana"
+                    perks = mutableSetOf("Mythological Ritual")
                 }
-                processMayorResponse(response)
             }
             .error { error ->
-                handleApiError(error.message ?: "Request failed")
+                mayorApiError = true
+                mayor = "Diana"
+                perks = mutableSetOf("Mythological Ritual")
+                SBOKotlin.logger.error("Error getting mayor from API: ${error.message}")
+                refreshingMayor = false
             }
     }
 
-    private fun processMayorResponse(response: MayorResponse) {
-        apiLastUpdated = response.lastUpdated
-        mayor = response.mayor.name
-        perks = response.mayor.perks.map { it.name }.toMutableSet()
-        minister = response.mayor.minister?.name
-        ministerPerk = response.mayor.minister?.perk?.name
-        mayorApiError = false
-
-        checkApiFreshness()
-    }
-
-    private fun checkApiFreshness() {
-        val apiTimeStamp = apiLastUpdated ?: return
-        val apiDate = convertStringToDate(calcSkyblockDate(apiTimeStamp))
-        val electedDate = dateMayorElected
-
-        outDatedApi = electedDate != null && apiDate.time < electedDate.time
-        if (outDatedApi) applyFallback()
-    }
-
-    private fun handleApiError(message: String) {
-        mayorApiError = true
-        applyFallback()
-        SBOKotlin.logger.error("API error: $message")
-    }
-
-    private fun applyFallback() {
-        mayor = FALLBACK_MAYOR
-        perks = mutableSetOf(FALLBACK_PERK)
-    }
-
-    private fun date(day: Int, month: Int, year: Int): Date =
-        GregorianCalendar(year, month - 1, day).time
-
+    // ... (convertStringToDate und calcSkyblockDate bleiben unverändert)
     private fun convertStringToDate(string: String): Date {
         val parts = string.split(".")
-        return date(parts[0].toInt(), parts[1].toInt(), parts[2].toInt())
+        val day = parts[0].toInt()
+        val month = parts[1].toInt() - 1
+        val year = parts[2].toInt()
+        return GregorianCalendar(year, month, day).time
     }
 
     private fun calcSkyblockDate(date: Long): String {
+        val monthsInYear = 12
+        val secondsPerMinute = 0.8333333333333334
+        val secondsPerMonth = 37200.0
+
         val unix = floor(date.toDouble() / 1000).toLong()
-        var secondsSinceEpoch = unix - SKYBLOCK_EPOCH
+        var secondsSinceLastLog = unix - 1560276000L
 
         var year = 1
         var month = 1
         var day = 1
         var hour = 6
+        var minute = 0
 
-        val secondsPerYear = SECONDS_PER_MONTH * MONTHS_IN_YEAR
+        val secondsPerYear = secondsPerMonth * monthsInYear
+        val secondsPerDay = 1200.0
+        val secondsPerHour = 50.0
 
-        val yearDiff = floor(secondsSinceEpoch / secondsPerYear).toInt()
-        secondsSinceEpoch -= yearDiff * secondsPerYear.toLong()
+        val yearDiff = floor(secondsSinceLastLog / secondsPerYear).toInt()
+        secondsSinceLastLog -= yearDiff * secondsPerYear.toLong()
         year += yearDiff
 
-        val monthDiff = floor(secondsSinceEpoch / SECONDS_PER_MONTH).toInt() % 13
-        secondsSinceEpoch -= monthDiff * SECONDS_PER_MONTH.toLong()
-        month = (month + monthDiff).let { if (it == 0) 13 else it }
+        val monthDiff = floor(secondsSinceLastLog / secondsPerMonth).toInt() % 13
+        secondsSinceLastLog -= monthDiff * secondsPerMonth.toLong()
+        month = (month + monthDiff) % 13
+        if (month == 0) month = 13
 
-        val dayDiff = floor(secondsSinceEpoch / SECONDS_PER_DAY).toInt() % 32
-        secondsSinceEpoch -= dayDiff * SECONDS_PER_DAY.toLong()
-        day = (day + dayDiff).let { if (it == 0) DAYS_IN_MONTH else it }
+        val dayDiff = floor(secondsSinceLastLog / secondsPerDay).toInt() % 32
+        secondsSinceLastLog -= dayDiff * secondsPerDay.toLong()
+        day = (day + dayDiff) % 32
+        if (day == 0) day = 32
 
-        val hourDiff = floor(secondsSinceEpoch / SECONDS_PER_HOUR).toInt() % 24
-        secondsSinceEpoch -= hourDiff * SECONDS_PER_HOUR.toLong()
+        val hourDiff = floor(secondsSinceLastLog / secondsPerHour).toInt() % 24
+        secondsSinceLastLog -= hourDiff * secondsPerHour.toLong()
         hour = (hour + hourDiff) % 24
 
         if (hour < 6) {
-            day = if (day < DAYS_IN_MONTH) day + 1 else 1
-            if (day == 1) month++
+            if (day < 31) {
+                day += 1
+            } else {
+                day = 1
+                month += 1
+            }
         }
 
-        floor(secondsSinceEpoch / SECONDS_PER_MINUTE).toInt() % 60
+        val minuteDiff = floor(secondsSinceLastLog / secondsPerMinute).toInt() % 60
+        secondsSinceLastLog -= minuteDiff * secondsPerMinute.toLong()
+        minute = (minute + minuteDiff) % 60
+
+        minute = (round(minute / 5.0) * 5).toInt() % 60
 
         return "$day.$month.$year"
     }

--- a/src/main/kotlin/net/sbo/mod/utils/http/Http.kt
+++ b/src/main/kotlin/net/sbo/mod/utils/http/Http.kt
@@ -15,8 +15,8 @@ import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
 
 object Http {
-    private const val CONNECT_TIMEOUT = 20_000L
-    private const val REQUEST_TIMEOUT = 20_000L
+    private const val CONNECT_TIMEOUT = 30_000L
+    private const val REQUEST_TIMEOUT = 30_000L
 
     private val USER_AGENT =
         "SBO-Kotlin-Mod/${SBOKotlin.version}+${SharedConstants.getCurrentVersion().name()}"
@@ -60,21 +60,22 @@ object Http {
     fun sendGetRequest(urlString: String): HttpRequestHandle {
         val handle = HttpRequestHandle()
 
-        val uri = URI.create(urlString)
-        val httpVersion = if (uri.host in HTTP2_ONLY) HttpClient.Version.HTTP_2 else HTTP_3_OR_2
-
-        val request = HttpRequest.newBuilder()
-            .version(httpVersion)
-            .uri(uri)
-            .timeout(Duration.ofMillis(REQUEST_TIMEOUT))
-            .header("User-Agent", USER_AGENT)
-            .GET()
-            .build()
-
         EXECUTOR.execute {
             try {
+                val uri = URI.create(urlString)
+                val httpVersion = if (uri.host in HTTP2_ONLY) HttpClient.Version.HTTP_2 else HTTP_3_OR_2
+
+                val request = HttpRequest.newBuilder()
+                    .version(httpVersion)
+                    .uri(uri)
+                    .timeout(Duration.ofMillis(REQUEST_TIMEOUT))
+                    .header("User-Agent", USER_AGENT)
+                    .GET()
+                    .build()
+
                 val response = CLIENT.send(request, BodyHandlers.ofInputStream())
                 val code = response.statusCode()
+
                 handle.complete(
                     HttpResponse(
                         code,

--- a/src/main/kotlin/net/sbo/mod/utils/render/RenderUtils3D.kt
+++ b/src/main/kotlin/net/sbo/mod/utils/render/RenderUtils3D.kt
@@ -10,7 +10,6 @@ import net.minecraft.client.gui.Font
 import net.minecraft.client.renderer.MultiBufferSource
 import net.minecraft.client.renderer.texture.OverlayTexture
 import net.minecraft.client.renderer.blockentity.BeaconRenderer
-import net.minecraft.client.renderer.rendertype.RenderTypes
 import net.minecraft.gizmos.GizmoStyle
 import net.minecraft.gizmos.Gizmos
 import net.minecraft.network.chat.Component
@@ -239,7 +238,7 @@ object RenderUtils3D {
             val ny = upVec.y.toFloat()
             val nz = upVec.z.toFloat()
 
-            val renderLayer = RenderTypes.LINES
+            val renderLayer = SboRenderLayers.LINES_THROUGH_WALLS
 
             //#if MC > 1.21.11
             //$$ context.submitNodeCollector().submitCustomGeometry(

--- a/src/main/kotlin/net/sbo/mod/utils/render/SboRenderLayers.kt
+++ b/src/main/kotlin/net/sbo/mod/utils/render/SboRenderLayers.kt
@@ -5,6 +5,12 @@ import net.minecraft.client.renderer.rendertype.RenderSetup
 import net.minecraft.client.renderer.rendertype.RenderType
 
 object SboRenderLayers {
+    val LINES_THROUGH_WALLS: RenderType = RenderType.create(
+        "sbo/lines_through_walls",
+        RenderSetup.builder(SboRenderPipelines.LINES_THROUGH_WALLS)
+            .createRenderSetup()
+    )
+
     //#if MC < 26.1
     val BEACON_BEAM_OPAQUE_THROUGH_WALLS: RenderType = RenderType.create(
         "sbo/beacon_beam_opaque_through_walls",

--- a/src/main/kotlin/net/sbo/mod/utils/render/SboRenderPipelines.kt
+++ b/src/main/kotlin/net/sbo/mod/utils/render/SboRenderPipelines.kt
@@ -2,7 +2,10 @@ package net.sbo.mod.utils.render
 
 import com.mojang.blaze3d.pipeline.BlendFunction
 import com.mojang.blaze3d.pipeline.RenderPipeline
-//#if MC < 26.1
+//#if MC > 1.21.11
+//$$ import com.mojang.blaze3d.pipeline.DepthStencilState
+//$$ import com.mojang.blaze3d.platform.CompareOp
+//#else
 import com.mojang.blaze3d.platform.DepthTestFunction
 //#endif
 import com.mojang.blaze3d.vertex.DefaultVertexFormat
@@ -12,6 +15,22 @@ import net.sbo.mod.SBOKotlin
 
 /** Add new pipelines to [net.sbo.mod.compat.IrisCompatibility] */
 object SboRenderPipelines {
+    val LINES_THROUGH_WALLS: RenderPipeline = RenderPipelines.register(
+        RenderPipeline.builder(RenderPipelines.LINES_SNIPPET)
+            .withLocation(SBOKotlin.id("pipeline/line_through_walls"))
+            //#if MC > 1.21.11
+            //$$ .withDepthStencilState(DepthStencilState(CompareOp.ALWAYS_PASS, false, 0.0f, 0.0f))
+            //#else
+            .withCull(false)
+            .withShaderDefine("shad")
+            .withVertexFormat(DefaultVertexFormat.POSITION_COLOR_NORMAL_LINE_WIDTH, Mode.LINES)
+            .withBlend(BlendFunction.TRANSLUCENT)
+            .withDepthWrite(false)
+            .withDepthTestFunction(DepthTestFunction.NO_DEPTH_TEST)
+            //#endif
+            .build()
+    )
+
     //#if MC < 26.1
     val BEACON_BEAM_OPAQUE_THROUGH_WALLS: RenderPipeline = RenderPipeline.builder(RenderPipelines.BEACON_BEAM_SNIPPET)
         .withLocation(SBOKotlin.id("beacon_beam_opaque_through_walls"))

--- a/src/main/kotlin/net/sbo/mod/utils/waypoint/Waypoint.kt
+++ b/src/main/kotlin/net/sbo/mod/utils/waypoint/Waypoint.kt
@@ -150,10 +150,14 @@ class Waypoint(
                 val text = "§" + (if (this.type == "rareMob" || this.type == "world") "d" else "b") + "Warp §e$warpName$distanceText"
                 val asSubtitle = Customization.warpTitleAsSubtitle
 
-                val title = if (asSubtitle) "" else text
-                val subtitle = if (asSubtitle) text else null
+                val titleBusy = !mc.gui.title?.string.isNullOrEmpty() && mc.gui.titleTime > 0 // When asSubtitle is disabled, Helper.showTitle checks internally if busy or not; but when its subtitle, it appends warp subtitle inside another one, e.g. Use Spade one, with higher duration, causing warp title to keep showing as subtitle even after warping till the main title (e.g., Use Spade one) expires; this makes it delay warp title till the original title disappears which fixes the issue.
 
-                Helper.showTitle(title, subtitle, 0, 1, 0, overwrite = false) // 1 ticks because next tick this will be called again. Overwrite false to not wipe rare mob title or use spade title.
+                if (!asSubtitle || !titleBusy) {
+                    val title = if (asSubtitle) "" else text
+                    val subtitle = if (asSubtitle) text else null
+
+                    Helper.showTitle(title, subtitle, 0, 1, 0, overwrite = false) // 1 ticks because next tick this will be called again. Overwrite false to not wipe rare mob title or use spade title.
+                }
             }
         } else {
             this.formattedText = "${this.text}${this.distanceText}$timesDugText"
@@ -230,7 +234,7 @@ class Waypoint(
                 val newest = inqWaypoints.lastOrNull() == this
 
                 if (newest) isClosest = true
-                this.line = newest && Diana.inqLine
+                this.line = newest && Diana.inqLine && this.distanceRaw >= 8.0
 
                 if (newest) {
                     setWarpText()

--- a/src/main/kotlin/net/sbo/mod/utils/waypoint/Waypoint.kt
+++ b/src/main/kotlin/net/sbo/mod/utils/waypoint/Waypoint.kt
@@ -137,7 +137,7 @@ class Waypoint(
         val timesDugText = if (showTimesDug && dist) " §7[§" + (if (timesDug >= 1) "6" else "e") + timesDug + "§7/§a2§7]" else ""
 
         if (isClosest) {
-            val closest = WaypointManager.getClosestWarp(this.pos)
+            val closest = WaypointManager.getFinalClosestWarp(this.pos)
 
             this.formattedText = closest?.let {
                 "$text§7 (warp $it)${this.distanceText}$timesDugText"

--- a/src/main/kotlin/net/sbo/mod/utils/waypoint/WaypointManager.kt
+++ b/src/main/kotlin/net/sbo/mod/utils/waypoint/WaypointManager.kt
@@ -36,7 +36,6 @@ import kotlin.math.roundToInt
 
 object WaypointManager {
     private val waypoints = ConcurrentHashMap<String, CopyOnWriteArrayList<Waypoint>>()
-    private var closestWaypoint: Pair<Waypoint?, Double> = null to 1000.0
     private val rareMobs: Set<String> = setOf(
         "minos inquisitor",
         "inquisitor",
@@ -249,7 +248,6 @@ object WaypointManager {
                 }
             }
 
-            closestWaypoint = getClosestWaypointFrom(playerPos) ?: null to 1000.0
             val bestGuessWp = getBestGuess()
 
             val rareWp = getWaypointsOfType("rareMob")
@@ -273,9 +271,9 @@ object WaypointManager {
                 Helper.showTitle(
                     "§r§6§l<§b§l§kO§6§l> §d§lINQUISITOR! §6§l<§b§l§kO§6§l>",
                     player.ifEmpty { null },
-                    Diana.rareTitleFadeIn,
-                    Diana.rareTitleTime,
-                    Diana.rareTitleFadeOut
+                    Diana.rareTitleFadeInTime,
+                    Diana.rareTitleStayTime,
+                    Diana.rareTitleFadeOutTime
                 )
                 playCustomSound(
                     SboDataObject.soundSettingsData.inqSound,
@@ -288,9 +286,9 @@ object WaypointManager {
                 Helper.showTitle(
                     "§r§6§l<§b§l§kO§6§l> §6§lKING MINOS! §6§l<§b§l§kO§6§l>",
                     player.ifEmpty { null },
-                    Diana.rareTitleFadeIn,
-                    Diana.rareTitleTime,
-                    Diana.rareTitleFadeOut
+                    Diana.rareTitleFadeInTime,
+                    Diana.rareTitleStayTime,
+                    Diana.rareTitleFadeOutTime
                 )
                 playCustomSound(
                     SboDataObject.soundSettingsData.kingSound,
@@ -303,9 +301,9 @@ object WaypointManager {
                 Helper.showTitle(
                     "§r§6§l<§b§l§kO§6§l> §2§lMANTICORE! §6§l<§b§l§kO§6§l>",
                     player.ifEmpty { null },
-                    Diana.rareTitleFadeIn,
-                    Diana.rareTitleTime,
-                    Diana.rareTitleFadeOut
+                    Diana.rareTitleFadeInTime,
+                    Diana.rareTitleStayTime,
+                    Diana.rareTitleFadeOutTime
                 )
                 playCustomSound(
                     SboDataObject.soundSettingsData.mantiSound,
@@ -318,9 +316,9 @@ object WaypointManager {
                 Helper.showTitle(
                     "§r§6§l<§b§l§kO§6§l> §9§lSPHINX! §6§l<§b§l§kO§6§l>",
                     player.ifEmpty { null },
-                    Diana.rareTitleFadeIn,
-                    Diana.rareTitleTime,
-                    Diana.rareTitleFadeOut
+                    Diana.rareTitleFadeInTime,
+                    Diana.rareTitleStayTime,
+                    Diana.rareTitleFadeOutTime
                 )
                 playCustomSound(
                     SboDataObject.soundSettingsData.sphinxSound,
@@ -333,9 +331,9 @@ object WaypointManager {
                 Helper.showTitle(
                     "§r§6§l<§b§l§kO§6§l> §3§lRARE MOB! §6§l<§b§l§kO§6§l>",
                     player.ifEmpty { null },
-                    Diana.rareTitleFadeIn,
-                    Diana.rareTitleTime,
-                    Diana.rareTitleFadeOut
+                    Diana.rareTitleFadeInTime,
+                    Diana.rareTitleStayTime,
+                    Diana.rareTitleFadeOutTime
                 )
                 playCustomSound(
                     SboDataObject.soundSettingsData.rareMobSound,
@@ -650,8 +648,12 @@ object WaypointManager {
             color.blue / 255f
         )
 
-        chain.zipWithNext().forEach { (a, b) ->
+        chain.zipWithNext().forEachIndexed { index, (a, b) ->
             val bDistance = Player.getLastPosition().distanceTo(b.pos)
+
+            if (index >= 2 && bDistance > 70) {
+                return@forEachIndexed
+            }
 
             val opacity =
                 (
@@ -692,9 +694,6 @@ object WaypointManager {
      * @param waypoint The waypoint to remove.
      */
     fun removeWaypoint(waypoint: Waypoint) {
-        if (closestWaypoint.first == waypoint) {
-            closestWaypoint = null to 1000.0
-        }
         waypoints[waypoint.type]?.remove(waypoint)
     }
 
@@ -722,9 +721,6 @@ object WaypointManager {
         val waypoint = list?.find { it.pos.roundLocationToBlock() == pos.roundLocationToBlock() }
         if (waypoint != null) {
             list.remove(waypoint)
-            if (closestWaypoint.first == waypoint) {
-                closestWaypoint = null to 1000.0
-            }
         }
     }
 
@@ -854,19 +850,6 @@ object WaypointManager {
             .minByOrNull { if (Diana.ignoreYLevel) it.pos.distanceToIgnoringY(pos) else it.pos.distanceTo(pos) }
     }
 
-    private fun getClosestWaypointFrom(pos: SboVec): Pair<Waypoint, Double>? {
-        return getClosestWaypointFrom(pos, getAllGuessesAndBurrows())
-    }
-
-    private fun getClosestWaypointFrom(pos: SboVec, waypoints: List<Waypoint>): Pair<Waypoint, Double>? {
-        return waypoints
-            .filter { !it.hidden }
-            .map { waypoint ->
-                waypoint to pos.distanceTo(waypoint.pos)
-            }
-            .minByOrNull { it.second }
-    }
-
     private fun getClosestWarp(pos: SboVec): String? = getClosestWarp(pos, Player.getLastPosition())
 
     /**
@@ -928,14 +911,19 @@ object WaypointManager {
             closestDistance = secondClosestDistance
         }
 
-        if (Diana.ignoreYLevel) playerDistance = pos.distanceToIgnoringY(playerPos)
+        val extra = closestWarpPoint?.extraBlocks ?: 0
 
-        val condition1 = playerDistance > closestDistance + Diana.warpDiff + (closestWarpPoint?.extraBlocks ?: 0)
-        val condition2 = condition1 && (closestWaypoint.second > 60 || getWaypointsOfType("rareMob").isNotEmpty() || getWaypointsOfType("world").isNotEmpty())
+        val warpIsWorthIt =
+            playerDistance > closestDistance + Diana.warpDiff + extra
 
-        val condition = if (Diana.dontWarpIfBurrowClose) condition2 else condition1
+        val targetIsFarEnough =
+            !Diana.dontWarpIfBurrowClose ||
+            playerDistance > 60
 
-        return if (condition) closestWarp else null
+        return if (warpIsWorthIt && targetIsFarEnough)
+            closestWarp
+        else
+            null
     }
 
     /**

--- a/src/main/kotlin/net/sbo/mod/utils/waypoint/WaypointManager.kt
+++ b/src/main/kotlin/net/sbo/mod/utils/waypoint/WaypointManager.kt
@@ -809,6 +809,11 @@ object WaypointManager {
      * @return The name of the closest warp, or null if no warps are available.
      */
     fun getClosestWarp(pos: SboVec): String? {
+        if (BurrowDetector.pendingUseSpadeTitle != null) {
+            // Prevent warping before using spade.
+            return null
+        }
+
         var warps = hubWarps.filter { it.value.unlocked }.mapValues { it.value }
         for (warp in Diana.allowedWarps) {
             val warpName = warp.name.lowercase()

--- a/src/main/kotlin/net/sbo/mod/utils/waypoint/WaypointManager.kt
+++ b/src/main/kotlin/net/sbo/mod/utils/waypoint/WaypointManager.kt
@@ -8,6 +8,7 @@ import net.minecraft.world.entity.decoration.ArmorStand
 import net.minecraft.world.level.block.Blocks
 import net.minecraft.world.level.block.state.BlockState
 import net.sbo.mod.SBOKotlin.mc
+import net.sbo.mod.diana.DianaTracker
 import net.sbo.mod.diana.burrows.BurrowDetector
 import net.sbo.mod.diana.guesses.ArrowGuessBurrow
 import net.sbo.mod.settings.categories.Customization
@@ -45,6 +46,8 @@ object WaypointManager {
         "king",
         "sphinx"
     )
+
+    private const val HUB_WIZARD_MIN_GAP = 20.0
 
     fun init() {
         Register.command("sbosendping") { args ->
@@ -88,14 +91,15 @@ object WaypointManager {
                         return@onChatMessage
                     }
 
+                    val isOwnSpawn = player.contains(selfName)
                     val mobDisplayName = notifyRareMob(player, mobType)
 
                     addRareMobWaypoint(
                         player,
                         pos,
                         mobType,
-                        selfName,
-                        mobDisplayName
+                        mobDisplayName,
+                        isOwnSpawn
                     )
                 } else if (patcherWaypoints) {
                     if (hideOwnWaypoints.contains(HideOwnWaypoints.NORMAL) && player.contains(selfName)) return@onChatMessage
@@ -455,13 +459,23 @@ object WaypointManager {
             val name = stand.customName?.string ?: return@forEach
             if (name.contains("0/")) return@forEach
 
-            val mobType = when {
-                name.contains("King Minos") -> Diana.ReceiveList.KING
-                name.contains("Minos Inquisitor") -> Diana.ReceiveList.INQ
-                name.contains("Manticore") -> Diana.ReceiveList.MANTICORE
-                name.contains("Sphinx") -> Diana.ReceiveList.SPHINX
+            val (mobType, mobName) = when {
+                name.contains("King Minos") ->
+                    Diana.ReceiveList.KING to "King Minos"
+
+                name.contains("Minos Inquisitor") ->
+                    Diana.ReceiveList.INQ to "Minos Inquisitor"
+
+                name.contains("Manticore") ->
+                    Diana.ReceiveList.MANTICORE to "Manticore"
+
+                name.contains("Sphinx") ->
+                    Diana.ReceiveList.SPHINX to "Sphinx"
+
                 else -> return@forEach
             }
+
+            if (mobType !in Diana.ReceiveMobs) return@forEach
 
             if (stand.isDeadOrDying()) return@forEach
 
@@ -471,12 +485,16 @@ object WaypointManager {
             if (existing.none { it.pos.distanceTo(standPos) <= 60 }) {
                 val pos = floorToGround(level, standPos)
 
+                val isOwnSpawn =
+                    DianaTracker.lastSpawnedMob == mobName &&
+                    System.nanoTime() - DianaTracker.lastSpawnedMobTime <= TimeUnit.SECONDS.toNanos(5)
+
                 addRareMobWaypoint(
                     player = "",
                     pos = pos,
                     mobType = mobType,
-                    selfName = "",
-                    mobDisplayName = notifyRareMob("", mobType)
+                    mobDisplayName = notifyRareMob("", mobType),
+                    isOwnSpawn
                 )?.let(existing::add)
             }
         }
@@ -484,20 +502,24 @@ object WaypointManager {
         removeStaleRareMobWaypoints(level, rareMobPositions)
     }
 
-    private fun addRareMobWaypoint(player: String, pos: SboVec, mobType: Diana.ReceiveList, selfName: String, mobDisplayName: String): Waypoint? {
-        val hasOwner = player.isNotEmpty()
-
-        if (hasOwner && selfName.isNotEmpty()) {
+    private fun addRareMobWaypoint(
+        player: String,
+        pos: SboVec,
+        mobType: Diana.ReceiveList,
+        mobDisplayName: String,
+        isOwnSpawn: Boolean
+    ): Waypoint? {
+        if (isOwnSpawn) {
             when (mobType) {
-                Diana.ReceiveList.INQ -> if (hideOwnWaypoints.contains(HideOwnWaypoints.INQ) && player.contains(selfName)) return null
-                Diana.ReceiveList.KING -> if (hideOwnWaypoints.contains(HideOwnWaypoints.KING) && player.contains(selfName)) return null
-                Diana.ReceiveList.MANTICORE -> if (hideOwnWaypoints.contains(HideOwnWaypoints.MANTICORE) && player.contains(selfName)) return null
-                Diana.ReceiveList.SPHINX -> if (hideOwnWaypoints.contains(HideOwnWaypoints.SPHINX) && player.contains(selfName)) return null
+                Diana.ReceiveList.INQ -> if (hideOwnWaypoints.contains(HideOwnWaypoints.INQ)) return null
+                Diana.ReceiveList.KING -> if (hideOwnWaypoints.contains(HideOwnWaypoints.KING)) return null
+                Diana.ReceiveList.MANTICORE -> if (hideOwnWaypoints.contains(HideOwnWaypoints.MANTICORE)) return null
+                Diana.ReceiveList.SPHINX -> if (hideOwnWaypoints.contains(HideOwnWaypoints.SPHINX)) return null
                 else -> {}
             }
         }
 
-        val owner = if (hasOwner) " §7($player§7)" else ""
+        val owner = if (player.isNotEmpty()) " §7($player§7)" else ""
         val waypoint = Waypoint("$mobDisplayName$owner", pos.x, pos.y, pos.z, ttl = 45, type = "rareMob")
 
         addWaypoint(waypoint)
@@ -823,6 +845,34 @@ object WaypointManager {
                 secondClosestWarp = name
                 secondClosestWarpPoint = warp
                 secondClosestDistance = distance
+            }
+        }
+
+        val hubPoint = hubWarps["hub"]
+        val wizardPoint = additionalHubWarps["wizard"]
+
+        if (
+            closestWarp == "wizard" &&
+            secondClosestWarp == "hub" &&
+            hubPoint != null &&
+            wizardPoint != null
+        ) {
+            val hubDistance = if (Diana.ignoreYLevel) {
+                pos.distanceToIgnoringY(hubPoint.pos)
+            } else {
+                pos.distanceTo(hubPoint.pos)
+            }
+
+            val wizardDistance = if (Diana.ignoreYLevel) {
+                pos.distanceToIgnoringY(wizardPoint.pos)
+            } else {
+                pos.distanceTo(wizardPoint.pos)
+            }
+
+            if (wizardDistance - hubDistance < HUB_WIZARD_MIN_GAP) {
+                closestWarp = "hub"
+                closestWarpPoint = hubPoint
+                closestDistance = hubDistance
             }
         }
 

--- a/src/main/kotlin/net/sbo/mod/utils/waypoint/WaypointManager.kt
+++ b/src/main/kotlin/net/sbo/mod/utils/waypoint/WaypointManager.kt
@@ -47,8 +47,6 @@ object WaypointManager {
         "sphinx"
     )
 
-    private const val HUB_WIZARD_MIN_GAP = 20.0
-
     fun init() {
         Register.command("sbosendping") { args ->
             val playerPos = Player.getLastPosition()
@@ -780,14 +778,22 @@ object WaypointManager {
         return waypoints[type] ?: emptyList()
     }
 
+    private fun getWarpPoint(name: String): WarpPoint? {
+        return hubWarps[name] ?: additionalHubWarps[name]
+    }
+
     fun getAllGuessesAndBurrows(): List<Waypoint> {
         return getWaypointsOfType("burrow") + getWaypointsOfType("arrow") + getWaypointsOfType("guess")
     }
 
     private fun getBestGuess(): Waypoint? {
+        return getBestGuessAt(Player.getLastPosition())
+    }
+
+    private fun getBestGuessAt(pos: SboVec): Waypoint? {
         return getAllGuessesAndBurrows()
             .filter { !it.hidden }
-            .minByOrNull { if (Diana.ignoreYLevel) it.distanceToPlayerIgnoringY() else it.distanceToPlayer() }
+            .minByOrNull { if (Diana.ignoreYLevel) it.pos.distanceToIgnoringY(pos) else it.pos.distanceTo(pos) }
     }
 
     private fun getClosestWaypointFrom(pos: SboVec): Pair<Waypoint, Double>? {
@@ -803,12 +809,15 @@ object WaypointManager {
             .minByOrNull { it.second }
     }
 
+    private fun getClosestWarp(pos: SboVec): String? = getClosestWarp(pos, Player.getLastPosition())
+
     /**
      * Gets the closest warp point to a given position.
      * @param pos The position to find the closest warp to.
+     * @param playerPos The player's position to warp from.
      * @return The name of the closest warp, or null if no warps are available.
      */
-    fun getClosestWarp(pos: SboVec): String? {
+    private fun getClosestWarp(pos: SboVec, playerPos: SboVec): String? {
         if (BurrowDetector.pendingUseSpadeTitle != null) {
             // Prevent warping before using spade.
             return null
@@ -825,7 +834,7 @@ object WaypointManager {
             }
         }
 
-        var playerDistance = if (Diana.ignoreYLevel) pos.distanceToIgnoringY(Player.getLastPosition()) else pos.distanceTo(Player.getLastPosition())
+        var playerDistance = if (Diana.ignoreYLevel) pos.distanceToIgnoringY(playerPos) else pos.distanceTo(playerPos)
 
         var closestWarp: String? = null
         var closestWarpPoint: WarpPoint? = null
@@ -853,34 +862,6 @@ object WaypointManager {
             }
         }
 
-        val hubPoint = hubWarps["hub"]
-        val wizardPoint = additionalHubWarps["wizard"]
-
-        if (
-            closestWarp == "wizard" &&
-            secondClosestWarp == "hub" &&
-            hubPoint != null &&
-            wizardPoint != null
-        ) {
-            val hubDistance = if (Diana.ignoreYLevel) {
-                pos.distanceToIgnoringY(hubPoint.pos)
-            } else {
-                pos.distanceTo(hubPoint.pos)
-            }
-
-            val wizardDistance = if (Diana.ignoreYLevel) {
-                pos.distanceToIgnoringY(wizardPoint.pos)
-            } else {
-                pos.distanceTo(wizardPoint.pos)
-            }
-
-            if (wizardDistance - hubDistance < HUB_WIZARD_MIN_GAP) {
-                closestWarp = "hub"
-                closestWarpPoint = hubPoint
-                closestDistance = hubDistance
-            }
-        }
-
         val preferredAgainst = secondClosestWarpPoint?.preferWarpAgainstCompetitive
 
         if (Diana.badWarpDistance > 0 && preferredAgainst != null && preferredAgainst == closestWarpPoint?.warpType && secondClosestDistance - closestDistance < Diana.badWarpDistance) {
@@ -889,7 +870,7 @@ object WaypointManager {
             closestDistance = secondClosestDistance
         }
 
-        if (Diana.ignoreYLevel) playerDistance = pos.distanceToIgnoringY(Player.getLastPosition())
+        if (Diana.ignoreYLevel) playerDistance = pos.distanceToIgnoringY(playerPos)
 
         val condition1 = playerDistance > closestDistance + Diana.warpDiff + (closestWarpPoint?.extraBlocks ?: 0)
         val condition2 = condition1 && (closestWaypoint.second > 60 || getWaypointsOfType("rareMob").isNotEmpty() || getWaypointsOfType("world").isNotEmpty())
@@ -899,16 +880,43 @@ object WaypointManager {
         return if (condition) closestWarp else null
     }
 
+    /**
+     * Gets the final closest warp point to a given target position.
+     * This method handles the case where a new warp would be suggested after warping to the current suggested warp by simulating up to four
+     * warps and picking the final warp.
+     * @param targetPos The target position to find the closest warp to.
+     * @return The name of the closest warp, or null if no warps are available.
+     */
+    fun getFinalClosestWarp(targetPos: SboVec): String? {
+        var simulatedPlayerPos = Player.getLastPosition()
+        var simulatedTargetPos = targetPos
+        var lastWarp: String? = null
+
+        repeat(4) {
+            val warp = getClosestWarp(simulatedTargetPos, simulatedPlayerPos) ?: return lastWarp
+            if (warp == lastWarp) return warp
+
+            lastWarp = warp
+            val warpPoint = getWarpPoint(warp) ?: return warp
+            val nextGuess = getBestGuessAt(warpPoint.pos) ?: return warp
+
+            simulatedPlayerPos = warpPoint.pos
+            simulatedTargetPos = nextGuess.pos
+        }
+
+        return lastWarp
+    }
+
     fun warpToGuess() {
         val bestGuess = getBestGuess() ?: return
-        getClosestWarp(bestGuess.pos)?.let { executeWarpCommand(it) } ?: return
+        getFinalClosestWarp(bestGuess.pos)?.let { executeWarpCommand(it) } ?: return
     }
 
     fun warpToRareMob() {
         val newestRareMob = getWaypointsOfType("rareMob").maxByOrNull { it.creationNs }
         val newestWorldRareMob = getWaypointsOfType("world").maxByOrNull { it.creationNs }
         val pos = newestRareMob?.pos ?: newestWorldRareMob?.pos ?: return
-        val warp = getClosestWarp(pos) ?: return
+        val warp = getFinalClosestWarp(pos) ?: return
 
         executeWarpCommand(warp)
     }

--- a/src/main/kotlin/net/sbo/mod/utils/waypoint/WaypointManager.kt
+++ b/src/main/kotlin/net/sbo/mod/utils/waypoint/WaypointManager.kt
@@ -444,9 +444,9 @@ object WaypointManager {
     }
 
     private fun updateRareMobWaypoints() {
-        if (!Diana.scanWorldForRareMob) return
-
         val level = mc.level ?: return
+
+        val shouldAddWaypoints = Diana.scanWorldForRareMob
 
         val existing = (getWaypointsOfType("rareMob") + getWaypointsOfType("world")).toMutableList()
         val rareMobPositions = mutableListOf<SboVec>()
@@ -458,27 +458,20 @@ object WaypointManager {
             if (name.contains("0/")) return@forEach
 
             val (mobType, mobName) = when {
-                name.contains("King Minos") ->
-                    Diana.ReceiveList.KING to "King Minos"
-
-                name.contains("Minos Inquisitor") ->
-                    Diana.ReceiveList.INQ to "Minos Inquisitor"
-
-                name.contains("Manticore") ->
-                    Diana.ReceiveList.MANTICORE to "Manticore"
-
-                name.contains("Sphinx") ->
-                    Diana.ReceiveList.SPHINX to "Sphinx"
-
+                name.contains("King Minos") -> Diana.ReceiveList.KING to "King Minos"
+                name.contains("Minos Inquisitor") -> Diana.ReceiveList.INQ to "Minos Inquisitor"
+                name.contains("Manticore") -> Diana.ReceiveList.MANTICORE to "Manticore"
+                name.contains("Sphinx") -> Diana.ReceiveList.SPHINX to "Sphinx"
                 else -> return@forEach
             }
 
             if (mobType !in Diana.ReceiveMobs) return@forEach
-
             if (stand.isDeadOrDying()) return@forEach
 
             val standPos = SboVec(stand.x, stand.y, stand.z)
             rareMobPositions += standPos
+
+            if (!shouldAddWaypoints) return@forEach
 
             if (existing.none { it.pos.distanceTo(standPos) <= 60 }) {
                 val pos = floorToGround(level, standPos)
@@ -616,18 +609,39 @@ object WaypointManager {
         }
     }
 
+    private fun buildGreedyGuessChain(startPos: SboVec): List<Waypoint> {
+        val remaining = getAllGuessesAndBurrows()
+            .asSequence()
+            .filter { !it.hidden }
+            .toMutableList()
+
+        if (remaining.isEmpty()) return emptyList()
+
+        val chain = mutableListOf<Waypoint>()
+        var currentPos = startPos
+
+        while (remaining.isNotEmpty()) {
+            val next = remaining.minByOrNull { wp ->
+                if (Diana.ignoreYLevel) {
+                    wp.pos.distanceToIgnoringY(currentPos)
+                } else {
+                    wp.pos.distanceTo(currentPos)
+                }
+            } ?: break
+
+            chain += next
+            remaining.remove(next)
+            currentPos = next.pos
+        }
+
+        return chain
+    }
+
     private fun renderGuessChainLines(context: WorldRenderContext) {
         if (!Diana.drawOptimalOrderLines) return
 
-        val ordered = getAllGuessesAndBurrows()
-            .asSequence()
-            .filter { !it.hidden }
-            .sortedBy {
-                if (Diana.ignoreYLevel) it.distanceToPlayerIgnoringY() else it.distanceToPlayer()
-            }
-            .toList()
-
-        if (ordered.size < 2) return
+        val chain = buildGreedyGuessChain(Player.getLastPosition())
+        if (chain.size < 2) return
 
         val color = Color(Customization.OptimalOrderLineColor)
         val rgb = floatArrayOf(
@@ -636,15 +650,13 @@ object WaypointManager {
             color.blue / 255f
         )
 
-        ordered.zipWithNext().forEach { (a, b) ->
-            val aPos = a.pos.toVec3d().add(0.0, 0.5, 0.0)
-            val bPos = b.pos.toVec3d().add(0.0, 0.5, 0.0)
+        chain.zipWithNext().forEach { (a, b) ->
+            val bDistance = Player.getLastPosition().distanceTo(b.pos)
 
             val opacity =
                 (
                     if (Customization.dynamicWaypointOpacity) {
-                        val distance = Player.getLastPosition().distanceTo(b.pos)
-                        calculateDynamicOpacity(distance)
+                        calculateDynamicOpacity(bDistance)
                     } else {
                         Customization.waypointOpacity / 100f
                     }
@@ -652,8 +664,8 @@ object WaypointManager {
 
             RenderUtils3D.drawLine(
                 context,
-                aPos,
-                bPos,
+                a.pos.toVec3d().add(0.0, 0.5, 0.0),
+                b.pos.toVec3d().add(0.0, 0.5, 0.0),
                 rgb,
                 (Diana.dianaLineWidth.toFloat() / 1.6f).coerceIn(1.0f, 20.0f),
                 opacity

--- a/src/main/kotlin/net/sbo/mod/utils/waypoint/WaypointManager.kt
+++ b/src/main/kotlin/net/sbo/mod/utils/waypoint/WaypointManager.kt
@@ -575,6 +575,7 @@ object WaypointManager {
         }
 
         renderSubGuessLines(context)
+        renderGuessChainLines(context)
     }
 
     private fun renderSubGuessLines(context: WorldRenderContext) {
@@ -612,6 +613,51 @@ object WaypointManager {
                         opacity
                     )
                 }
+        }
+    }
+
+    private fun renderGuessChainLines(context: WorldRenderContext) {
+        if (!Diana.drawOptimalOrderLines) return
+
+        val ordered = getAllGuessesAndBurrows()
+            .asSequence()
+            .filter { !it.hidden }
+            .sortedBy {
+                if (Diana.ignoreYLevel) it.distanceToPlayerIgnoringY() else it.distanceToPlayer()
+            }
+            .toList()
+
+        if (ordered.size < 2) return
+
+        val color = Color(Customization.OptimalOrderLineColor)
+        val rgb = floatArrayOf(
+            color.red / 255f,
+            color.green / 255f,
+            color.blue / 255f
+        )
+
+        ordered.zipWithNext().forEach { (a, b) ->
+            val aPos = a.pos.toVec3d().add(0.0, 0.5, 0.0)
+            val bPos = b.pos.toVec3d().add(0.0, 0.5, 0.0)
+
+            val opacity =
+                (
+                    if (Customization.dynamicWaypointOpacity) {
+                        val distance = Player.getLastPosition().distanceTo(b.pos)
+                        calculateDynamicOpacity(distance)
+                    } else {
+                        Customization.waypointOpacity / 100f
+                    }
+                ).coerceIn(0.3f, 0.5f)
+
+            RenderUtils3D.drawLine(
+                context,
+                aPos,
+                bPos,
+                rgb,
+                (Diana.dianaLineWidth.toFloat() / 1.6f).coerceIn(1.0f, 20.0f),
+                opacity
+            )
         }
     }
 

--- a/src/main/kotlin/net/sbo/mod/utils/waypoint/WaypointManager.kt
+++ b/src/main/kotlin/net/sbo/mod/utils/waypoint/WaypointManager.kt
@@ -651,7 +651,9 @@ object WaypointManager {
         chain.zipWithNext().forEachIndexed { index, (a, b) ->
             val bDistance = Player.getLastPosition().distanceTo(b.pos)
 
-            if (index >= 2 && bDistance > 70) {
+            // Always show the first line.
+            // Only show the 2nd and 3rd lines if the destination is nearby.
+            if (index > 0 && (index > 2 || bDistance > 50)) {
                 return@forEachIndexed
             }
 
@@ -920,7 +922,18 @@ object WaypointManager {
             !Diana.dontWarpIfBurrowClose ||
             playerDistance > 60
 
-        return if (warpIsWorthIt && targetIsFarEnough)
+        val playerToWarpDistance = closestWarpPoint?.let {
+            if (Diana.ignoreYLevel) {
+                playerPos.distanceToIgnoringY(it.pos)
+            } else {
+                playerPos.distanceTo(it.pos)
+            }
+        } ?: Double.MAX_VALUE
+
+        val warpIsFarEnough =
+            playerToWarpDistance > 60
+
+        return if (warpIsWorthIt && targetIsFarEnough && warpIsFarEnough)
             closestWarp
         else
             null


### PR DESCRIPTION
- Now setting preferGradleTask to true to avoid issues related to caching when running from IDEA.
- Added lastSpawnedMobTime in addition to lastSpawnedMob, used for rare mob self spawn detection to make it respect Hide Own Waypoints.
- Added Diana.hiltDropMessage / "Hilt of Revelations Drop Message" setting, as some users wanted to disable it.
- Improved Arrow Guess accuracy slightly.
- Moved "Send All Test Messages" up to its relevant place after the custom spawn message options.
- Fixed behaviour of Warp Title differing if Warp Title as Subtitle option is enabled by making warp title not show as subtitle when Use Spade title is showing. This waits till Use Spade title expires and only then shows the Warp Title (as subtitle). When as subtitle option is disabled, the Helper.showTitle with overwrite = false does this check for us, but if we are showing it as a subtitle, it makes the title Use Spade, and subtitle the warp subtitle. This can make the user warp before using spade, which reduces rates. Should be fixed now.
- Made it so the line to Rare Mob waypoints will not draw if you are 8 blocks near them. Since Rare Mob waypoints are added now for solo spawned mobs, some users reported that the line was confusing and taking away attraction from damaging the mob itself, since the line draws to a block and not the rare mob, therefore hide it when close.
- Fixed world-scan added rare mob waypoints not respecting the Hide Own Waypoints or Select Which Mobs to Receive settings.
- Attempted a fix for Hub->Wizard double warp prompt with the HUB_WIZARD_MIN_GAP and specific work-around code.