### PR TITLE
Fix file already exists error

### DIFF
--- a/src/main/kotlin/net/sbo/mod/diana/RareMobHighlight.kt
+++ b/src/main/kotlin/net/sbo/mod/diana/RareMobHighlight.kt
@@ -65,7 +65,7 @@ object RareMobHighlight {
                 continue
             }
 
-            val hasLineOfSight = player != null && player.hasLineOfSight(mob)
+            val hasLineOfSight = player != null && player.hasLineOfSight(mob) // TODO: Migrate this to what Skyblocker uses (Custom depth-tested glow rather than a simple lineOfSight check)
             if (Diana.HighlightRareMobs && hasLineOfSight && !mob.isInvisible) {
                 mob.isSboGlowing = true
                 val color = when (type) {

--- a/src/main/kotlin/net/sbo/mod/utils/Helper.kt
+++ b/src/main/kotlin/net/sbo/mod/utils/Helper.kt
@@ -24,7 +24,6 @@ import net.sbo.mod.utils.game.World
 import net.sbo.mod.utils.http.Http
 import net.sbo.mod.utils.math.SboVec
 import net.sbo.mod.utils.math.SboVec.Companion.toSboVec
-import net.sbo.mod.utils.waypoint.WaypointManager.removeNearbyRareMobWaypointAt
 import java.math.BigDecimal
 import java.math.RoundingMode
 import java.text.DecimalFormat
@@ -134,7 +133,6 @@ object Helper {
         val lsOverride = Diana.assumeAllLS && nearby && (last == null || !name.contains(last)) // we need to check if dying mob is not spawned by user by comparing to last spawned mob to avoid counting self-mob as lootshare
         when {
             name.contains("Minos Inquisitor") -> {
-                removeNearbyRareMobWaypointAt(pos)
                 if (lsOverride) onLootShare() // makes the gotLootShareRecently condition below always pass
                 if (gotLootShareRecently() && !hasTrackedInq) {
                     hasTrackedInq = true
@@ -147,7 +145,6 @@ object Helper {
                 lastInqDeath = System.nanoTime()
             }
             name.contains("King Minos") -> {
-                removeNearbyRareMobWaypointAt(pos)
                 if (lsOverride) onLootShare() // makes the gotLootShareRecently condition below always pass
                 if (gotLootShareRecently() && !hasTrackedKing) {
                     hasTrackedKing = true
@@ -160,7 +157,6 @@ object Helper {
                 lastKingDeath = System.nanoTime()
             }
             name.contains("Sphinx") -> {
-                removeNearbyRareMobWaypointAt(pos)
                 if (gotLootShareRecently() && !hasTrackedSphinx) {
                     hasTrackedSphinx = true
                     notifyUserOfLs("Sphinx")
@@ -172,7 +168,6 @@ object Helper {
                 lastSphinxDeath = System.nanoTime()
             }
             name.contains("Manticore") -> {
-                removeNearbyRareMobWaypointAt(pos)
                 if (lsOverride) onLootShare() // makes the gotLootShareRecently condition below always pass
                 if (gotLootShareRecently() && !hasTrackedManti) {
                     hasTrackedManti = true

--- a/src/main/kotlin/net/sbo/mod/utils/data/SboDataObject.kt
+++ b/src/main/kotlin/net/sbo/mod/utils/data/SboDataObject.kt
@@ -199,6 +199,7 @@ object SboDataObject {
                             SBOKotlin.logger.info("[$modName] Merged config folder from $oldDir to $newDir (case-insensitive FS)")
                         } else {
                             val tempDir = Files.createTempDirectory(baseDir, "${newName}_tmp_")
+                            Files.delete(tempDir)
                             try {
                                 Files.move(oldDir, tempDir)
                                 Files.move(tempDir, newDir)

--- a/src/main/kotlin/net/sbo/mod/utils/waypoint/WaypointManager.kt
+++ b/src/main/kotlin/net/sbo/mod/utils/waypoint/WaypointManager.kt
@@ -432,6 +432,7 @@ object WaypointManager {
 
     private fun updateRareMobWaypoints() {
         val level = mc.level ?: return
+        val player = mc.player ?: return
 
         val shouldAddWaypoints = Diana.scanWorldForRareMob
 
@@ -459,6 +460,9 @@ object WaypointManager {
             rareMobPositions += standPos
 
             if (!shouldAddWaypoints) return@forEach
+
+            // Best-effort to not be considered a cheat
+            if (!player.hasLineOfSight(entity)) return@forEach
 
             if (existing.none { it.pos.distanceTo(standPos) <= 60 }) {
                 val pos = floorToGround(level, standPos)
@@ -534,10 +538,6 @@ object WaypointManager {
                 removeWaypoint(waypoint)
             }
         }
-    }
-
-    fun removeNearbyRareMobWaypointAt(pos: SboVec) {
-        removeWithinDistanceFrom(pos, "rareMob", 30, 1)
     }
 
     /**

--- a/src/main/kotlin/net/sbo/mod/utils/waypoint/WaypointManager.kt
+++ b/src/main/kotlin/net/sbo/mod/utils/waypoint/WaypointManager.kt
@@ -71,7 +71,7 @@ object WaypointManager {
             val mob = trailing.replace("|", "").trim().lowercase()
             val selfName = Player.getName() ?: ""
             if (!channel.contains("Guild")) {
-                if ((!trailing.startsWith(" ") || rareMobs.contains(mob)) && Diana.receiveRareMob) {
+                if (rareMobs.contains(mob) && Diana.receiveRareMob) {
                     val mobType: Diana.ReceiveList = when (mob) {
                         "minos inquisitor", "inquisitor", "inq" -> Diana.ReceiveList.INQ
                         "king minos", "king" -> Diana.ReceiveList.KING


### PR DESCRIPTION
During directory rename from SBO to sbo in Windows, this would occur after the recent Files.isSameFile patch.

---

The error occurs because we create the directory with createTempDirectory then try to move with Files.move into it. This wont work as createTempDirectory already created the file. If we do Files.delete before, we still use the randomized name obtained from createTempDirectory, while avoiding the already exists error.

---

Edit: Also some other final changes before release. Didn't want to make a separate PR.