### PR TITLE
Bump version to 0.5.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -42,7 +42,7 @@ dgt.loom.loader.use=false
 # Mod properties
 mod.name=SBO
 mod.id=sbo
-mod.version=0.4.3
+mod.version=0.5.0
 mod.group=net.sbo.mod
 mod.description=SBO is the ultimate diana mod for Hypixel Skyblock! FPS friendly, and packed with QOL features!
 


### PR DESCRIPTION
# SBO 0.5.0 for Minecraft 26.2 and 26.1.2

# 1 Million Downloads!
We have reached 1 Million Downloads in Modrinth! Thanks to all our users, everyone that helped in testing and provided feedback, and to all our contributors! If you have a GitHub account, make sure to give a STAR to our [GitHub repository](http://github.com/SkyblockOverhaul/SBO) and remember that you can always [join our Discord](https://discord.com/invite/QvM6b9jsJD) as well if you do not like opening issues over at GitHub.

# Upgrade notes
As always, ensure your Fabric API and Fabric Language Kotlin is up-to-date as this release requires a newer version of these. The main breaking changes you should be aware of are:
 - You might need to re-set your "Rare Mob Warp Key" in the controls menu, as the old "Inq Warp Key" has been renamed to "Rare Mob Warp Key" to better reflect what it does.
 - You might need to re-set your custom drop messages (read below) as their toggle settings are removed and custom messages are always preferred if not-empty now.
 - You might need to re-set your custom sounds (read below) as the custom sound system was entirely revamped.
 - You might need to re-set your "Rare Mob Title Timings" category of options ("Rare Mob Title Fade In Time", "Rare Mob Title Stay Time", "Rare Mob Title Fade Out Time"). Set them all to 0 if you want to disable Rare Mob Titles. The old defaults were 0, 90 and 20 ticks; the new ones are 0, 60 and 0 ticks, respectively.
 - You might need to disable "Show Title When Chain Ends" if you do not prefer the new behaviour of it being default enabled and staying on screen till you actually use your spade, although this will most likely reduce your burrows/hr and money/hr rates.
 - You might need to disable the new "Scan World for Rare-Mob" option if you prefer not to get Rare Mob waypoints, Rare Mob titles and Rare Mob spawn sounds when playing Solo.

This list is not exhaustive and you are recommended to read the full changelog at a comfortable time to become aware of any other changes.

# Minecraft 26.2 Support
Added support for Minecraft 26.2. While less tested than the 26.1.2 version, please report bugs and any issues you encounter in our [Discord](https://discord.com/invite/QvM6b9jsJD).

# Less custom message option clutter
We have removed all the custom message toggles and changed default custom drop messages to empty text. Instead of having a separate toggle, the custom messages will now be preferred if they are not empty.

Due to this change, your existing custom drop messages will be reset to empty. You will have to set them up again. We're sorry about this, but it was a necessary evil to clean up the settings menu from these unnecessary toggle options.

# Revamped Custom Sound system
NOTE: We're sorry but if you configured custom sounds, since the options are now moved to /sbosounds, your sound configurations will be reset; but you can just open /sbosounds and pick your sounds again from the new dropdown menus easily, and adjust the volume or play the sounds from the same menu with the "Test" button.

No longer requires a resourcepack. (No more annoying "Custom sounds are inactive." message spam!)
No longer clutters the Diana category of the Settings menu. There's a dedicated menu at /sbosounds.
No longer have to manually enter file name; there's a dropdown menu allowing you to select through available sounds.
Now supports .mp3, .wav, .au, .aif and .aiff files in addition to .ogg.

We no longer set a default Burrow Found Sound or Rare Mob Sound since people have found it annoying. If you have liked the previous sounds, you can set "Burrow Found Sound" in /sbosounds to notification.ogg yourself.

# Rare Mob Waypoint enhancements
Rare Mob Waypoints will now get automatically removed if they are in a loaded chunk and there is no alive Rare Mob 60 blocks near them. We have also added a new world detection for them - if a Rare Mob is in a loaded chunk, is alive and is in your line of sight, and no Rare Mob waypoints exists for it - the mod will now add one. This should greatly help muted players and people playing in public lobbies.

Note that, due to this, now, even when playing solo the mod can add a waypoint for your Rare Mobs, and this also triggers the rare mob title and the custom spawn sound for the rare mobs you set. You can control this behaviour in the settings -> Diana -> "Scan World for Rare-Mob". To disable the Rare Mob titles, you can set all three Rare Mob Title Timing ("Rare Mob Title Fade In Time", "Rare Mob Title Stay Time", "Rare Mob Title Fade Out Time") options to zero. You can also use the "Hide Own Waypoints" setting to only hide your own ones, or tweak the "Which Mobs to Receive" to not add waypoints for specific mobs, as always.

Additionally, the "Inq Warp Key" was renamed to "Rare Mob Warp Key".

# Glow color per Rare Mob
The generic "Higlight Color" was removed in place of the new per Rare Mob glow colors. The defaults colors are blue for sphinx (same as before), pink for inquisitor, green for manticore and orange for the Minos King.

# Default config changes
The "Show Title When Chain Ends" option is now default enabled to help users not run out of concurrent chains. As we changed the internal ID of the option, upgrading users also get this change without having to manually enable the option.

This option usually makes you find new Start burrows when the mod tells you to use the spade ability, helping you keep up your concurrent chains.

How the feature works was also changed to make you not forget using the spade:
 - The "Use Spade" title will now not go away until you actually use your spade.
 - The "Use Spade" title will now instantly go away when you actually use your spade.
 - The "Use Spade" title will block warping before using your spade.

The "Rare Mob Title Timings" category of options were changed to make the rare mob title duration last less on-screen. The old values were 90 ticks for Stay Time, and 20 ticks for Fade Out time, totalling 5.5 seconds. The new defaults are 60 ticks for Stay Time and 0 ticks for Fade Out time, totalling 3 seconds.

The internal ID of the options were changed to ensure upgrading users also get the new default times. If you have previously set all 3 values to zero to effectively disable Rare Mob Titles, you will need to do so again.

# Medal integration
The mod now provides options to automatically capture a Medal clip when you get a rare enough drop such as Chimera or Minos Relic. These options live in the new "Medal" category.

# New Party commands
We've added !kingls, !king, !sphinxls, !sphinx, !mantils, !manti, !dye and !braided Party Commands.

# Smarter Overlay hiding
Diana-related overlays will now hide when outside The Hub, for a cleaner look on other islands. The Legion and Bobber overlays will still render in other islands if you are in Skyblock, as they can be useful outside of Diana as well.

# More achievements
Added "Got 'Em All" - Get every diana drop in 1 event and "Chimera VIII" - Get 128 Chimera in one event achievements. If you have previously met the conditions to unlock these, please run /sbobacktrackachievements to see if the mod would give the achievements based on your Past Diana Events data.

# Achievements are now partially toggle-able
You can now disable achievement title, chat message and sound via the "Disable Achievements" toggle in General category under Achievements subcategory. This does still track and unlock achievements internally, but with no user visible feedback for accessibility, as some might find the sounds or the title/chat message annoying or too loud.

# Less messages by the mod
We're aware some of you did not like the new messages the mod sends out - we have removed the "Registered cocooned mob: <mob name>" message the mod sends (this was there to ensure the mod correctly detects cocoon on all cases, e.g., when cocooning a runic mob - but we're confident that it works now since the message always appeared when the Hypixel one did), and made the "Registered Lootshare mob: <mob name>" only get send if you have the "Always Assume LS" option enabled (as in that case, the mod would make you know it registered even though the server did not send the LOOT SHARE! message).

There's also a new toggle, "Hilt of Revelations Drop Message" to disable the Hilt of Revelations drop message.

# Re-added Beam distance option
As some of you might remember, we have removed the old "Rare Mob Beam Distance" option that was only meant to work on Rare Mob beacon beams but worked on all beams instead, in place of the "Show Beacon Beams" toggle we added, but some people still wanted to be able to configure at which blocks the beam is hidden, so we decided to resurrect the option but with a more correct name, since it applies to all beams and nost just rare mob waypoint's beams.

# Experimental options
Added "Show Arrow Sub Guesses" which will create additional, gray (configurable via the "Sub Guess Color" option in Customization category) waypoints for the possible next spots of an Arrow Guess. These waypoints are not included in the closest guess/burrow selection or the warp selection purposes, and line from cursor is never drawn to them (a separate line between all the sub-guesses in-world are drawn however). These waypoints are textless (unless the option "Show Text On Sub Guess" is enabled) and only block higlights and draws lines in-between them to avoid confusion.

The mod already moves the arrow guess to the next sub guess automatically if you held your spade for at least 1 seconds and were within 30 blocks of the guess, so during normal gameplay you will only see these sub guess block higlights very rarely. Note that without a mod such as Hold That Chunk V2 or Bobby with Dynamic World Management, there might be some Sub Guesses in not yet loaded chunks that disappear when you get close. This is because we can only check if the guess is pointing at a grass block if the chunk is loaded.

Added "Draw Optimal Order Lines" which will draw lines in-between waypoints from closest to farthest. The closest is already drawn a line from your cursor. The second closest is drawn a line from the closest waypoint's position. The third and fourth closest are only drawn lines if they are within 50 blocks of you to avoid confusion.

# Bug fixes
- Fixed Mob and Treasure burrows sometimes re-appearing at the same location after digging them due to delayed particles or chat messages sent by the server.
- Fixed Skyblock Year based Mayor Tracker auto reset not working ever since 0.4.0 due to a Mayor.kt refactor. NOTE: This fix might not work yet as your last event might be based on Skyblock Year 0 mistakenly; but should work in future events. You can always use /sboresetmayortracker to reset it manually.
- Fixed Arrow Guess solving other players burrows if you were near them when they dig their burrows, typically after lootsharing a rare mob. It would also show the red use spade notification sometimes due to this. It should be fixed now but do note that the red Use Spade can sometimes still show even though the mod was able to solve the guess.
- Fixed double /h/h in the !totalstats command output formatting.
- Fixed empty price text (+) if you do not have "Show Price Title" enabled by removing the option and always acting as if it was enabled. This both fixes the bug and reduces the option clutter in the mod. Note that you can still disable the Rare Drop title by disabling "Loot Screen Announcer"
- Fixed custom drop messages and default drop messages both being sent in the client chat. This does not affect the Party Announcer.
- Fixed a possible Arrow Guess internal state desync after digging a second time before the Arrow Guess turns to a Mob/Treasure waypoint.
- Fixed Started chain amount desyncing in Ongoing Chains Display if you do not finish a Chain for 30 minutes while keeping the Chain active by progressing through the Chain.
- Fixed Burrow Found Sound playing for chat-message promoted Guesses to Mob/Treasure burrows when swapping shovel fast. It was supposed to, and should now only play for particle-detected Mob/Treasure (and Start) burrows.
- Fixed Bestiary achievements not working for some people by bumping up the delayed task from 200ms to 500ms, as for some people with high ping the menu might not load fully in 200ms.
- Fixed Supercrafting Enchanted Gold and Enchanted Ancient Claw adding to the tracker due to Sacks message in chat; also fixed other cases of mistracking e.g., gold collected from gold minions or gained from fishing. The Sacks message tracking is now guarded by a diana mob recently dying before it. If you were previously getting [SBO] Paused playtime timer after 15 seconds of inactivity. in chat randomly before, this change should fix that.
- Fixed client-side chat loot announcer not including the lootshare in the total # number of drops, whereas the party announcer would correctly show it. Both should show the correct total drop amount with own + lootshare drops now.
- Fixed dropping 2 chimeras from a single inquisitor (lootsharing from own) not counting one of the chimeras to the tracker.
- Fixed "Sound file not found: /.ogg" warning in the logs when sounds are set to empty with the intention to not play a sound / disable a specific sound.
- Fixed HTTP timeouts when fetching AH or BZ prices during game startup in certain cases.
- Fixed "Warp Title As Subtitle" causing Warp Title to show together with Use Spade title. Use Spade will now take priority.
- Fixed lines (such as line from cursor) not rendering through (strong) walls in MC 26.1.2, which was rendering through in MC 1.21.11.
- Fixed Customization category allowing you to pick opacity for the color values that would not respect it. (such as the "Waypoint Opacity" and "Dynamic Waypoint Opacity" settings taking priority)
- Fixed "Skipping existing file" warnings for each file in the SBO directory during startup due to data migration code trying to migrate from the same file to itself in Windows. This warning was essentially harmless, but should now go away.

# Removed
- Removed the "All Waypoints are Rare Mobs" option as it was rarely useful. The mod internally defaulted all waypoints without a mob name as Inquisitor waypoints previously when this option was enabled, which could cause confusion.
- Removed the "Higlight Color" option from the Diana category in place of the new glow color options in the Customization category.

# Optimizations
- The Waypoint renderer is now more optimized by caching the text width and visual order text (FormattedCharSequence) per tick instead of recomputing every rendered frame.

# Misc
- The !burrows Party Command now formats burrows with commas if you have more than a thousand just like the Diana Loot Overlay does.
- Bumped up the Refresh cooldown in Party Finder party list from 1 second to 5 seconds to reduce requests in the SBO's backend server. This should reduce load on the servers and prevent Party List from not loading entirely. There is also now a limit of 1 concurrent Refresh request, which means you will not be able to perform another Refresh while one is already in progress (e.g., you must wait for the first request to timeout before you can send another one if our backend server is down).
- Changed /7-8 into just /7 with a fallback to /8 or above in Ongoing Chains Display.
- Overlays will now always show in the editing screen even if their conditions are not met (e.g Diana overlays now reuqire you to be in the Hub, but will still render elsewhere whilst in the /sbomoveguis menu)
- The Guess and Burrow Waypoints will now not render when you do not have a Spade (Ancestral, Archaic or Deific) in your inventory, even if you are in the Hub and Diana is mayor and you have previously discovered these guesses/burrows (reducing visual clutter)
- The !since Party Command will now not default the Mobs since inq when no arguments are provided, to not mess with other mod's !since commands. To check Mobs since inq now, please type "!since inq" instead.
- Renamed "General warp Key" to "General Warp Key" in controls menu to match capitalization of other control settings.
- The mod will now simulate up to 4 warps before suggesting you a warp, to avoid issues like suggesting Hub warp and then Wizard warp once you warp to Hub. It will now only prompt the final warp, after 4 simulations.
- The "Don't Warp If Burrow Close" handling was changed to check both if you were close to the burrow and to the warp, fixing cases where the mod would suggest warping even though you are next to the warp.
- The line to Rare Mob waypoints will now not render when at least 8 blocks nearby, to not take attention from the Rare Mob itself away, as the line is drawn to the Rare Mob waypoint and not to the Rare Mob.
- Moved "Send All Test Messages" up to its relevant section in the Diana category.
- The "Player stats loaded" message after joining skyblock will now be logged instead of being sent to chat to reduce unnecessary mod messages.
- The HP Overlay will now show hits remaining for Minos King in the hitphase.
- The Arrow Guess and Spade Guess should now be slighty more accurate.
- The !tps command of SBO now matches the sample data and richer output format of Odin's, with min/max/avg TPS and not just current, to reduce false positives during server lag. The credits for this goes to the [work done by PanTruskawka045 in the Odin project](https://github.com/odtheking/Odin/pull/124).
- Reverted the behaviour of "world" type waypoints (waypoints added from chat messages with just a x y z and no rare mob name) to old behaviour, they are treated as separate waypoints instead of being considered equal to rare mob waypoints internally in code now, as it was in older versions. This means: The Rare Mob Warp Key will not consider them for warping close to them, the new only render diana waypoints in Hub and when holding Spade checks do not apply to them, they are not removed when a rare mob dies near them, they are not removed for being outside The Hub bounds x y z radius, and the line from cursor to them won't be drawn. This is ultimately separates rare mob waypoints for general purpose (even outside of Diana) waypoints again, as some people were e.g., using it to add waypoints for rare fishing mobs; therefore not rendering them outside The Hub was voiding that use case of the feature. With it being back to old behaviour, it should work fine again now.

# Technical changes
- Removed 1.21.11 support fully from the mod as Hypixel disallows joining Skyblock with MC 1.21.11 now.
- The required Fabric API version for 26.1.2 was updated; 26.1.2 requires 0.155.2. You might need to update your mods before launching with this version.
- The required Fabric Language Kotlin version for 26.1.2 was updated to 1.13.13+kotlin.2.4.10.
- Removed the fallback Regexes for old unicode symbols before the Hypixel Skyblock Resourcepack's addition to clean up the code.
- The /sbodebugburrows command will now only add waypoints at internal state locations that are missing a waypoint.
- Updated Google Kotlin Symbol Processing API (KSP) version to 2.3.11 from 2.3.9. The KSP version is now unified as a single source of version inside libs.versions.toml.
- Updated our compile-time Mod Menu dependency for MC 26.1.2 to version 18.0.0 from 18.0.0-beta.1.
- The Loom version used when compiling the mod is updated to 1.17.19 from 1.17.3.
- The Kotlin serialization plugin used in the mod is updated to 2.4.10 from 2.4.0.
- The bundled Elementa library version in the mod is updated to build 757 from 745.
- Strengthened the mod more against Sodium Extra disabled particles, although we still recommend not disabling any particles relevant to diana as the mod still might not be able to detect them in that case.
- Migrated to System.nanoTime() when comparing time passed in more places in the code for better accuracy, performance and monotonic time.
- Migrated to SubmitNodeCollector Rendering API for the Vulkan and 26.2 compatibility. The affected rendering are beacon beam, line from cursor/in-world line rendering, and in-world text such as waypoint "Guess [distance]" text. The new API should not change anything visually but should have more performance.
- Migrated to an iterative version of the extendLine method to avoid deep recursion and improve performance slightly.
- Cleaned up a legacy closestWaypoint variable to simplify code.