### PR TITLE
0.5.3 bug fixes

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -42,7 +42,7 @@ dgt.loom.loader.use=false
 # Mod properties
 mod.name=SBO
 mod.id=sbo
-mod.version=0.5.1
+mod.version=0.5.2
 mod.group=net.sbo.mod
 mod.description=SBO is the ultimate diana mod for Hypixel Skyblock! FPS friendly, and packed with QOL features!
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -63,10 +63,10 @@ fabricapi.version.26.1.2=0.155.2+26.1.2
 fabricapi.version.26.2=0.158.0+26.2
 
 # UniversalCraft
-universalcraft.version=505
+universalcraft.version=517
 
 # Elementa
-elementa.version=757
+elementa.version=762
 
 # ResourcefulConfig
 rconfig.version.26.1.2=4.0.1

--- a/src/main/kotlin/net/sbo/mod/diana/burrows/BurrowDetector.kt
+++ b/src/main/kotlin/net/sbo/mod/diana/burrows/BurrowDetector.kt
@@ -174,7 +174,7 @@ object BurrowDetector {
     }
 
     fun requestSpade(reason: String) {
-        if (World.getWorld() != "Hub") return
+        if (World.getWorld() != "Hub" || !Diana.spadeGuess) return
 
         val color = if (reason == "failure") "c" else "e"
 

--- a/src/main/kotlin/net/sbo/mod/partyfinder/PartyPlayer.kt
+++ b/src/main/kotlin/net/sbo/mod/partyfinder/PartyPlayer.kt
@@ -65,8 +65,6 @@ object PartyPlayer {
             }
         }
 
