### PR TITLE
Fix crash on 26.2 when Skyblocker not installed

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -78,7 +78,7 @@ rconfigkt.version.26.2=4.0.0-beta.1
 
 # hm-api
 hmapi.version.26.1.2=1.0.3+26.1
-hmapi.version.26.2=1.0.3+26.1
+hmapi.version.26.2=1.0.4+26.2
 
 # Sound support
 vorbis.version=1.2.1


### PR DESCRIPTION
Skyblocker ships hm-api as well, and Fabric parses SemVer to load the newer version automatically, which is for 26.2. When only SBO is installed without Skyblocker however, we are the only mod providing hm-api, so Fabric proceeds to load our wrongfully shipped 26.1 version of hm-api and causes launch to fail.

This wasn't noticed in testing since most people have the Skyblocker mod installed.