-        // The confirmation, not "Switching to profile": while the switch is in flight the tab list
-        // still holds the old profile.
         Register.onChatMessage(
             Regex("^Your profile was changed to: (\\S+)"),
             noFormatting = true
@@ -91,7 +89,6 @@ object PartyPlayer {
 
     /**
      * Refetches with readCache=false, for /sboreloadstats.
-     *
      * @param onError Called on failure instead of [callback], which otherwise gets the old stats.
      */
     fun reloadStats(
@@ -107,7 +104,6 @@ object PartyPlayer {
 
     /**
      * Reads through the API cache, unless the profile or the name changed.
-     *
      * @param forceRefresh Skips the 10 minute freshness check.
      * @param onError Called on failure instead of [callback], which otherwise gets the old stats.
      */
@@ -141,8 +137,6 @@ object PartyPlayer {
             if (onError != null) onError(error) else callback(stats)
         }
 
-        // Off the render thread there is no player while a profile switch is still loading, an
-        // empty name would just come back as "Player not found".
         val name = Player.getName()?.takeIf { it.isNotBlank() }
         if (name == null) {
             fail(Exception("No player name available"))
@@ -155,8 +149,6 @@ object PartyPlayer {
             .toJson<PlayerInfoResponse>(ignoreUnknownKeys = true) { response ->
                 refreshing = false
                 if (response.success) {
-                    // The client knows the current name, so a stale one means the server cache is
-                    // outdated and needs one refetch to pick the rename up.
                     if (readCache && nameOutdated(response.playerInfo) && cacheBypassReadyIn() == 0L) {
                         fetch(readCache = false, profile = profile, onError = onError, callback = callback)
                         return@toJson

--- a/src/main/kotlin/net/sbo/mod/partyfinder/PartyPlayer.kt
+++ b/src/main/kotlin/net/sbo/mod/partyfinder/PartyPlayer.kt
@@ -9,7 +9,10 @@ import net.sbo.mod.utils.Player
 import net.sbo.mod.utils.chat.Chat
 import net.sbo.mod.utils.data.PartyPlayerStats
 import net.sbo.mod.utils.data.PlayerInfoResponse
+import net.sbo.mod.utils.data.SboDataObject
+import net.sbo.mod.utils.data.SboDataObject.sboData
 import net.sbo.mod.utils.events.Register
+import net.sbo.mod.utils.game.TabList
 import net.sbo.mod.utils.http.SboApi
 import java.util.concurrent.TimeUnit
 
@@ -21,6 +24,28 @@ object PartyPlayer {
 
     private val CACHE_BYPASS_COOLDOWN = TimeUnit.SECONDS.toNanos(20)
 
+    private fun currentProfile(): String? = TabList.findInfo("Profile: ")?.trim()?.takeIf { it.isNotEmpty() }
+
+    /** True when the name the API returned is not the one we are playing on. */
+    private fun nameOutdated(info: PartyPlayerStats?): Boolean {
+        val returned = info?.name?.takeIf { it.isNotEmpty() } ?: return false
+        val current = Player.getName()?.takeIf { it.isNotEmpty() } ?: return false
+        return !current.equals(returned, ignoreCase = true)
+    }
+
+    /** True when [profile] is not the one the stored stats belong to. */
+    private fun profileChanged(profile: String?): Boolean {
+        val cached = sboData.lastStatsProfile.takeIf { it.isNotEmpty() } ?: return false
+        if (profile == null) return false
+        return !profile.equals(cached, ignoreCase = true)
+    }
+
+    private fun rememberProfile(profile: String?) {
+        if (profile == null || profile.equals(sboData.lastStatsProfile, ignoreCase = true)) return
+        sboData.lastStatsProfile = profile
+        SboDataObject.save("SboData")
+    }
+
     private fun cacheBypassReadyIn(): Long =
         TimeUnit.NANOSECONDS.toSeconds((lastCacheBypass + CACHE_BYPASS_COOLDOWN - System.nanoTime()).coerceAtLeast(0))
 
@@ -31,8 +56,7 @@ object PartyPlayer {
                 Chat.chat("§6[SBO] §cPlease wait ${waitSeconds}s before reloading stats again.")
                 return@command
             }
-            getPartyPlayerStats(
-                forceRefresh = true,
+            reloadStats(
                 onError = { error ->
                     Chat.chat("§6[SBO] §cFailed to reload stats: ${error.message}")
                 }
@@ -41,25 +65,51 @@ object PartyPlayer {
             }
         }
 
+        // The confirmation, not "Switching to profile": while the switch is in flight the tab list
+        // still holds the old profile.
         Register.onChatMessage(
-            Regex("^Switching to profile (.*)$"),
+            Regex("^Your profile was changed to: (\\S+)"),
             noFormatting = true
-        ) { _, _ ->
+        ) { _, match ->
+            val profile = match.groupValues[1]
             sleep(2000) {
-                load()
+                load(profile)
             }
         }
     }
 
-    fun load() {
-        getPartyPlayerStats(forceRefresh = true) { stats ->
+    fun load(profile: String? = currentProfile()) {
+        if (refreshing) return
+        fetch(
+            readCache = !(profileChanged(profile) && cacheBypassReadyIn() == 0L),
+            profile = profile,
+            onError = { error -> logger.warn("[SBO] Player stats not loaded: ${error.message}") }
+        ) { stats ->
             logger.info("[SBO] Player stats loaded: ${stats.name} (SB Level: ${stats.sbLvl})")
         }
     }
 
     /**
-     * @param onError Called instead of [callback] when the request fails. Without it a failure
-     * falls back to the last known stats, which is what the callers that only read stats want.
+     * Refetches with readCache=false, for /sboreloadstats.
+     *
+     * @param onError Called on failure instead of [callback], which otherwise gets the old stats.
+     */
+    fun reloadStats(
+        onError: ((Exception) -> Unit)? = null,
+        callback: (PartyPlayerStats) -> Unit
+    ) {
+        if (refreshing) {
+            callback(stats)
+            return
+        }
+        fetch(readCache = false, profile = currentProfile(), onError = onError, callback = callback)
+    }
+
+    /**
+     * Reads through the API cache, unless the profile or the name changed.
+     *
+     * @param forceRefresh Skips the 10 minute freshness check.
+     * @param onError Called on failure instead of [callback], which otherwise gets the old stats.
      */
     fun getPartyPlayerStats(
         forceRefresh: Boolean = false,
@@ -75,22 +125,45 @@ object PartyPlayer {
             return
         }
 
-        val bypassCache = forceRefresh && cacheBypassReadyIn() == 0L
-        if (bypassCache) lastCacheBypass = System.nanoTime()
+        val profile = currentProfile()
+        fetch(!(profileChanged(profile) && cacheBypassReadyIn() == 0L), profile, onError, callback)
+    }
 
+    private fun fetch(
+        readCache: Boolean,
+        profile: String?,
+        onError: ((Exception) -> Unit)? = null,
+        callback: (PartyPlayerStats) -> Unit
+    ) {
         val fail = { error: Exception ->
             refreshing = false
             logger.error("Failed to fetch party player stats: $error")
             if (onError != null) onError(error) else callback(stats)
         }
 
+        // Off the render thread there is no player while a profile switch is still loading, an
+        // empty name would just come back as "Player not found".
+        val name = Player.getName()?.takeIf { it.isNotBlank() }
+        if (name == null) {
+            fail(Exception("No player name available"))
+            return
+        }
+
+        if (!readCache) lastCacheBypass = System.nanoTime()
         refreshing = true
-        SboApi.playerInfo(Player.getName() ?: "", readCache = !bypassCache)
+        SboApi.playerInfo(name, readCache = readCache)
             .toJson<PlayerInfoResponse>(ignoreUnknownKeys = true) { response ->
                 refreshing = false
                 if (response.success) {
+                    // The client knows the current name, so a stale one means the server cache is
+                    // outdated and needs one refetch to pick the rename up.
+                    if (readCache && nameOutdated(response.playerInfo) && cacheBypassReadyIn() == 0L) {
+                        fetch(readCache = false, profile = profile, onError = onError, callback = callback)
+                        return@toJson
+                    }
                     lastUpdate = System.nanoTime()
                     stats = response.playerInfo ?: PartyPlayerStats()
+                    rememberProfile(profile)
                     if (stats.sbLvl == -1) {
                         Chat.chat("§6[SBO] §cYour stats are not available, please try again later.")
                     } else {

--- a/src/main/kotlin/net/sbo/mod/settings/categories/Diana.kt
+++ b/src/main/kotlin/net/sbo/mod/settings/categories/Diana.kt
@@ -112,7 +112,7 @@ object Diana : CategoryKt("Diana") {
         this.description = Literal("Shows a title to use spade when the arrow guess fails to solve the burrow. This might sometimes show wrongfully on a second solve attempt if the first was successfull and second failed for any reason.")
     }
 
-    var showTitleWhenChainEnds by boolean(true) {
+    var showTitleWhenChainEnds by boolean(false) {
         this.name = Literal("Show Title When Chain Ends")
         this.description = Literal("Shows a title to use spade when the burrow chain is complete and there's no more guesses or burrows at least 90 blocks nearby, which will usually point to a new Start burrow to hold up your concurrent chains.")
     }

--- a/src/main/kotlin/net/sbo/mod/settings/categories/Diana.kt
+++ b/src/main/kotlin/net/sbo/mod/settings/categories/Diana.kt
@@ -103,7 +103,7 @@ object Diana : CategoryKt("Diana") {
     }
 
     var beamDistance by int(8) {
-        this.name = Literal("Beam Distance")
+        this.name = Literal("Beacon Beam Distance")
         this.description = Literal("Hide the beam when this many blocks or more close to it.")
     }
 
@@ -144,7 +144,7 @@ object Diana : CategoryKt("Diana") {
         this.description = Literal("If enabled, the warp key will not warp you if you are within 60 blocks of a burrow.")
     }
 
-    var warpDiff by int(10) {
+    var warpDiff by int(22) {
         this.range = 0..60
         this.slider = true
         this.name = Literal("Warp Block Difference")

--- a/src/main/kotlin/net/sbo/mod/utils/data/Configs.kt
+++ b/src/main/kotlin/net/sbo/mod/utils/data/Configs.kt
@@ -115,6 +115,8 @@ data class SboData(
     var b2bFood: Boolean = false,
     var sphinxSinceLsFood: Int = 0,
     var b2bFoodLs: Boolean = false,
+
+    var lastStatsProfile: String = "",
 )
 
 data class AchievementsData(

--- a/src/main/kotlin/net/sbo/mod/utils/http/SboApi.kt
+++ b/src/main/kotlin/net/sbo/mod/utils/http/SboApi.kt
@@ -2,6 +2,7 @@ package net.sbo.mod.utils.http
 
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
+import net.sbo.mod.SBOKotlin
 import net.sbo.mod.SBOKotlin.API_URL
 import net.sbo.mod.utils.data.MembersRequest
 import net.sbo.mod.utils.data.PartyRequest
@@ -12,13 +13,27 @@ import java.nio.charset.StandardCharsets
 /**
  * Thin client for the SBO backend.
  *
- * the SBO key travels in the `x-sbo-key` header
+ * the SBO key travels in the `x-sbo-key` header, the mod version in the `X-SBO-Version` header
  */
 object SboApi {
     private val json = Json { encodeDefaults = false }
+    
+    private val VERSION_PATTERN = Regex("[A-Za-z0-9][A-Za-z0-9.+_-]{0,31}")
 
-    private fun headers(): Map<String, String> =
-        sboData.sboKey.takeIf { it.isNotBlank() }?.let { mapOf("x-sbo-key" to it) } ?: emptyMap()
+    private var cachedVersion: String? = null
+
+    private fun modVersion(): String? {
+        cachedVersion?.let { return it }
+        val version = runCatching { SBOKotlin.version }.getOrNull()
+            ?.takeIf { VERSION_PATTERN.matches(it) } ?: return null
+        cachedVersion = version
+        return version
+    }
+
+    private fun headers(): Map<String, String> = buildMap {
+        sboData.sboKey.takeIf { it.isNotBlank() }?.let { put("x-sbo-key", it) }
+        modVersion()?.let { put("X-SBO-Version", it) }
+    }
 
     private fun post(path: String, body: String = "{}"): HttpRequestHandle =
         Http.sendPostRequest("$API_URL$path", body, headers())

--- a/src/main/kotlin/net/sbo/mod/utils/waypoint/Waypoint.kt
+++ b/src/main/kotlin/net/sbo/mod/utils/waypoint/Waypoint.kt
@@ -89,6 +89,7 @@ class Waypoint(
     var userInteractedWith = false
     private var dynamicOpacity = 1.0f
     var preventInvalidRemoval = false
+    var rareMobMissingTicks: Int = 0
 
     private var visualOrderText = ChatUtils.fromLegacy(text).visualOrderText
 

--- a/src/main/kotlin/net/sbo/mod/utils/waypoint/WaypointManager.kt
+++ b/src/main/kotlin/net/sbo/mod/utils/waypoint/WaypointManager.kt
@@ -34,6 +34,9 @@ import java.util.concurrent.CopyOnWriteArrayList
 import java.util.concurrent.TimeUnit
 import kotlin.math.roundToInt
 
+private const val RARE_MOB_STALE_TICKS = 40
+private const val RARE_MOB_VALIDATION_DISTANCE = 30.0
+
 object WaypointManager {
     private val waypoints = ConcurrentHashMap<String, CopyOnWriteArrayList<Waypoint>>()
     private val rareMobs: Set<String> = setOf(
@@ -508,33 +511,31 @@ object WaypointManager {
         return waypoint
     }
 
-    private fun removeStaleRareMobWaypoints(level: ClientLevel, rareMobPositions: List<SboVec>) {
+    private fun removeStaleRareMobWaypoints(
+        level: ClientLevel,
+        rareMobPositions: List<SboVec>
+    ) {
+        val player = mc.player ?: return
+        val playerPos = SboVec(player.x, player.y, player.z)
+
         getWaypointsOfType("rareMob").forEach { waypoint ->
-            val blockPos = waypoint.pos.roundLocationToBlock()
-
-            // If the chunk waypoint is in is not loaded, no rare mob entity will exist, since the entity is not loaded as well.
-            if (!level.isLoaded(blockPos.toBlockPos()))
+            if (playerPos.distanceTo(waypoint.pos) > RARE_MOB_VALIDATION_DISTANCE) {
+                waypoint.rareMobMissingTicks = 0
                 return@forEach
-
-            // The radius of a rare mob 60 blocks near the waypoint spans multiple chunks (> 16) so we need to also check that all the neighbor chunks relevant to our radius are loaded as well.
-            val center = waypoint.pos.roundLocationToBlock().toBlockPos()
-            val radius = 60
-
-            val minChunkX = center.x - radius shr 4
-            val maxChunkX = center.x + radius shr 4
-            val minChunkZ = center.z - radius shr 4
-            val maxChunkZ = center.z + radius shr 4
-
-            for (chunkX in minChunkX..maxChunkX) {
-                for (chunkZ in minChunkZ..maxChunkZ) {
-                    if (!level.hasChunk(chunkX, chunkZ)) {
-                        return@forEach
-                    }
-                }
             }
 
-            // If the chunk waypoint is in and all the neighboring chunks in our radius distance is loaded but we were not able to find a rare mob entity in our radius distance to the waypoint, we should clean up the leftover stale rare mob waypoint by removing it.
-            if (rareMobPositions.none { it.distanceTo(waypoint.pos) <= radius }) {
+            val mobPresent = rareMobPositions.any {
+                it.distanceTo(waypoint.pos) <= RARE_MOB_VALIDATION_DISTANCE
+            }
+
+            if (mobPresent) {
+                waypoint.rareMobMissingTicks = 0
+                return@forEach
+            }
+
+            waypoint.rareMobMissingTicks++
+
+            if (waypoint.rareMobMissingTicks >= RARE_MOB_STALE_TICKS) {
                 removeWaypoint(waypoint)
             }
         }


### PR DESCRIPTION
# SBO 0.5.2 for Minecraft 26.2 and 26.1.2

# Bug fixes

- Fixed "Use Spade" title showing via `requestSpade` even when Spade Guess is disabled in settings. The title will now only show if you have Spade Guess enabled.
- Fixed Rare Mob waypoints not being removed when they should be, or being removed prematurely. The old chunk-loading check was too strict and would fail to clean up stale waypoints in many cases. Rewrote the stale removal logic to check proximity in a simpler and more reliable way.
- Fixed "Beam Distance" option description not matching its actual behavior it was hiding all beacon beams, not just Rare Mob waypoint beams. Renamed to "Beacon Beam Distance" to clarify this.

---

**What changed:**
- **Profile tracking** The mod now reads your active profile directly from the tab list (`Profile: ` entry) and persists the last queried profile name across sessions via `SboData.lastStatsProfile`. This means it can detect when you've actually switched profiles, not just guess.
- **Smarter cache invalidation** Previously, switching profiles would still return cached stats from the old profile until you manually ran `/sboreloadstats`. Now, if the cached profile doesn't match the current one and the 20s cooldown has expired, the cache is bypassed automatically.
- **Name mismatch detection** When the API returns a different player's name than the one currently logged in (e.g. after switching accounts), the mod re-fetches with cache bypass to prevent cross-contamination between accounts.
- **`/sboreloadstats` command** Now forces a fresh API fetch with cache bypass, respecting the existing 20s cooldown to prevent spam.
- **Profile switch hook updated** The chat regex was updated from `"^Switching to profile (.*)$"` to `"^Your profile was changed to: (\S+)"` to match the actual Hypixel message format. The old regex was likely not capturing the profile name correctly.
- **New internal architecture** Split `getPartyPlayerStats()` into `fetch()` as the core API call, with `load()` defaulting to cached reads and `reloadStats()` for forced refreshes.

---

# Default config changes

- **`showTitleWhenChainEnds`** Default changed from `true` → `false`. The "Use Spade" title could fire incorrectly on a second solve attempt even when the first was successful, so it is now disabled by default.
- **`Warp Block Difference`** Default changed from `10` → `22`. The previous default was too low and would suggest warping even when you were very close to the warp destination.
- **`"Beam Distance"` renamed to `"Beacon Beam Distance"`** To better reflect that this option applies to all beacon beams, not just Rare Mob waypoint beams.

---

# API version header added

The mod now sends its version string in the `X-SBO-Version` HTTP header when making requests to the SBO backend server. This allows the backend to identify which mod version is making requests.
